### PR TITLE
Added: Elasticsearch: Support for Percentile Aggregations

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,7 @@
 # v2.5.3
 
 * Added: size to TermsAggregation
+* Added: support for Elasticsearch percentile aggregations
 
 # v2.5.2
 

--- a/core/src/main/java/org/vertexium/query/AggregationResult.java
+++ b/core/src/main/java/org/vertexium/query/AggregationResult.java
@@ -7,19 +7,22 @@ import java.util.ArrayList;
 public abstract class AggregationResult {
     public static <TResult extends AggregationResult> TResult createEmptyResult(Class<? extends TResult> resultType) {
         if (resultType.equals(TermsResult.class)) {
-            return resultType.cast(new TermsResult(new ArrayList<TermsBucket>()));
+            return resultType.cast(new TermsResult(new ArrayList<>()));
         }
         if (resultType.equals(StatisticsResult.class)) {
             return resultType.cast(new StatisticsResult(0, 0.0, 0.0, 0.0, 0.0));
         }
         if (resultType.equals(HistogramResult.class)) {
-            return resultType.cast(new HistogramResult(new ArrayList<HistogramBucket>()));
+            return resultType.cast(new HistogramResult(new ArrayList<>()));
         }
         if (resultType.equals(RangeResult.class)) {
-            return resultType.cast(new RangeResult(new ArrayList<RangeBucket>()));
+            return resultType.cast(new RangeResult(new ArrayList<>()));
+        }
+        if (resultType.equals(PercentilesResult.class)) {
+            return resultType.cast(new PercentilesResult(new ArrayList<>()));
         }
         if (resultType.equals(GeohashResult.class)) {
-            return resultType.cast(new GeohashResult(new ArrayList<GeohashBucket>()));
+            return resultType.cast(new GeohashResult(new ArrayList<>()));
         }
         throw new VertexiumException("Unhandled type to create empty results for: " + resultType.getName());
     }

--- a/core/src/main/java/org/vertexium/query/Percentile.java
+++ b/core/src/main/java/org/vertexium/query/Percentile.java
@@ -1,0 +1,19 @@
+package org.vertexium.query;
+
+public class Percentile {
+    private final Double percentile;
+    private final Double value;
+
+    public Percentile(Double percentile, Double value) {
+        this.percentile = percentile;
+        this.value = value;
+    }
+
+    public Double getPercentile() {
+        return percentile;
+    }
+
+    public Double getValue() {
+        return value;
+    }
+}

--- a/core/src/main/java/org/vertexium/query/PercentilesAggregation.java
+++ b/core/src/main/java/org/vertexium/query/PercentilesAggregation.java
@@ -1,0 +1,38 @@
+package org.vertexium.query;
+
+import org.vertexium.Visibility;
+
+public class PercentilesAggregation extends Aggregation {
+    private final String aggregationName;
+    private final String fieldName;
+    private final Visibility visibility;
+
+    private double[] percents;
+
+    public PercentilesAggregation(String aggregationName, String fieldName, Visibility visibility) {
+        this.aggregationName = aggregationName;
+        this.fieldName = fieldName;
+        this.visibility = visibility;
+    }
+
+    @Override
+    public String getAggregationName() {
+        return aggregationName;
+    }
+
+    public String getFieldName() {
+        return fieldName;
+    }
+
+    public Visibility getVisibility() {
+        return visibility;
+    }
+
+    public double[] getPercents() {
+        return percents;
+    }
+
+    public void setPercents(double... percents) {
+        this.percents = percents;
+    }
+}

--- a/core/src/main/java/org/vertexium/query/PercentilesResult.java
+++ b/core/src/main/java/org/vertexium/query/PercentilesResult.java
@@ -1,0 +1,13 @@
+package org.vertexium.query;
+
+public class PercentilesResult extends AggregationResult {
+    private final Iterable<Percentile> percentiles;
+
+    public PercentilesResult(Iterable<Percentile> percentiles) {
+        this.percentiles = percentiles;
+    }
+
+    public Iterable<Percentile> getPercentiles() {
+        return percentiles;
+    }
+}

--- a/elasticsearch-singledocument/src/main/java/org/vertexium/elasticsearch/ElasticsearchSingleDocumentSearchIndex.java
+++ b/elasticsearch-singledocument/src/main/java/org/vertexium/elasticsearch/ElasticsearchSingleDocumentSearchIndex.java
@@ -593,7 +593,7 @@ public class ElasticsearchSingleDocumentSearchIndex implements SearchIndex, Sear
         return deflatePropertyName(graph, propertyName, propertyVisibility);
     }
 
-    private String deflatePropertyName(Graph graph, String propertyName, Visibility propertyVisibility) {
+    protected String deflatePropertyName(Graph graph, String propertyName, Visibility propertyVisibility) {
         String visibilityHash = getVisibilityHash(graph, propertyName, propertyVisibility);
         return this.nameSubstitutionStrategy.deflate(propertyName) + "_" + visibilityHash;
     }


### PR DESCRIPTION
This adds support for ES percentile aggregations. Unlike other aggregations, we are unable to reduce the results of multiple percentile aggregations into a single answer. Because of this, a percentile aggregation must be run on a field for a specific visibility. 