### PR TITLE
Added: size to TermsAggregation

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,7 @@
+# v2.5.3
+
+* Added: size to TermsAggregation
+
 # v2.5.2
 
 * Added: support for Elasticsearch range aggregations

--- a/core/src/main/java/org/vertexium/query/TermsAggregation.java
+++ b/core/src/main/java/org/vertexium/query/TermsAggregation.java
@@ -1,13 +1,13 @@
 package org.vertexium.query;
 
 import java.util.ArrayList;
-import java.util.Collection;
 import java.util.List;
 
 public class TermsAggregation extends Aggregation implements SupportsNestedAggregationsAggregation {
     private final String aggregationName;
     private final String propertyName;
     private final List<Aggregation> nestedAggregations = new ArrayList<>();
+    private Integer size;
 
     public TermsAggregation(String aggregationName, String propertyName) {
         this.aggregationName = aggregationName;
@@ -30,5 +30,13 @@ public class TermsAggregation extends Aggregation implements SupportsNestedAggre
     @Override
     public Iterable<Aggregation> getNestedAggregations() {
         return nestedAggregations;
+    }
+
+    public Integer getSize() {
+        return size;
+    }
+
+    public void setSize(Integer size) {
+        this.size = size;
     }
 }

--- a/elasticsearch-singledocument/src/main/java/org/vertexium/elasticsearch/ElasticSearchSingleDocumentSearchQueryBase.java
+++ b/elasticsearch-singledocument/src/main/java/org/vertexium/elasticsearch/ElasticSearchSingleDocumentSearchQueryBase.java
@@ -880,6 +880,9 @@ public class ElasticSearchSingleDocumentSearchQueryBase extends QueryBase implem
                 String visibilityHash = getSearchIndex().getPropertyVisibilityHashFromDeflatedPropertyName(propertyName);
                 TermsBuilder termsAgg = AggregationBuilders.terms(createAggregationName(agg.getAggregationName(), visibilityHash));
                 termsAgg.field(propertyName);
+                if (agg.getSize() != null) {
+                    termsAgg.size(agg.getSize());
+                }
 
                 for (AbstractAggregationBuilder subAgg : getElasticsearchAggregations(agg.getNestedAggregations())) {
                     termsAgg.subAggregation(subAgg);


### PR DESCRIPTION
Currently ElasticSearch defaults the number of results from a terms aggregation to 10. Should we up the default number of results or add this option or both?