### PR TITLE
Added: Elasticsearch 2.x support

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,7 @@
 # v2.6.0
 
 * Added: ability to store extended data rows on an element
+* Added: Elasticsearch 2.x support
 
 # v2.5.4
 

--- a/accumulo-blueprints/pom.xml
+++ b/accumulo-blueprints/pom.xml
@@ -3,7 +3,7 @@
     <parent>
         <artifactId>vertexium-root</artifactId>
         <groupId>org.vertexium</groupId>
-        <version>2.5.4-SNAPSHOT</version>
+        <version>2.6.0-SNAPSHOT</version>
     </parent>
     <modelVersion>4.0.0</modelVersion>
 

--- a/accumulo-iterators/pom.xml
+++ b/accumulo-iterators/pom.xml
@@ -3,7 +3,7 @@
     <parent>
         <artifactId>vertexium-root</artifactId>
         <groupId>org.vertexium</groupId>
-        <version>2.5.4-SNAPSHOT</version>
+        <version>2.6.0-SNAPSHOT</version>
     </parent>
     <modelVersion>4.0.0</modelVersion>
 

--- a/accumulo-migrations/pom.xml
+++ b/accumulo-migrations/pom.xml
@@ -3,7 +3,7 @@
     <parent>
         <artifactId>vertexium-root</artifactId>
         <groupId>org.vertexium</groupId>
-        <version>2.5.4-SNAPSHOT</version>
+        <version>2.6.0-SNAPSHOT</version>
     </parent>
     <modelVersion>4.0.0</modelVersion>
 

--- a/accumulo-titan-hadoop/pom.xml
+++ b/accumulo-titan-hadoop/pom.xml
@@ -3,7 +3,7 @@
     <parent>
         <artifactId>vertexium-root</artifactId>
         <groupId>org.vertexium</groupId>
-        <version>2.5.4-SNAPSHOT</version>
+        <version>2.6.0-SNAPSHOT</version>
     </parent>
     <modelVersion>4.0.0</modelVersion>
 

--- a/accumulo/pom.xml
+++ b/accumulo/pom.xml
@@ -3,7 +3,7 @@
     <parent>
         <artifactId>vertexium-root</artifactId>
         <groupId>org.vertexium</groupId>
-        <version>2.5.4-SNAPSHOT</version>
+        <version>2.6.0-SNAPSHOT</version>
     </parent>
     <modelVersion>4.0.0</modelVersion>
 

--- a/blueprints-test/pom.xml
+++ b/blueprints-test/pom.xml
@@ -3,7 +3,7 @@
     <parent>
         <artifactId>vertexium-root</artifactId>
         <groupId>org.vertexium</groupId>
-        <version>2.5.4-SNAPSHOT</version>
+        <version>2.6.0-SNAPSHOT</version>
     </parent>
     <modelVersion>4.0.0</modelVersion>
 

--- a/blueprints/pom.xml
+++ b/blueprints/pom.xml
@@ -3,7 +3,7 @@
     <parent>
         <artifactId>vertexium-root</artifactId>
         <groupId>org.vertexium</groupId>
-        <version>2.5.4-SNAPSHOT</version>
+        <version>2.6.0-SNAPSHOT</version>
     </parent>
     <modelVersion>4.0.0</modelVersion>
 

--- a/cli/pom.xml
+++ b/cli/pom.xml
@@ -3,7 +3,7 @@
     <parent>
         <artifactId>vertexium-root</artifactId>
         <groupId>org.vertexium</groupId>
-        <version>2.5.4-SNAPSHOT</version>
+        <version>2.6.0-SNAPSHOT</version>
     </parent>
     <modelVersion>4.0.0</modelVersion>
 

--- a/core/pom.xml
+++ b/core/pom.xml
@@ -3,7 +3,7 @@
     <parent>
         <artifactId>vertexium-root</artifactId>
         <groupId>org.vertexium</groupId>
-        <version>2.5.4-SNAPSHOT</version>
+        <version>2.6.0-SNAPSHOT</version>
     </parent>
     <modelVersion>4.0.0</modelVersion>
 

--- a/core/src/main/java/org/vertexium/query/QueryBase.java
+++ b/core/src/main/java/org/vertexium/query/QueryBase.java
@@ -506,7 +506,11 @@ public abstract class QueryBase implements Query, SimilarToGraphQuery {
         return this;
     }
 
+    /**
+     * @deprecated As of 2.6.0 this call has no effect in Elasticsearch and will be remove
+     */
     @Override
+    @Deprecated
     public SimilarToGraphQuery percentTermsToMatch(float percentTermsToMatch) {
         if (!(parameters instanceof SimilarToQueryParameters)) {
             throw new VertexiumException("Invalid query parameters, expected " + SimilarToQueryParameters.class.getName() + " found " + parameters.getClass().getName());

--- a/core/src/main/java/org/vertexium/query/SimilarToGraphQuery.java
+++ b/core/src/main/java/org/vertexium/query/SimilarToGraphQuery.java
@@ -23,7 +23,10 @@ public interface SimilarToGraphQuery extends GraphQuery {
 
     /**
      * The percentage of terms that must match to be considered similar.
+     *
+     * @deprecated As of 2.6.0 this call has no effect in Elasticsearch and will be remove
      */
+    @Deprecated
     SimilarToGraphQuery percentTermsToMatch(float percentTermsToMatch);
 
     /**

--- a/core/src/main/java/org/vertexium/query/SimilarToQueryParameters.java
+++ b/core/src/main/java/org/vertexium/query/SimilarToQueryParameters.java
@@ -52,10 +52,12 @@ public abstract class SimilarToQueryParameters extends QueryParameters {
         this.maxDocFrequency = maxDocFrequency;
     }
 
+    @Deprecated
     public Float getPercentTermsToMatch() {
         return percentTermsToMatch;
     }
 
+    @Deprecated
     public void setPercentTermsToMatch(Float percentTermsToMatch) {
         this.percentTermsToMatch = percentTermsToMatch;
     }

--- a/dist/pom.xml
+++ b/dist/pom.xml
@@ -3,7 +3,7 @@
     <parent>
         <artifactId>vertexium-root</artifactId>
         <groupId>org.vertexium</groupId>
-        <version>2.5.4-SNAPSHOT</version>
+        <version>2.6.0-SNAPSHOT</version>
     </parent>
     <modelVersion>4.0.0</modelVersion>
 

--- a/elasticsearch-singledocument-plugin/pom.xml
+++ b/elasticsearch-singledocument-plugin/pom.xml
@@ -3,7 +3,7 @@
     <parent>
         <artifactId>vertexium-root</artifactId>
         <groupId>org.vertexium</groupId>
-        <version>2.5.4-SNAPSHOT</version>
+        <version>2.6.0-SNAPSHOT</version>
     </parent>
     <modelVersion>4.0.0</modelVersion>
 

--- a/elasticsearch-singledocument/pom.xml
+++ b/elasticsearch-singledocument/pom.xml
@@ -3,7 +3,7 @@
     <parent>
         <artifactId>vertexium-root</artifactId>
         <groupId>org.vertexium</groupId>
-        <version>2.5.4-SNAPSHOT</version>
+        <version>2.6.0-SNAPSHOT</version>
     </parent>
     <modelVersion>4.0.0</modelVersion>
 
@@ -29,11 +29,6 @@
             <version>${elasticsearch.version}</version>
         </dependency>
         <dependency>
-            <groupId>org.codelibs</groupId>
-            <artifactId>elasticsearch-cluster-runner</artifactId>
-            <version>1.7.0.0</version>
-        </dependency>
-        <dependency>
             <groupId>com.vividsolutions</groupId>
             <artifactId>jts</artifactId>
             <version>${jts.version}</version>
@@ -42,6 +37,13 @@
             <groupId>net.jodah</groupId>
             <artifactId>recurrent</artifactId>
             <version>${recurrent.version}</version>
+        </dependency>
+
+        <dependency>
+            <groupId>org.codelibs</groupId>
+            <artifactId>elasticsearch-cluster-runner</artifactId>
+            <version>1.7.0.0</version>
+            <scope>test</scope>
         </dependency>
         <dependency>
             <groupId>org.slf4j</groupId>

--- a/elasticsearch-singledocument/src/main/java/org/vertexium/elasticsearch/ElasticSearchSingleDocumentSearchQueryBase.java
+++ b/elasticsearch-singledocument/src/main/java/org/vertexium/elasticsearch/ElasticSearchSingleDocumentSearchQueryBase.java
@@ -304,7 +304,8 @@ public class ElasticSearchSingleDocumentSearchQueryBase extends QueryBase implem
                             ids.getExtendedDataIds().size(),
                             ids.getVertexIds().size() + ids.getEdgeIds().size() + ids.getExtendedDataIds().size(),
                             hits.getTotalHits(),
-                            (endTime - startTime) / 1000 / 1000);
+                            (endTime - startTime) / 1000 / 1000
+                    );
                 }
 
                 // since ES doesn't support security we will rely on the graph to provide edge filtering
@@ -325,27 +326,14 @@ public class ElasticSearchSingleDocumentSearchQueryBase extends QueryBase implem
                     items.add(extendedDataRows);
                 }
                 Iterable<VertexiumObject> vertexiumObjects = new JoinIterable<>(items);
-                vertexiumObjects = sortvertexiumObjectsByResultOrder(vertexiumObjects, ids.getIds());
+                vertexiumObjects = sortVertexiumObjectsByResultOrder(vertexiumObjects, ids.getIds());
                 // TODO instead of passing false here to not evaluate the query string it would be better to support the Lucene query
                 return createIterable(response, filterParameters, vertexiumObjects, evaluateQueryString, evaluateHasContainers, evaluateSortContainers, searchTime, hits);
             }
         };
     }
 
-    private Iterable<ExtendedDataRow> sortExtendedDataByResultOrder(Iterable<ExtendedDataRow> rows, List<ExtendedDataRowId> ids) {
-        ImmutableMap<ExtendedDataRowId, ExtendedDataRow> elementsMap = Maps.uniqueIndex(rows, ExtendedDataRow::getId);
-
-        List<ExtendedDataRow> results = new ArrayList<>();
-        for (ExtendedDataRowId id : ids) {
-            ExtendedDataRow element = elementsMap.get(id);
-            if (element != null) {
-                results.add(element);
-            }
-        }
-        return results;
-    }
-
-    private <T extends VertexiumObject> Iterable<T> sortvertexiumObjectsByResultOrder(Iterable<T> vertexiumObjects, List<String> ids) {
+    private <T extends VertexiumObject> Iterable<T> sortVertexiumObjectsByResultOrder(Iterable<T> vertexiumObjects, List<String> ids) {
         ImmutableMap<String, T> itemMap = Maps.uniqueIndex(vertexiumObjects, vertexiumObject -> {
             if (vertexiumObject instanceof Element) {
                 return ((Element) vertexiumObject).getId();
@@ -531,9 +519,9 @@ public class ElasticSearchSingleDocumentSearchQueryBase extends QueryBase implem
                         } else {
                             filters
                                     .add(FilterBuilders
-                                            .geoDistanceFilter(propertyName)
-                                            .point(lat, lon)
-                                            .distance(distance, DistanceUnit.KILOMETERS));
+                                                 .geoDistanceFilter(propertyName)
+                                                 .point(lat, lon)
+                                                 .distance(distance, DistanceUnit.KILOMETERS));
                         }
                     } else if (value instanceof GeoRect) {
                         GeoRect geoRect = (GeoRect) value;
@@ -556,9 +544,9 @@ public class ElasticSearchSingleDocumentSearchQueryBase extends QueryBase implem
                         } else {
                             filters
                                     .add(FilterBuilders
-                                            .geoBoundingBoxFilter(propertyName)
-                                            .topLeft(nwLat, nwLon)
-                                            .bottomRight(seLat, seLon));
+                                                 .geoBoundingBoxFilter(propertyName)
+                                                 .topLeft(nwLat, nwLon)
+                                                 .bottomRight(seLat, seLon));
                         }
                     } else {
                         throw new VertexiumException("Unexpected has value type " + value.getClass().getName());
@@ -1040,7 +1028,7 @@ public class ElasticSearchSingleDocumentSearchQueryBase extends QueryBase implem
 
                 if (!Strings.isNullOrEmpty(agg.getFormat())) {
                     throw new VertexiumException("Invalid use of format for property: " + agg.getFieldName() +
-                            ". Format is only valid for date properties");
+                                                         ". Format is only valid for date properties");
                 }
 
                 for (RangeAggregation.Range range : agg.getRanges()) {
@@ -1048,7 +1036,7 @@ public class ElasticSearchSingleDocumentSearchQueryBase extends QueryBase implem
                     Object to = range.getTo();
                     if ((from != null && !(from instanceof Number)) || (to != null && !(to instanceof Number))) {
                         throw new VertexiumException("Invalid range for property: " + agg.getFieldName() +
-                                ". Both to and from must be Numeric.");
+                                                             ". Both to and from must be Numeric.");
                     }
                     rangeBuilder.addRange(
                             range.getKey(),

--- a/elasticsearch-singledocument/src/test/java/org/vertexium/elasticsearch/ElasticsearchSingleDocumentSearchIndexTestBase.java
+++ b/elasticsearch-singledocument/src/test/java/org/vertexium/elasticsearch/ElasticsearchSingleDocumentSearchIndexTestBase.java
@@ -66,8 +66,8 @@ public abstract class ElasticsearchSingleDocumentSearchIndexTestBase extends Gra
 
     private static void installPlugin(File basePath) throws IOException, ZipException {
         File pluginsPath = new File(basePath, "plugins");
-        File vertexiumZipFile = new File(pluginsPath, "vertexium.zip");
-        File vertexiumPluginPath = new File(pluginsPath, "vertexium");
+        File vertexiumZipFile = new File(basePath, "vertexium.zip");
+        File vertexiumPluginPath = new File(pluginsPath, "vertexium-elasticsearch");
         if (!vertexiumPluginPath.mkdirs()) {
             System.out.println("Could not create directories");
         }

--- a/elasticsearch2-plugin/README.md
+++ b/elasticsearch2-plugin/README.md
@@ -1,0 +1,11 @@
+## Installing
+
+```bash
+bin/plugin install org.vertexium/vertexium-elasticsearch2-plugin/<version>
+```
+
+or
+
+```bash
+bin/plugin install file:///path/to/vertexium-elasticsearch2-plugin-<version>.zip
+```

--- a/elasticsearch2-plugin/pom.xml
+++ b/elasticsearch2-plugin/pom.xml
@@ -1,0 +1,73 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+    <parent>
+        <artifactId>vertexium-root</artifactId>
+        <groupId>org.vertexium</groupId>
+        <version>2.6.0-SNAPSHOT</version>
+    </parent>
+    <modelVersion>4.0.0</modelVersion>
+
+    <artifactId>vertexium-elasticsearch2-plugin</artifactId>
+    <name>Vertexium: Elasticsearch2: Plugin</name>
+
+    <dependencies>
+        <dependency>
+            <groupId>org.vertexium</groupId>
+            <artifactId>vertexium-security</artifactId>
+            <version>${project.version}</version>
+        </dependency>
+        <dependency>
+            <groupId>org.elasticsearch</groupId>
+            <artifactId>elasticsearch</artifactId>
+            <version>${elasticsearch2.version}</version>
+        </dependency>
+    </dependencies>
+
+    <build>
+        <plugins>
+            <plugin>
+                <groupId>org.apache.maven.plugins</groupId>
+                <artifactId>maven-source-plugin</artifactId>
+            </plugin>
+            <plugin>
+                <groupId>org.apache.maven.plugins</groupId>
+                <artifactId>maven-javadoc-plugin</artifactId>
+            </plugin>
+            <plugin>
+                <artifactId>maven-assembly-plugin</artifactId>
+                <executions>
+                    <execution>
+                        <id>release</id>
+                        <phase>package</phase>
+                        <goals>
+                            <goal>single</goal>
+                        </goals>
+                        <configuration>
+                            <appendAssemblyId>false</appendAssemblyId>
+                            <outputDirectory>${project.build.directory}/releases/</outputDirectory>
+                            <descriptors>
+                                <descriptor>${basedir}/src/main/assemblies/plugin.xml</descriptor>
+                            </descriptors>
+                        </configuration>
+                    </execution>
+                    <execution>
+                        <id>test</id>
+                        <phase>package</phase>
+                        <goals>
+                            <goal>single</goal>
+                        </goals>
+                        <configuration>
+                            <finalName>vertexium-elasticsearch2-plugin</finalName>
+                            <appendAssemblyId>false</appendAssemblyId>
+                            <outputDirectory>${basedir}/../elasticsearch2/src/test/resources/
+                            </outputDirectory>
+                            <descriptors>
+                                <descriptor>${basedir}/src/main/assemblies/plugin.xml</descriptor>
+                            </descriptors>
+                        </configuration>
+                    </execution>
+                </executions>
+            </plugin>
+        </plugins>
+    </build>
+</project>

--- a/elasticsearch2-plugin/src/main/assemblies/plugin-descriptor.properties
+++ b/elasticsearch2-plugin/src/main/assemblies/plugin-descriptor.properties
@@ -1,0 +1,7 @@
+description=Vertexium
+version=master
+classname=org.vertexium.elasticsearch2.plugin.VertexiumElasticsearchPlugin
+jvm=true
+java.version=1.8
+elasticsearch.version=2.4.4
+name=vertexium

--- a/elasticsearch2-plugin/src/main/assemblies/plugin.xml
+++ b/elasticsearch2-plugin/src/main/assemblies/plugin.xml
@@ -1,0 +1,27 @@
+<?xml version="1.0"?>
+<assembly>
+    <id>plugin</id>
+    <formats>
+        <format>zip</format>
+    </formats>
+    <includeBaseDirectory>false</includeBaseDirectory>
+    <fileSets>
+        <fileSet>
+            <directory>${project.basedir}/src/main/assemblies</directory>
+            <outputDirectory>/</outputDirectory>
+            <includes>
+                <include>plugin-descriptor.properties</include>
+            </includes>
+        </fileSet>
+    </fileSets>
+    <dependencySets>
+        <dependencySet>
+            <outputDirectory>/</outputDirectory>
+            <useProjectArtifact>true</useProjectArtifact>
+            <useTransitiveFiltering>true</useTransitiveFiltering>
+            <excludes>
+                <exclude>org.elasticsearch:elasticsearch</exclude>
+            </excludes>
+        </dependencySet>
+    </dependencySets>
+</assembly>

--- a/elasticsearch2-plugin/src/main/java/org/vertexium/elasticsearch2/plugin/FieldNameToVisibilityMap.java
+++ b/elasticsearch2-plugin/src/main/java/org/vertexium/elasticsearch2/plugin/FieldNameToVisibilityMap.java
@@ -1,0 +1,25 @@
+package org.vertexium.elasticsearch2.plugin;
+
+import java.util.Map;
+import java.util.Set;
+
+public class FieldNameToVisibilityMap {
+    private final Map<String, String> fieldNameToVisibilityMapping;
+
+    public FieldNameToVisibilityMap(Map<String, String> fieldNameToVisibilityMapping) {
+        this.fieldNameToVisibilityMapping = fieldNameToVisibilityMapping;
+    }
+
+    public Set<String> getFieldNames() {
+        return fieldNameToVisibilityMapping.keySet();
+    }
+
+    public String getFieldVisibility(String fieldName) {
+        return fieldNameToVisibilityMapping.get(fieldName);
+    }
+
+    @SuppressWarnings("unchecked")
+    public static FieldNameToVisibilityMap createFromVertexiumMetadata(Object vertexiumMeta) {
+        return new FieldNameToVisibilityMap((Map<String, String>) vertexiumMeta);
+    }
+}

--- a/elasticsearch2-plugin/src/main/java/org/vertexium/elasticsearch2/plugin/VertexiumElasticsearchPlugin.java
+++ b/elasticsearch2-plugin/src/main/java/org/vertexium/elasticsearch2/plugin/VertexiumElasticsearchPlugin.java
@@ -1,0 +1,20 @@
+package org.vertexium.elasticsearch2.plugin;
+
+import org.elasticsearch.indices.IndicesModule;
+import org.elasticsearch.plugins.Plugin;
+
+public class VertexiumElasticsearchPlugin extends Plugin {
+    @Override
+    public String name() {
+        return "Vertexium";
+    }
+
+    @Override
+    public String description() {
+        return "Vertexium secure graph database plugin";
+    }
+
+    public void onModule(IndicesModule module) {
+        module.registerQueryParser(VertexiumQueryStringQueryParser.class);
+    }
+}

--- a/elasticsearch2-plugin/src/main/java/org/vertexium/elasticsearch2/plugin/VertexiumMapperQueryParser.java
+++ b/elasticsearch2-plugin/src/main/java/org/vertexium/elasticsearch2/plugin/VertexiumMapperQueryParser.java
@@ -1,0 +1,57 @@
+package org.vertexium.elasticsearch2.plugin;
+
+import org.apache.lucene.analysis.Analyzer;
+import org.apache.lucene.queryparser.classic.MapperQueryParser;
+import org.apache.lucene.queryparser.classic.ParseException;
+import org.apache.lucene.search.DisjunctionMaxQuery;
+import org.apache.lucene.search.Query;
+import org.elasticsearch.index.query.QueryParseContext;
+
+import java.util.regex.Matcher;
+import java.util.regex.Pattern;
+
+public class VertexiumMapperQueryParser extends MapperQueryParser {
+    private final String[] authorizations;
+    private final FieldNameToVisibilityMap fieldNameToVisibilityMap;
+    private static final Pattern PROPERTY_NAME_PATTERN = Pattern.compile("^(.*?)(_([0-9a-f]{32}))?(_([a-z]))?$");
+
+    public VertexiumMapperQueryParser(
+            QueryParseContext parseContext,
+            FieldNameToVisibilityMap fieldNameToVisibilityMap,
+            String[] authorizations
+    ) {
+        super(parseContext);
+        this.authorizations = authorizations;
+        this.fieldNameToVisibilityMap = fieldNameToVisibilityMap;
+    }
+
+    @Override
+    protected Query newFieldQuery(Analyzer analyzer, String field, String queryText, boolean quoted) throws ParseException {
+        if (field == null || field.length() == 0) {
+            return super.newFieldQuery(analyzer, field, queryText, quoted);
+        }
+
+        Matcher m = PROPERTY_NAME_PATTERN.matcher(field);
+        if (m.matches() && m.group(2) != null) {
+            return super.newFieldQuery(analyzer, field, queryText, quoted);
+        }
+
+        String fieldPrefix = field + "_";
+        DisjunctionMaxQuery query = new DisjunctionMaxQuery(0.0f);
+        for (String fieldName : fieldNameToVisibilityMap.getFieldNames()) {
+            if (fieldName.startsWith(fieldPrefix)) {
+                String visibility = fieldNameToVisibilityMap.getFieldVisibility(fieldName);
+                if (VisibilityUtils.canRead(visibility, authorizations)) {
+                    Query termQuery = super.newFieldQuery(analyzer, fieldName, queryText, quoted);
+                    query.add(termQuery);
+                }
+            }
+        }
+
+        if (query.getDisjuncts().size() == 0) {
+            return super.newFieldQuery(analyzer, field, queryText, quoted);
+        }
+
+        return query;
+    }
+}

--- a/elasticsearch2-plugin/src/main/java/org/vertexium/elasticsearch2/plugin/VertexiumQueryStringQueryParser.java
+++ b/elasticsearch2-plugin/src/main/java/org/vertexium/elasticsearch2/plugin/VertexiumQueryStringQueryParser.java
@@ -1,0 +1,326 @@
+// This file is based off of
+// https://raw.githubusercontent.com/elastic/elasticsearch/2.4/core/src/main/java/org/elasticsearch/index/query/QueryStringQueryParser.java
+package org.vertexium.elasticsearch2.plugin;
+
+import com.carrotsearch.hppc.ObjectFloatHashMap;
+import com.google.common.collect.ImmutableMap;
+import com.google.common.collect.Lists;
+import org.apache.lucene.queryparser.classic.MapperQueryParser;
+import org.apache.lucene.queryparser.classic.QueryParserSettings;
+import org.apache.lucene.search.BooleanQuery;
+import org.apache.lucene.search.Query;
+import org.elasticsearch.common.ParseField;
+import org.elasticsearch.common.Strings;
+import org.elasticsearch.common.inject.Inject;
+import org.elasticsearch.common.lucene.search.Queries;
+import org.elasticsearch.common.regex.Regex;
+import org.elasticsearch.common.settings.Settings;
+import org.elasticsearch.common.unit.Fuzziness;
+import org.elasticsearch.common.util.LocaleUtils;
+import org.elasticsearch.common.xcontent.XContentParser;
+import org.elasticsearch.index.analysis.NamedAnalyzer;
+import org.elasticsearch.index.fielddata.FieldDataType;
+import org.elasticsearch.index.mapper.DocumentMapper;
+import org.elasticsearch.index.mapper.FieldMapper;
+import org.elasticsearch.index.query.QueryParseContext;
+import org.elasticsearch.index.query.QueryParser;
+import org.elasticsearch.index.query.QueryParsingException;
+import org.elasticsearch.index.query.support.QueryParsers;
+import org.joda.time.DateTimeZone;
+
+import java.io.IOException;
+import java.util.*;
+
+import static org.elasticsearch.common.lucene.search.Queries.fixNegativeQueryIfNeeded;
+
+public class VertexiumQueryStringQueryParser implements QueryParser {
+    public static final String NAME = "vertexium_query_string";
+    private static final ParseField FUZZINESS = Fuzziness.FIELD.withDeprecation("fuzzy_min_sim");
+    private static final String ELEMENT_DOCUMENT_MAPPER_NAME = "element";
+
+    private final boolean defaultAnalyzeWildcard;
+    private final boolean defaultAllowLeadingWildcard;
+
+    @Inject
+    public VertexiumQueryStringQueryParser(Settings settings) {
+        this.defaultAnalyzeWildcard = settings.getAsBoolean("indices.query.query_string.analyze_wildcard", QueryParserSettings.DEFAULT_ANALYZE_WILDCARD);
+        this.defaultAllowLeadingWildcard = settings.getAsBoolean("indices.query.query_string.allowLeadingWildcard", QueryParserSettings.DEFAULT_ALLOW_LEADING_WILDCARD);
+    }
+
+    @Override
+    public String[] names() {
+        return new String[]{NAME, Strings.toCamelCase(NAME)};
+    }
+
+    @Override
+    public Query parse(QueryParseContext parseContext) throws IOException, QueryParsingException {
+        String[] authorizations = null;
+        DocumentMapper documentMapper = parseContext.mapperService().documentMapper(ELEMENT_DOCUMENT_MAPPER_NAME);
+        FieldNameToVisibilityMap fieldNameToVisibilityMap = getFieldNameToVisibilityMap(documentMapper);
+
+        XContentParser parser = parseContext.parser();
+
+        String queryName = null;
+        QueryParserSettings qpSettings = new QueryParserSettings();
+        qpSettings.defaultField(parseContext.defaultField());
+        qpSettings.lenient(parseContext.queryStringLenient());
+        qpSettings.analyzeWildcard(defaultAnalyzeWildcard);
+        qpSettings.allowLeadingWildcard(defaultAllowLeadingWildcard);
+        qpSettings.locale(Locale.ROOT);
+
+        String currentFieldName = null;
+        XContentParser.Token token;
+        while ((token = parser.nextToken()) != XContentParser.Token.END_OBJECT) {
+            if (token == XContentParser.Token.FIELD_NAME) {
+                currentFieldName = parser.currentName();
+            } else if (token == XContentParser.Token.START_ARRAY) {
+                if ("authorizations".equals(currentFieldName)) {
+                    authorizations = xContentToAuthorizationsArray(parser);
+                    Set<String> fields = getQueryableFields(documentMapper, fieldNameToVisibilityMap, authorizations);
+
+                    if (qpSettings.fields() == null) {
+                        qpSettings.fields(Lists.newArrayList());
+                    }
+                    for (String field : fields) {
+                        qpSettings.fields().add(field);
+                    }
+                } else if ("fields".equals(currentFieldName)) {
+                    while ((token = parser.nextToken()) != XContentParser.Token.END_ARRAY) {
+                        String fField = null;
+                        float fBoost = -1;
+                        char[] text = parser.textCharacters();
+                        int end = parser.textOffset() + parser.textLength();
+                        for (int i = parser.textOffset(); i < end; i++) {
+                            if (text[i] == '^') {
+                                int relativeLocation = i - parser.textOffset();
+                                fField = new String(text, parser.textOffset(), relativeLocation);
+                                fBoost = Float.parseFloat(new String(text, i + 1, parser.textLength() - relativeLocation - 1));
+                                break;
+                            }
+                        }
+                        if (fField == null) {
+                            fField = parser.text();
+                        }
+                        if (qpSettings.fields() == null) {
+                            qpSettings.fields(new ArrayList<String>());
+                        }
+
+                        if (Regex.isSimpleMatchPattern(fField)) {
+                            for (String field : parseContext.mapperService().simpleMatchToIndexNames(fField)) {
+                                qpSettings.fields().add(field);
+                                if (fBoost != -1) {
+                                    if (qpSettings.boosts() == null) {
+                                        qpSettings.boosts(new ObjectFloatHashMap<String>());
+                                    }
+                                    qpSettings.boosts().put(field, fBoost);
+                                }
+                            }
+                        } else {
+                            qpSettings.fields().add(fField);
+                            if (fBoost != -1) {
+                                if (qpSettings.boosts() == null) {
+                                    qpSettings.boosts(new ObjectFloatHashMap<String>());
+                                }
+                                qpSettings.boosts().put(fField, fBoost);
+                            }
+                        }
+                    }
+                } else {
+                    throw new QueryParsingException(parseContext, "[query_string] query does not support [" + currentFieldName
+                            + "]");
+                }
+            } else if (token.isValue()) {
+                if ("query".equals(currentFieldName)) {
+                    qpSettings.queryString(parser.text());
+                } else if ("default_field".equals(currentFieldName) || "defaultField".equals(currentFieldName)) {
+                    qpSettings.defaultField(parser.text());
+                } else if ("default_operator".equals(currentFieldName) || "defaultOperator".equals(currentFieldName)) {
+                    String op = parser.text();
+                    if ("or".equalsIgnoreCase(op)) {
+                        qpSettings.defaultOperator(org.apache.lucene.queryparser.classic.QueryParser.Operator.OR);
+                    } else if ("and".equalsIgnoreCase(op)) {
+                        qpSettings.defaultOperator(org.apache.lucene.queryparser.classic.QueryParser.Operator.AND);
+                    } else {
+                        throw new QueryParsingException(parseContext, "Query default operator [" + op + "] is not allowed");
+                    }
+                } else if ("analyzer".equals(currentFieldName)) {
+                    NamedAnalyzer analyzer = parseContext.analysisService().analyzer(parser.text());
+                    if (analyzer == null) {
+                        throw new QueryParsingException(parseContext, "[query_string] analyzer [" + parser.text() + "] not found");
+                    }
+                    qpSettings.forcedAnalyzer(analyzer);
+                } else if ("quote_analyzer".equals(currentFieldName) || "quoteAnalyzer".equals(currentFieldName)) {
+                    NamedAnalyzer analyzer = parseContext.analysisService().analyzer(parser.text());
+                    if (analyzer == null) {
+                        throw new QueryParsingException(parseContext, "[query_string] quote_analyzer [" + parser.text()
+                                + "] not found");
+                    }
+                    qpSettings.forcedQuoteAnalyzer(analyzer);
+                } else if ("allow_leading_wildcard".equals(currentFieldName) || "allowLeadingWildcard".equals(currentFieldName)) {
+                    qpSettings.allowLeadingWildcard(parser.booleanValue());
+                } else if ("auto_generate_phrase_queries".equals(currentFieldName) || "autoGeneratePhraseQueries".equals(currentFieldName)) {
+                    qpSettings.autoGeneratePhraseQueries(parser.booleanValue());
+                } else if ("max_determinized_states".equals(currentFieldName) || "maxDeterminizedStates".equals(currentFieldName)) {
+                    qpSettings.maxDeterminizedStates(parser.intValue());
+                } else if ("lowercase_expanded_terms".equals(currentFieldName) || "lowercaseExpandedTerms".equals(currentFieldName)) {
+                    qpSettings.lowercaseExpandedTerms(parser.booleanValue());
+                } else if ("enable_position_increments".equals(currentFieldName) || "enablePositionIncrements".equals(currentFieldName)) {
+                    qpSettings.enablePositionIncrements(parser.booleanValue());
+                } else if ("escape".equals(currentFieldName)) {
+                    qpSettings.escape(parser.booleanValue());
+                } else if ("use_dis_max".equals(currentFieldName) || "useDisMax".equals(currentFieldName)) {
+                    qpSettings.useDisMax(parser.booleanValue());
+                } else if ("fuzzy_prefix_length".equals(currentFieldName) || "fuzzyPrefixLength".equals(currentFieldName)) {
+                    qpSettings.fuzzyPrefixLength(parser.intValue());
+                } else if ("fuzzy_max_expansions".equals(currentFieldName) || "fuzzyMaxExpansions".equals(currentFieldName)) {
+                    qpSettings.fuzzyMaxExpansions(parser.intValue());
+                } else if ("fuzzy_rewrite".equals(currentFieldName) || "fuzzyRewrite".equals(currentFieldName)) {
+                    qpSettings.fuzzyRewriteMethod(QueryParsers.parseRewriteMethod(parseContext.parseFieldMatcher(), parser.textOrNull()));
+                } else if ("phrase_slop".equals(currentFieldName) || "phraseSlop".equals(currentFieldName)) {
+                    qpSettings.phraseSlop(parser.intValue());
+                } else if (parseContext.parseFieldMatcher().match(currentFieldName, FUZZINESS)) {
+                    qpSettings.setFuzziness(Fuzziness.parse(parser));
+                } else if ("boost".equals(currentFieldName)) {
+                    qpSettings.boost(parser.floatValue());
+                } else if ("tie_breaker".equals(currentFieldName) || "tieBreaker".equals(currentFieldName)) {
+                    qpSettings.tieBreaker(parser.floatValue());
+                } else if ("analyze_wildcard".equals(currentFieldName) || "analyzeWildcard".equals(currentFieldName)) {
+                    qpSettings.analyzeWildcard(parser.booleanValue());
+                } else if ("rewrite".equals(currentFieldName)) {
+                    qpSettings.rewriteMethod(QueryParsers.parseRewriteMethod(parseContext.parseFieldMatcher(), parser.textOrNull()));
+                } else if ("minimum_should_match".equals(currentFieldName) || "minimumShouldMatch".equals(currentFieldName)) {
+                    qpSettings.minimumShouldMatch(parser.textOrNull());
+                } else if ("quote_field_suffix".equals(currentFieldName) || "quoteFieldSuffix".equals(currentFieldName)) {
+                    qpSettings.quoteFieldSuffix(parser.textOrNull());
+                } else if ("lenient".equalsIgnoreCase(currentFieldName)) {
+                    qpSettings.lenient(parser.booleanValue());
+                } else if ("locale".equals(currentFieldName)) {
+                    String localeStr = parser.text();
+                    qpSettings.locale(LocaleUtils.parse(localeStr));
+                } else if ("time_zone".equals(currentFieldName)) {
+                    try {
+                        qpSettings.timeZone(DateTimeZone.forID(parser.text()));
+                    } catch (IllegalArgumentException e) {
+                        throw new QueryParsingException(
+                                parseContext,
+                                "[query_string] time_zone [" + parser.text() + "] is unknown"
+                        );
+                    }
+                } else if ("_name".equals(currentFieldName)) {
+                    queryName = parser.text();
+                } else {
+                    throw new QueryParsingException(parseContext, "[query_string] query does not support [" + currentFieldName
+                            + "]");
+                }
+            }
+        }
+        if (qpSettings.queryString() == null) {
+            throw new QueryParsingException(parseContext, "query_string must be provided with a [query]");
+        }
+        qpSettings.defaultAnalyzer(parseContext.mapperService().searchAnalyzer());
+        qpSettings.defaultQuoteAnalyzer(parseContext.mapperService().searchQuoteAnalyzer());
+
+        if (qpSettings.escape()) {
+            qpSettings.queryString(org.apache.lucene.queryparser.classic.QueryParser.escape(qpSettings.queryString()));
+        }
+
+        MapperQueryParser queryParser = new VertexiumMapperQueryParser(
+                parseContext,
+                fieldNameToVisibilityMap,
+                authorizations
+        );
+        queryParser.reset(qpSettings);
+
+        try {
+            Query query = queryParser.parse(qpSettings.queryString());
+            if (query == null) {
+                return null;
+            }
+            if (qpSettings.boost() != QueryParserSettings.DEFAULT_BOOST) {
+                query.setBoost(query.getBoost() * qpSettings.boost());
+            }
+            query = fixNegativeQueryIfNeeded(query);
+            // If the coordination factor is disabled on a boolean query we don't apply the minimum should match.
+            // This is done to make sure that the minimum_should_match doesn't get applied when there is only one word
+            // and multiple variations of the same word in the query (synonyms for instance).
+            if (query instanceof BooleanQuery && !((BooleanQuery) query).isCoordDisabled()) {
+                query = Queries.applyMinimumShouldMatch((BooleanQuery) query, qpSettings.minimumShouldMatch());
+            }
+            if (queryName != null) {
+                parseContext.addNamedQuery(queryName, query);
+            }
+            return query;
+        } catch (org.apache.lucene.queryparser.classic.ParseException e) {
+            throw new QueryParsingException(parseContext, "Failed to parse query [" + qpSettings.queryString() + "]", e);
+        }
+    }
+
+    private FieldNameToVisibilityMap getFieldNameToVisibilityMap(DocumentMapper documentMapper) throws IOException {
+        ImmutableMap<String, Object> elementMetadata = documentMapper.meta();
+        if (elementMetadata == null) {
+            throw new IOException("Could not find " + ELEMENT_DOCUMENT_MAPPER_NAME + " metadata");
+        }
+        Object vertexiumMeta = elementMetadata.get("vertexium");
+        if (vertexiumMeta == null) {
+            throw new IOException("Could not find vertexium metadata in field mapping");
+        }
+        return FieldNameToVisibilityMap.createFromVertexiumMetadata(vertexiumMeta);
+    }
+
+    private Set<String> getQueryableFields(
+            DocumentMapper documentMapper,
+            FieldNameToVisibilityMap fieldNameToVisibilityMap,
+            String[] authorizations
+    ) {
+        Map<String, FieldDataType> fieldNameToDataType = getFieldTypes(documentMapper);
+        Set<String> fields = new HashSet<>();
+        for (String fieldName : fieldNameToVisibilityMap.getFieldNames()) {
+            if (isReservedFieldName(fieldName)) {
+                continue;
+            }
+
+            FieldDataType fieldDataType = fieldNameToDataType.get(fieldName);
+            if (!isQueryableFieldType(fieldDataType)) {
+                continue;
+            }
+
+            if (VisibilityUtils.canRead(fieldNameToVisibilityMap.getFieldVisibility(fieldName), authorizations)) {
+                fields.add(fieldName);
+            }
+        }
+        return fields;
+    }
+
+    private boolean isReservedFieldName(String fieldName) {
+        return fieldName.startsWith("__");
+    }
+
+    private boolean isQueryableFieldType(FieldDataType fieldDataType) {
+        switch (fieldDataType.getType()) {
+            case "string":
+                return true;
+            case "long":
+            case "int":
+                return false;
+            default:
+                return false;
+        }
+    }
+
+    private String[] xContentToAuthorizationsArray(XContentParser parser) throws IOException {
+        Set<String> authorizationsSet = new HashSet<>();
+        while (parser.nextToken() != XContentParser.Token.END_ARRAY) {
+            String authorization = parser.text();
+            authorizationsSet.add(authorization);
+        }
+        return authorizationsSet.toArray(new String[authorizationsSet.size()]);
+    }
+
+    private Map<String, FieldDataType> getFieldTypes(DocumentMapper documentMapper) {
+        Map<String, FieldDataType> fieldNameToDataType = new HashMap<>();
+        for (FieldMapper fieldMapper : documentMapper.mappers()) {
+            fieldNameToDataType.put(fieldMapper.name(), fieldMapper.fieldType().fieldDataType());
+        }
+        return fieldNameToDataType;
+    }
+}

--- a/elasticsearch2-plugin/src/main/java/org/vertexium/elasticsearch2/plugin/VisibilityUtils.java
+++ b/elasticsearch2-plugin/src/main/java/org/vertexium/elasticsearch2/plugin/VisibilityUtils.java
@@ -1,0 +1,18 @@
+package org.vertexium.elasticsearch2.plugin;
+
+import org.vertexium.security.Authorizations;
+import org.vertexium.security.ColumnVisibility;
+import org.vertexium.security.VisibilityEvaluator;
+import org.vertexium.security.VisibilityParseException;
+
+public class VisibilityUtils {
+    public static boolean canRead(String visibility, String[] authorizations) {
+        VisibilityEvaluator visibilityEvaluator = new VisibilityEvaluator(new Authorizations(authorizations));
+        ColumnVisibility columnVisibility = new ColumnVisibility(visibility);
+        try {
+            return visibilityEvaluator.evaluate(columnVisibility);
+        } catch (VisibilityParseException ex) {
+            throw new RuntimeException("could not evaluate visibility " + visibility, ex);
+        }
+    }
+}

--- a/elasticsearch2/README.md
+++ b/elasticsearch2/README.md
@@ -1,0 +1,4 @@
+# Elasticsearch
+
+Each vertex/edge is stored in a single Elasticsearch document. Security is accomplished
+by hashing the visibility string and appending it to the property name.

--- a/elasticsearch2/pom.xml
+++ b/elasticsearch2/pom.xml
@@ -1,0 +1,108 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+    <parent>
+        <artifactId>vertexium-root</artifactId>
+        <groupId>org.vertexium</groupId>
+        <version>2.6.0-SNAPSHOT</version>
+    </parent>
+    <modelVersion>4.0.0</modelVersion>
+
+    <artifactId>vertexium-elasticsearch2</artifactId>
+    <name>Vertexium: Elasticsearch2</name>
+
+    <dependencies>
+        <dependency>
+            <groupId>org.vertexium</groupId>
+            <artifactId>vertexium-core</artifactId>
+            <version>${project.version}</version>
+        </dependency>
+
+        <dependency>
+            <groupId>org.elasticsearch</groupId>
+            <artifactId>elasticsearch</artifactId>
+            <version>${elasticsearch2.version}</version>
+        </dependency>
+        <dependency>
+            <groupId>org.elasticsearch.module</groupId>
+            <artifactId>lang-groovy</artifactId>
+            <version>${elasticsearch2.version}</version>
+        </dependency>
+        <dependency>
+            <groupId>net.java.dev.jna</groupId>
+            <artifactId>jna</artifactId>
+            <version>${jna.version}</version>
+        </dependency>
+        <dependency>
+            <groupId>com.vividsolutions</groupId>
+            <artifactId>jts</artifactId>
+            <version>${jts.version}</version>
+        </dependency>
+        <dependency>
+            <groupId>net.jodah</groupId>
+            <artifactId>recurrent</artifactId>
+            <version>${recurrent.version}</version>
+        </dependency>
+
+        <!-- test dependencies -->
+        <dependency>
+            <groupId>org.codehaus.groovy</groupId>
+            <artifactId>groovy-all</artifactId>
+            <version>2.4.4</version>
+            <scope>test</scope>
+        </dependency>
+        <dependency>
+            <groupId>org.codelibs</groupId>
+            <artifactId>elasticsearch-cluster-runner</artifactId>
+            <version>2.4.0.0</version>
+            <scope>test</scope>
+        </dependency>
+        <dependency>
+            <groupId>org.slf4j</groupId>
+            <artifactId>slf4j-log4j12</artifactId>
+            <version>${slf4j.version}</version>
+            <scope>test</scope>
+        </dependency>
+        <dependency>
+            <groupId>net.lingala.zip4j</groupId>
+            <artifactId>zip4j</artifactId>
+            <version>1.3.2</version>
+            <scope>test</scope>
+        </dependency>
+        <dependency>
+            <groupId>commons-io</groupId>
+            <artifactId>commons-io</artifactId>
+            <version>${commons-io.version}</version>
+            <scope>test</scope>
+        </dependency>
+        <dependency>
+            <groupId>org.json</groupId>
+            <artifactId>json</artifactId>
+            <scope>test</scope>
+        </dependency>
+        <dependency>
+            <groupId>org.vertexium</groupId>
+            <artifactId>vertexium-test</artifactId>
+            <version>${project.version}</version>
+            <scope>test</scope>
+        </dependency>
+        <dependency>
+            <groupId>org.vertexium</groupId>
+            <artifactId>vertexium-inmemory</artifactId>
+            <version>${project.version}</version>
+            <scope>test</scope>
+        </dependency>
+    </dependencies>
+
+    <build>
+        <plugins>
+            <plugin>
+                <groupId>org.apache.maven.plugins</groupId>
+                <artifactId>maven-source-plugin</artifactId>
+            </plugin>
+            <plugin>
+                <groupId>org.apache.maven.plugins</groupId>
+                <artifactId>maven-javadoc-plugin</artifactId>
+            </plugin>
+        </plugins>
+    </build>
+</project>

--- a/elasticsearch2/src/main/java/org/vertexium/elasticsearch2/AuthorizationFilterBuilder.java
+++ b/elasticsearch2/src/main/java/org/vertexium/elasticsearch2/AuthorizationFilterBuilder.java
@@ -1,0 +1,24 @@
+package org.vertexium.elasticsearch2;
+
+import org.elasticsearch.common.xcontent.ToXContent;
+import org.elasticsearch.common.xcontent.XContentBuilder;
+import org.elasticsearch.index.query.QueryBuilder;
+
+import java.io.IOException;
+
+public class AuthorizationFilterBuilder extends QueryBuilder {
+    private final String[] authorizations;
+
+    public AuthorizationFilterBuilder(String[] authorizations) {
+        this.authorizations = authorizations;
+    }
+
+    @Override
+    protected void doXContent(XContentBuilder builder, ToXContent.Params params) throws IOException {
+        builder.startArray("authorizations");
+        for (String authorization : authorizations) {
+            builder.value(authorization);
+        }
+        builder.endArray();
+    }
+}

--- a/elasticsearch2/src/main/java/org/vertexium/elasticsearch2/DefaultIndexSelectionStrategy.java
+++ b/elasticsearch2/src/main/java/org/vertexium/elasticsearch2/DefaultIndexSelectionStrategy.java
@@ -1,0 +1,109 @@
+package org.vertexium.elasticsearch2;
+
+import org.vertexium.Element;
+import org.vertexium.ExtendedDataRowId;
+import org.vertexium.GraphConfiguration;
+import org.vertexium.PropertyDefinition;
+import org.vertexium.util.VertexiumLogger;
+import org.vertexium.util.VertexiumLoggerFactory;
+
+import java.util.Date;
+import java.util.EnumSet;
+import java.util.HashSet;
+import java.util.Set;
+
+public class DefaultIndexSelectionStrategy implements IndexSelectionStrategy {
+    private static final VertexiumLogger LOGGER = VertexiumLoggerFactory.getLogger(DefaultIndexSelectionStrategy.class);
+    public static final String CONFIG_INDEX_NAME = "indexName";
+    public static final String DEFAULT_INDEX_NAME = "vertexium";
+    public static final String CONFIG_EXTENDED_DATA_INDEX_NAME_PREFIX = "extendedDataIndexNamePrefix";
+    public static final String DEFAULT_EXTENDED_DATA_INDEX_NAME_PREFIX = "vertexium_extdata_";
+    private static final long INDEX_UPDATE_MS = 60 * 60 * 1000;
+    private final String defaultIndexName;
+    private final String extendedDataIndexNamePrefix;
+    private final Set<String> indicesToQuery = new HashSet<>();
+    private String[] indicesToQueryArray;
+    private long nextUpdateTime;
+
+    public DefaultIndexSelectionStrategy(GraphConfiguration config) {
+        defaultIndexName = getDefaultIndexName(config);
+        extendedDataIndexNamePrefix = getExtendedDataIndexNamePrefix(config);
+    }
+
+    private static String getDefaultIndexName(GraphConfiguration config) {
+        String defaultIndexName = config.getString(GraphConfiguration.SEARCH_INDEX_PROP_PREFIX + "." + CONFIG_INDEX_NAME, DEFAULT_INDEX_NAME);
+        LOGGER.info("Default index name: %s", defaultIndexName);
+        return defaultIndexName;
+    }
+
+    private static String getExtendedDataIndexNamePrefix(GraphConfiguration config) {
+        String prefix = config.getString(GraphConfiguration.SEARCH_INDEX_PROP_PREFIX + "." + CONFIG_EXTENDED_DATA_INDEX_NAME_PREFIX, DEFAULT_EXTENDED_DATA_INDEX_NAME_PREFIX);
+        LOGGER.info("Extended data index name prefix: %s", prefix);
+        return prefix;
+    }
+
+    @Override
+    public String[] getIndicesToQuery(Elasticsearch2SearchIndex es) {
+        Set<String> indicesToQuery = getIndicesToQuerySet(es);
+        if (indicesToQueryArray == null || indicesToQueryArray.length != indicesToQuery.size()) {
+            indicesToQueryArray = indicesToQuery.toArray(new String[indicesToQuery.size()]);
+        }
+        return indicesToQueryArray;
+    }
+
+    private Set<String> getIndicesToQuerySet(Elasticsearch2SearchIndex es) {
+        if (indicesToQuery.size() == 0 || new Date().getTime() > nextUpdateTime) {
+            indicesToQuery.add(defaultIndexName);
+            Set<String> indexNames = es.getIndexNamesFromElasticsearch();
+            for (String indexName : indexNames) {
+                if (indexName.startsWith(extendedDataIndexNamePrefix)) {
+                    indicesToQuery.add(indexName);
+                }
+            }
+            nextUpdateTime = new Date().getTime() + INDEX_UPDATE_MS;
+        }
+        return indicesToQuery;
+    }
+
+    @Override
+    public String getIndexName(Elasticsearch2SearchIndex es, Element element) {
+        return defaultIndexName;
+    }
+
+    @Override
+    public String getExtendedDataIndexName(Elasticsearch2SearchIndex es, Element element, String tableName, String rowId) {
+        return getExtendedDataIndexName(es, tableName);
+    }
+
+    @Override
+    public String getExtendedDataIndexName(Elasticsearch2SearchIndex es, ExtendedDataRowId rowId) {
+        return getExtendedDataIndexName(es, rowId.getTableName());
+    }
+
+    private String getExtendedDataIndexName(Elasticsearch2SearchIndex es, String tableName) {
+        String cleanTableName = tableName.replaceAll("[^a-zA-Z0-9]", "_").toLowerCase();
+        String extendedDataIndexName = extendedDataIndexNamePrefix + cleanTableName;
+        getIndicesToQuerySet(es).add(extendedDataIndexName);
+        return extendedDataIndexName;
+    }
+
+    @Override
+    public String[] getIndexNames(Elasticsearch2SearchIndex es, PropertyDefinition propertyDefinition) {
+        return getIndicesToQuery(es);
+    }
+
+    @Override
+    public boolean isIncluded(Elasticsearch2SearchIndex es, String indexName) {
+        return getIndicesToQuerySet(es).contains(indexName);
+    }
+
+    @Override
+    public String[] getManagedIndexNames(Elasticsearch2SearchIndex es) {
+        return getIndicesToQuery(es);
+    }
+
+    @Override
+    public String[] getIndicesToQuery(ElasticsearchSearchQueryBase query, EnumSet<ElasticsearchDocumentType> elementType) {
+        return getIndicesToQuery(query.getSearchIndex());
+    }
+}

--- a/elasticsearch2/src/main/java/org/vertexium/elasticsearch2/Elasticsearch2SearchIndex.java
+++ b/elasticsearch2/src/main/java/org/vertexium/elasticsearch2/Elasticsearch2SearchIndex.java
@@ -1,0 +1,1812 @@
+package org.vertexium.elasticsearch2;
+
+import com.carrotsearch.hppc.cursors.ObjectCursor;
+import com.google.common.base.Throwables;
+import com.google.common.collect.ImmutableMap;
+import com.google.common.collect.Lists;
+import com.google.common.collect.Maps;
+import com.google.common.util.concurrent.SettableFuture;
+import org.elasticsearch.action.ActionRequestBuilder;
+import org.elasticsearch.action.ListenableActionFuture;
+import org.elasticsearch.action.admin.cluster.health.ClusterHealthResponse;
+import org.elasticsearch.action.admin.cluster.node.info.NodeInfo;
+import org.elasticsearch.action.admin.cluster.node.info.NodesInfoResponse;
+import org.elasticsearch.action.admin.indices.create.CreateIndexResponse;
+import org.elasticsearch.action.admin.indices.delete.DeleteIndexRequest;
+import org.elasticsearch.action.admin.indices.mapping.get.GetMappingsResponse;
+import org.elasticsearch.action.bulk.BulkItemResponse;
+import org.elasticsearch.action.bulk.BulkRequest;
+import org.elasticsearch.action.bulk.BulkResponse;
+import org.elasticsearch.action.search.SearchRequestBuilder;
+import org.elasticsearch.action.search.SearchResponse;
+import org.elasticsearch.action.search.SearchType;
+import org.elasticsearch.action.update.UpdateRequest;
+import org.elasticsearch.action.update.UpdateRequestBuilder;
+import org.elasticsearch.client.Client;
+import org.elasticsearch.client.transport.TransportClient;
+import org.elasticsearch.cluster.health.ClusterHealthStatus;
+import org.elasticsearch.cluster.metadata.MappingMetaData;
+import org.elasticsearch.common.collect.ImmutableOpenMap;
+import org.elasticsearch.common.settings.Settings;
+import org.elasticsearch.common.transport.InetSocketTransportAddress;
+import org.elasticsearch.common.xcontent.XContentBuilder;
+import org.elasticsearch.common.xcontent.XContentFactory;
+import org.elasticsearch.index.query.FilteredQueryBuilder;
+import org.elasticsearch.index.query.QueryBuilder;
+import org.elasticsearch.index.query.QueryBuilders;
+import org.elasticsearch.index.query.TermQueryBuilder;
+import org.elasticsearch.node.Node;
+import org.elasticsearch.node.NodeBuilder;
+import org.elasticsearch.plugins.PluginInfo;
+import org.elasticsearch.script.Script;
+import org.elasticsearch.script.ScriptService;
+import org.elasticsearch.search.SearchHit;
+import org.elasticsearch.search.aggregations.Aggregation;
+import org.elasticsearch.search.aggregations.bucket.terms.Terms;
+import org.elasticsearch.search.aggregations.bucket.terms.TermsBuilder;
+import org.vertexium.*;
+import org.vertexium.elasticsearch2.utils.ElasticsearchExtendedDataIdUtils;
+import org.vertexium.id.NameSubstitutionStrategy;
+import org.vertexium.mutation.ExtendedDataMutation;
+import org.vertexium.property.StreamingPropertyValue;
+import org.vertexium.query.*;
+import org.vertexium.search.SearchIndex;
+import org.vertexium.search.SearchIndexWithVertexPropertyCountByValue;
+import org.vertexium.type.GeoCircle;
+import org.vertexium.type.GeoPoint;
+import org.vertexium.type.GeoShape;
+import org.vertexium.type.IpV4Address;
+import org.vertexium.util.ConfigurationUtils;
+import org.vertexium.util.IOUtils;
+import org.vertexium.util.VertexiumLogger;
+import org.vertexium.util.VertexiumLoggerFactory;
+
+import java.io.*;
+import java.math.BigDecimal;
+import java.math.BigInteger;
+import java.net.InetAddress;
+import java.net.UnknownHostException;
+import java.util.*;
+import java.util.concurrent.Future;
+import java.util.concurrent.TimeUnit;
+import java.util.regex.Matcher;
+import java.util.regex.Pattern;
+import java.util.stream.Collectors;
+
+import static org.vertexium.elasticsearch2.ElasticsearchPropertyNameInfo.PROPERTY_NAME_PATTERN;
+import static org.vertexium.util.Preconditions.checkNotNull;
+
+public class Elasticsearch2SearchIndex implements SearchIndex, SearchIndexWithVertexPropertyCountByValue {
+    private static final VertexiumLogger LOGGER = VertexiumLoggerFactory.getLogger(Elasticsearch2SearchIndex.class);
+    protected static final VertexiumLogger MUTATION_LOGGER = VertexiumLoggerFactory.getMutationLogger(SearchIndex.class);
+    public static final String ELEMENT_TYPE = "element";
+    public static final String ELEMENT_TYPE_FIELD_NAME = "__elementType";
+    public static final String VISIBILITY_FIELD_NAME = "__visibility";
+    public static final String OUT_VERTEX_ID_FIELD_NAME = "__outVertexId";
+    public static final String IN_VERTEX_ID_FIELD_NAME = "__inVertexId";
+    public static final String EDGE_LABEL_FIELD_NAME = "__edgeLabel";
+    public static final String EXTENDED_DATA_ELEMENT_ID_FIELD_NAME = "__extendedDataElementId";
+    public static final String EXTENDED_DATA_TABLE_NAME_FIELD_NAME = "__extendedDataTableName";
+    public static final String EXTENDED_DATA_TABLE_ROW_ID_FIELD_NAME = "__extendedDataRowId";
+    public static final String EXACT_MATCH_PROPERTY_NAME_SUFFIX = "_e";
+    public static final String GEO_PROPERTY_NAME_SUFFIX = "_g";
+    public static final String SORT_PROPERTY_NAME_SUFFIX = "_s";
+    public static final int MAX_BATCH_COUNT = 25000;
+    public static final long MAX_BATCH_SIZE = 15 * 1024 * 1024;
+    public static final int EXACT_MATCH_IGNORE_ABOVE_LIMIT = 10000;
+    private static final long IN_PROCESS_NODE_WAIT_TIME_MS = 10 * 60 * 1000;
+    private static final int MAX_RETRIES = 10;
+    private final Client client;
+    private final ElasticsearchSearchIndexConfiguration config;
+    private Map<String, IndexInfo> indexInfos;
+    private int indexInfosLastSize = 0; // Used to prevent creating a index name array each time
+    private String[] indexNamesAsArray;
+    private IndexSelectionStrategy indexSelectionStrategy;
+    private boolean allFieldEnabled;
+    private Node inProcessNode;
+    public static final Pattern AGGREGATION_NAME_PATTERN = Pattern.compile("(.*?)_([0-9a-f]+)");
+    public static final String CONFIG_PROPERTY_NAME_VISIBILITIES_STORE = "propertyNameVisibilitiesStore";
+    public static final Class<? extends PropertyNameVisibilitiesStore> DEFAULT_PROPERTY_NAME_VISIBILITIES_STORE = MetadataTablePropertyNameVisibilitiesStore.class;
+    private final NameSubstitutionStrategy nameSubstitutionStrategy;
+    private final PropertyNameVisibilitiesStore propertyNameVisibilitiesStore;
+    private final ThreadLocal<Queue<FlushObject>> flushFutures = new ThreadLocal<>();
+    private final Random random = new Random();
+    private boolean serverPluginInstalled;
+
+    public Elasticsearch2SearchIndex(Graph graph, GraphConfiguration config) {
+        this.config = new ElasticsearchSearchIndexConfiguration(graph, config);
+        this.nameSubstitutionStrategy = this.config.getNameSubstitutionStrategy();
+        this.indexSelectionStrategy = this.config.getIndexSelectionStrategy();
+        this.allFieldEnabled = this.config.isAllFieldEnabled(false);
+        this.propertyNameVisibilitiesStore = createPropertyNameVisibilitiesStore(graph, config);
+        this.client = createClient(this.config);
+        this.serverPluginInstalled = checkPluginInstalled(this.client);
+    }
+
+    protected Client createClient(ElasticsearchSearchIndexConfiguration config) {
+        if (config.isInProcessNode()) {
+            return createInProcessNode(config);
+        } else {
+            return createTransportClient(config);
+        }
+    }
+
+    private Client createInProcessNode(ElasticsearchSearchIndexConfiguration config) {
+        try {
+            Class.forName("groovy.lang.GroovyShell");
+        } catch (ClassNotFoundException e) {
+            throw new VertexiumException("Unable to load Groovy. This is required when running in-process ES.", e);
+        }
+
+        Settings settings = tryReadSettingsFromFile(config);
+        if (settings == null) {
+            String dataPath = config.getInProcessNodeDataPath();
+            checkNotNull(dataPath, ElasticsearchSearchIndexConfiguration.IN_PROCESS_NODE_DATA_PATH + " is required for in process Elasticsearch node");
+            String logsPath = config.getInProcessNodeLogsPath();
+            checkNotNull(logsPath, ElasticsearchSearchIndexConfiguration.IN_PROCESS_NODE_LOGS_PATH + " is required for in process Elasticsearch node");
+            String workPath = config.getInProcessNodeWorkPath();
+            checkNotNull(workPath, ElasticsearchSearchIndexConfiguration.IN_PROCESS_NODE_WORK_PATH + " is required for in process Elasticsearch node");
+            int numberOfShards = config.getNumberOfShards();
+
+            Map<String, String> mapSettings = new HashMap<>();
+            mapSettings.put("script.inline", "true");
+            mapSettings.put("index.number_of_shards", Integer.toString(numberOfShards));
+            mapSettings.put("index.number_of_replicas", "0");
+            mapSettings.put("path.data", dataPath);
+            mapSettings.put("path.logs", logsPath);
+            mapSettings.put("path.work", workPath);
+            mapSettings.put("discovery.zen.ping.multicast.enabled", "false");
+            mapSettings.put("discovery.zen.ping.unicast.hosts", "localhost");
+
+            mapSettings.putAll(config.getInProcessNodeAdditionalSettings());
+
+            settings = Settings.settingsBuilder()
+                    .put(mapSettings)
+                    .build();
+        }
+
+        NodeBuilder nodeBuilder = NodeBuilder
+                .nodeBuilder();
+        if (config.getClusterName() != null) {
+            nodeBuilder = nodeBuilder.clusterName(config.getClusterName());
+        }
+        this.inProcessNode = nodeBuilder
+                .settings(settings).node();
+        inProcessNode.start();
+        Client client = inProcessNode.client();
+
+        long startTime = System.currentTimeMillis();
+        while (true) {
+            if (System.currentTimeMillis() > startTime + IN_PROCESS_NODE_WAIT_TIME_MS) {
+                throw new VertexiumException("Status failed to exit red status after waiting " + IN_PROCESS_NODE_WAIT_TIME_MS + "ms. Giving up.");
+            }
+            ClusterHealthResponse health = client.admin().cluster().prepareHealth().get();
+            if (health.getStatus() != ClusterHealthStatus.RED) {
+                break;
+            }
+            try {
+                Thread.sleep(1000);
+            } catch (InterruptedException e) {
+                throw new VertexiumException("Could not sleep", e);
+            }
+            LOGGER.info("Status is %s, waiting...", health.getStatus());
+        }
+        return client;
+    }
+
+    private static TransportClient createTransportClient(ElasticsearchSearchIndexConfiguration config) {
+        Settings settings = tryReadSettingsFromFile(config);
+        if (settings == null) {
+            Settings.Builder settingsBuilder = Settings.settingsBuilder();
+            if (config.getClusterName() != null) {
+                settingsBuilder.put("cluster.name", config.getClusterName());
+            }
+            settings = settingsBuilder.build();
+        }
+        TransportClient transportClient = TransportClient.builder().settings(settings).build();
+        for (String esLocation : config.getEsLocations()) {
+            String[] locationSocket = esLocation.split(":");
+            String hostname;
+            int port;
+            if (locationSocket.length == 2) {
+                hostname = locationSocket[0];
+                port = Integer.parseInt(locationSocket[1]);
+            } else if (locationSocket.length == 1) {
+                hostname = locationSocket[0];
+                port = config.getPort();
+            } else {
+                throw new VertexiumException("Invalid elastic search location: " + esLocation);
+            }
+            InetAddress host;
+            try {
+                host = InetAddress.getByName(hostname);
+            } catch (UnknownHostException ex) {
+                throw new VertexiumException("Could not resolve host: " + hostname, ex);
+            }
+            transportClient.addTransportAddress(new InetSocketTransportAddress(host, port));
+        }
+        return transportClient;
+    }
+
+    private static Settings tryReadSettingsFromFile(ElasticsearchSearchIndexConfiguration config) {
+        File esConfigFile = config.getEsConfigFile();
+        if (esConfigFile == null) {
+            return null;
+        }
+        if (!esConfigFile.exists()) {
+            throw new VertexiumException(esConfigFile.getAbsolutePath() + " does not exist");
+        }
+        try (FileInputStream fileIn = new FileInputStream(esConfigFile)) {
+            return Settings.builder().loadFromStream(esConfigFile.getAbsolutePath(), fileIn).build();
+        } catch (IOException e) {
+            throw new VertexiumException("Could not read ES config file: " + esConfigFile.getAbsolutePath(), e);
+        }
+    }
+
+    private boolean checkPluginInstalled(Client client) {
+        NodesInfoResponse nodesInfoResponse = client.admin().cluster().prepareNodesInfo().setPlugins(true).get();
+        for (NodeInfo nodeInfo : nodesInfoResponse.getNodes()) {
+            for (PluginInfo pluginInfo : nodeInfo.getPlugins().getPluginInfos()) {
+                if ("Vertexium".equals(pluginInfo.getName())) {
+                    return true;
+                }
+            }
+        }
+        LOGGER.warn("Running without the server side Vertexium plugin will be deprecated in the future.");
+        return false;
+    }
+
+    protected final boolean isAllFieldEnabled() {
+        return allFieldEnabled;
+    }
+
+    public Set<String> getIndexNamesFromElasticsearch() {
+        return client.admin().indices().prepareStats().execute().actionGet().getIndices().keySet();
+    }
+
+    void clearIndexInfoCache() {
+        this.indexInfos = null;
+    }
+
+    private Map<String, IndexInfo> getIndexInfos(Graph graph) {
+        if (indexInfos == null) {
+            indexInfos = new HashMap<>();
+            loadIndexInfos(graph, indexInfos);
+        }
+        return indexInfos;
+    }
+
+    private void loadIndexInfos(Graph graph, Map<String, IndexInfo> indexInfos) {
+        Set<String> indices = getIndexNamesFromElasticsearch();
+        for (String indexName : indices) {
+            if (!indexSelectionStrategy.isIncluded(this, indexName)) {
+                LOGGER.debug("skipping index %s, not in indicesToQuery", indexName);
+                continue;
+            }
+
+            IndexInfo indexInfo = indexInfos.get(indexName);
+            if (indexInfo != null) {
+                continue;
+            }
+
+            LOGGER.debug("loading index info for %s", indexName);
+            indexInfo = createIndexInfo(indexName);
+            addPropertyNameVisibility(graph, indexInfo, ELEMENT_TYPE_FIELD_NAME, null);
+            addPropertyNameVisibility(graph, indexInfo, EXTENDED_DATA_ELEMENT_ID_FIELD_NAME, null);
+            addPropertyNameVisibility(graph, indexInfo, VISIBILITY_FIELD_NAME, null);
+            addPropertyNameVisibility(graph, indexInfo, OUT_VERTEX_ID_FIELD_NAME, null);
+            addPropertyNameVisibility(graph, indexInfo, IN_VERTEX_ID_FIELD_NAME, null);
+            addPropertyNameVisibility(graph, indexInfo, EDGE_LABEL_FIELD_NAME, null);
+            loadExistingMappingIntoIndexInfo(graph, indexInfo, indexName);
+            indexInfos.put(indexName, indexInfo);
+
+            updateMetadata(graph, indexInfo);
+        }
+    }
+
+    private void loadExistingMappingIntoIndexInfo(Graph graph, IndexInfo indexInfo, String indexName) {
+        try {
+            GetMappingsResponse mapping = client.admin().indices().prepareGetMappings(indexName).get();
+            for (ObjectCursor<String> mappingIndexName : mapping.getMappings().keys()) {
+                ImmutableOpenMap<String, MappingMetaData> typeMappings = mapping.getMappings().get(mappingIndexName.value);
+                for (ObjectCursor<String> typeName : typeMappings.keys()) {
+                    MappingMetaData typeMapping = typeMappings.get(typeName.value);
+                    Map<String, Map<String, String>> properties = getPropertiesFromTypeMapping(typeMapping);
+                    if (properties == null) {
+                        continue;
+                    }
+
+                    for (Map.Entry<String, Map<String, String>> propertyEntry : properties.entrySet()) {
+                        String rawPropertyName = propertyEntry.getKey();
+                        loadExistingPropertyMappingIntoIndexInfo(graph, indexInfo, rawPropertyName);
+                    }
+                }
+            }
+        } catch (IOException ex) {
+            throw new VertexiumException("Could not load type mappings", ex);
+        }
+    }
+
+    @SuppressWarnings("unchecked")
+    private Map<String, Map<String, String>> getPropertiesFromTypeMapping(MappingMetaData typeMapping) throws IOException {
+        return (Map<String, Map<String, String>>) typeMapping.getSourceAsMap().get("properties");
+    }
+
+    private void loadExistingPropertyMappingIntoIndexInfo(Graph graph, IndexInfo indexInfo, String rawPropertyName) {
+        ElasticsearchPropertyNameInfo p = ElasticsearchPropertyNameInfo.parse(graph, propertyNameVisibilitiesStore, rawPropertyName);
+        if (p == null) {
+            return;
+        }
+        addPropertyNameVisibility(graph, indexInfo, p.getPropertyName(), p.getPropertyVisibility());
+    }
+
+    private PropertyNameVisibilitiesStore createPropertyNameVisibilitiesStore(Graph graph, GraphConfiguration config) {
+        String className = config.getString(GraphConfiguration.SEARCH_INDEX_PROP_PREFIX + "." + CONFIG_PROPERTY_NAME_VISIBILITIES_STORE, DEFAULT_PROPERTY_NAME_VISIBILITIES_STORE.getName());
+        return ConfigurationUtils.createProvider(className, graph, config);
+    }
+
+    @SuppressWarnings("unchecked")
+    @Override
+    public void addElement(Graph graph, Element element, Authorizations authorizations) {
+        addElementWithScript(graph, element, authorizations);
+    }
+
+    private void addElementWithScript(
+            Graph graph,
+            final Element element,
+            Authorizations authorizations
+    ) {
+        if (MUTATION_LOGGER.isTraceEnabled()) {
+            MUTATION_LOGGER.trace("addElement: %s", element.getId());
+        }
+        if (!getConfig().isIndexEdges() && element instanceof Edge) {
+            return;
+        }
+
+        final IndexInfo indexInfo = addPropertiesToIndex(graph, element, element.getProperties());
+
+        try {
+            final XContentBuilder jsonBuilder = buildJsonContentFromElement(graph, element, authorizations);
+            final XContentBuilder source = jsonBuilder.endObject();
+            if (MUTATION_LOGGER.isTraceEnabled()) {
+                MUTATION_LOGGER.trace("addElement json: %s: %s", element.getId(), source.string());
+            }
+
+            if (flushObjectQueueContainsElementId(element.getId())) {
+                flushFlushObjectQueue();
+            }
+            UpdateRequestBuilder updateRequestBuilder = getClient()
+                    .prepareUpdate(indexInfo.getIndexName(), ELEMENT_TYPE, element.getId())
+                    .setDocAsUpsert(true)
+                    .setDoc(source)
+                    .setRetryOnConflict(MAX_RETRIES);
+
+            addActionRequestBuilderForFlush(element.getId(), updateRequestBuilder);
+
+            if (getConfig().isAutoFlush()) {
+                flush(graph);
+            }
+        } catch (Exception e) {
+            throw new VertexiumException("Could not add element", e);
+        }
+
+        getConfig().getScoringStrategy().addElement(this, graph, element, authorizations);
+    }
+
+    private boolean flushObjectQueueContainsElementId(String elementId) {
+        return getFlushObjectQueue().stream()
+                .anyMatch(flushObject -> flushObject.elementId.equals(elementId));
+    }
+
+    private void addActionRequestBuilderForFlush(String elementId, UpdateRequestBuilder updateRequestBuilder) {
+        Future future;
+        try {
+            future = updateRequestBuilder.execute();
+        } catch (Exception ex) {
+            LOGGER.debug("Could not execute update: %s", ex.getMessage());
+            future = SettableFuture.create();
+            ((SettableFuture) future).setException(ex);
+        }
+        getFlushObjectQueue().add(new FlushObject(elementId, updateRequestBuilder, future));
+    }
+
+    @Override
+    public void addElementExtendedData(Graph graph, Element element, Iterable<ExtendedDataMutation> extendedData, Authorizations authorizations) {
+        Map<String, Map<String, List<ExtendedDataMutation>>> extendedDataByTableByRow = mapExtendedDatasByTableByRow(extendedData);
+        for (Map.Entry<String, Map<String, List<ExtendedDataMutation>>> byTable : extendedDataByTableByRow.entrySet()) {
+            String tableName = byTable.getKey();
+            Map<String, List<ExtendedDataMutation>> byRow = byTable.getValue();
+            for (Map.Entry<String, List<ExtendedDataMutation>> row : byRow.entrySet()) {
+                String rowId = row.getKey();
+                List<ExtendedDataMutation> columns = row.getValue();
+                addElementExtendedData(graph, element, tableName, rowId, columns, authorizations);
+            }
+        }
+    }
+
+    @Override
+    public void deleteExtendedData(Graph graph, ExtendedDataRowId rowId, Authorizations authorizations) {
+        String indexName = getExtendedDataIndexName(rowId);
+        String docId = ElasticsearchExtendedDataIdUtils.toDocId(rowId);
+        getClient().prepareDelete(indexName, ELEMENT_TYPE, docId).execute().actionGet();
+    }
+
+    private void addElementExtendedData(
+            Graph graph,
+            Element element,
+            String tableName,
+            String rowId,
+            List<ExtendedDataMutation> columns,
+            Authorizations authorizations
+    ) {
+        if (MUTATION_LOGGER.isTraceEnabled()) {
+            MUTATION_LOGGER.trace("addElementExtendedData: %s:%s:%s", element.getId(), tableName, rowId);
+        }
+
+        final IndexInfo indexInfo = addExtendedDataColumnsToIndex(graph, element, tableName, rowId, columns);
+
+        try {
+            final XContentBuilder jsonBuilder = buildJsonContentFromExtendedDataMutations(graph, element, tableName, rowId, columns, authorizations);
+            final XContentBuilder source = jsonBuilder.endObject();
+            if (MUTATION_LOGGER.isTraceEnabled()) {
+                MUTATION_LOGGER.trace("addElementExtendedData json: %s:%s:%s: %s", element.getId(), tableName, rowId, source.string());
+            }
+
+            String extendedDataDocId = ElasticsearchExtendedDataIdUtils.createForElement(element, tableName, rowId);
+            UpdateRequestBuilder updateRequestBuilder = getClient()
+                    .prepareUpdate(indexInfo.getIndexName(), ELEMENT_TYPE, extendedDataDocId)
+                    .setDocAsUpsert(true)
+                    .setDoc(source)
+                    .setRetryOnConflict(MAX_RETRIES);
+            addActionRequestBuilderForFlush(element.getId(), updateRequestBuilder);
+
+            if (getConfig().isAutoFlush()) {
+                flush(graph);
+            }
+        } catch (Exception e) {
+            throw new VertexiumException("Could not add element extended data", e);
+        }
+
+        getConfig().getScoringStrategy().addElementExtendedData(this, graph, element, tableName, rowId, columns, authorizations);
+    }
+
+    private XContentBuilder buildJsonContentFromExtendedDataMutations(
+            Graph graph,
+            Element element,
+            String tableName,
+            String rowId,
+            List<ExtendedDataMutation> columns,
+            Authorizations authorizations
+    ) throws IOException {
+        XContentBuilder jsonBuilder;
+        jsonBuilder = XContentFactory.jsonBuilder()
+                .startObject();
+
+        jsonBuilder.field(ELEMENT_TYPE_FIELD_NAME, ElasticsearchDocumentType.getExtendedDataDocumentTypeFromElement(element).getKey());
+        String elementTypeVisibilityPropertyName = addElementTypeVisibilityPropertyToIndex(graph, element);
+        jsonBuilder.field(elementTypeVisibilityPropertyName, ElasticsearchDocumentType.VERTEX.getKey());
+        getConfig().getScoringStrategy().addFieldsToExtendedDataDocument(this, jsonBuilder, element, null, tableName, rowId, columns, authorizations);
+        jsonBuilder.field(EXTENDED_DATA_ELEMENT_ID_FIELD_NAME, element.getId());
+        jsonBuilder.field(EXTENDED_DATA_TABLE_NAME_FIELD_NAME, tableName);
+        jsonBuilder.field(EXTENDED_DATA_TABLE_ROW_ID_FIELD_NAME, rowId);
+        if (element instanceof Edge) {
+            Edge edge = (Edge) element;
+            jsonBuilder.field(IN_VERTEX_ID_FIELD_NAME, edge.getVertexId(Direction.IN));
+            jsonBuilder.field(OUT_VERTEX_ID_FIELD_NAME, edge.getVertexId(Direction.OUT));
+            jsonBuilder.field(EDGE_LABEL_FIELD_NAME, edge.getLabel());
+        }
+
+        Map<String, Object> fields = getExtendedDataColumnsAsFields(graph, columns);
+        addFieldsMap(jsonBuilder, fields);
+
+        return jsonBuilder;
+    }
+
+    private Map<String, Object> getExtendedDataColumnsAsFields(Graph graph, List<ExtendedDataMutation> columns) {
+        Map<String, Object> fieldsMap = new HashMap<>();
+        List<ExtendedDataMutation> streamingColumns = new ArrayList<>();
+        for (ExtendedDataMutation column : columns) {
+            if (column.getValue() != null && shouldIgnoreType(column.getValue().getClass())) {
+                continue;
+            }
+
+            if (column.getValue() instanceof StreamingPropertyValue) {
+                StreamingPropertyValue spv = (StreamingPropertyValue) column.getValue();
+                if (isStreamingPropertyValueIndexable(graph, column.getColumnName(), spv)) {
+                    streamingColumns.add(column);
+                }
+            } else {
+                addExtendedDataColumnToFieldMap(graph, column, column.getValue(), fieldsMap);
+            }
+        }
+        addStreamingExtendedDataColumnsValuesToMap(graph, streamingColumns, fieldsMap);
+        return fieldsMap;
+    }
+
+    private void addStreamingExtendedDataColumnsValuesToMap(Graph graph, List<ExtendedDataMutation> columns, Map<String, Object> fieldsMap) {
+        List<StreamingPropertyValue> streamingPropertyValues = columns.stream()
+                .map((column) -> {
+                    if (!(column.getValue() instanceof StreamingPropertyValue)) {
+                        throw new VertexiumException("column with a value that is not a StreamingPropertyValue passed to addStreamingPropertyValuesToFieldMap");
+                    }
+                    return (StreamingPropertyValue) column.getValue();
+                })
+                .collect(Collectors.toList());
+
+        List<InputStream> inputStreams = graph.getStreamingPropertyValueInputStreams(streamingPropertyValues);
+        for (int i = 0; i < columns.size(); i++) {
+            try {
+                String propertyValue = IOUtils.toString(inputStreams.get(i));
+                addExtendedDataColumnToFieldMap(graph, columns.get(i), new StreamingPropertyString(propertyValue), fieldsMap);
+            } catch (IOException ex) {
+                throw new VertexiumException("could not convert streaming property to string", ex);
+            }
+        }
+    }
+
+    private void addExtendedDataColumnToFieldMap(Graph graph, ExtendedDataMutation column, Object value, Map<String, Object> fieldsMap) {
+        String propertyName = deflateExtendedDataColumnName(graph, column);
+        addValuesToFieldMap(graph, fieldsMap, propertyName, value);
+    }
+
+    private void addFieldsMap(XContentBuilder jsonBuilder, Map<String, Object> fields) throws IOException {
+        for (Map.Entry<String, Object> property : fields.entrySet()) {
+            if (property.getValue() instanceof List) {
+                List list = (List) property.getValue();
+                jsonBuilder.field(property.getKey(), list.toArray(new Object[list.size()]));
+            } else {
+                jsonBuilder.field(property.getKey(), convertValueForIndexing(property.getValue()));
+            }
+        }
+    }
+
+    private Map<String, Map<String, List<ExtendedDataMutation>>> mapExtendedDatasByTableByRow(Iterable<ExtendedDataMutation> extendedData) {
+        Map<String, Map<String, List<ExtendedDataMutation>>> results = new HashMap<>();
+        for (ExtendedDataMutation ed : extendedData) {
+            Map<String, List<ExtendedDataMutation>> byRow = results.computeIfAbsent(ed.getTableName(), k -> new HashMap<>());
+            List<ExtendedDataMutation> items = byRow.computeIfAbsent(ed.getRow(), k -> new ArrayList<>());
+            items.add(ed);
+        }
+        return results;
+    }
+
+    private Queue<FlushObject> getFlushObjectQueue() {
+        Queue<FlushObject> queue = flushFutures.get();
+        if (queue == null) {
+            queue = new LinkedList<>();
+            flushFutures.set(queue);
+        }
+        return queue;
+    }
+
+    @Override
+    public void alterElementVisibility(
+            Graph graph,
+            Element element,
+            Visibility oldVisibility,
+            Visibility newVisibility,
+            Authorizations authorizations
+    ) {
+        String oldFieldName = deflatePropertyName(graph, ELEMENT_TYPE_FIELD_NAME, oldVisibility);
+        Script script = new Script(
+                "ctx._source.remove(oldFieldName);",
+                ScriptService.ScriptType.INLINE,
+                null,
+                ImmutableMap.<String, Object>of("oldFieldName", oldFieldName)
+        );
+        getClient().prepareUpdate()
+                .setIndex(getIndexName(element))
+                .setId(element.getId())
+                .setType(ELEMENT_TYPE)
+                .setScript(script)
+                .get();
+        addElement(graph, element, authorizations);
+    }
+
+    private XContentBuilder buildJsonContentFromElement(Graph graph, Element element, Authorizations authorizations) throws IOException {
+        XContentBuilder jsonBuilder;
+        jsonBuilder = XContentFactory.jsonBuilder()
+                .startObject();
+
+        String elementTypeVisibilityPropertyName = addElementTypeVisibilityPropertyToIndex(graph, element);
+
+        jsonBuilder.field(ELEMENT_TYPE_FIELD_NAME, getElementTypeValueFromElement(element));
+        if (element instanceof Vertex) {
+            jsonBuilder.field(elementTypeVisibilityPropertyName, ElasticsearchDocumentType.VERTEX.getKey());
+            getConfig().getScoringStrategy().addFieldsToVertexDocument(this, jsonBuilder, (Vertex) element, null, authorizations);
+        } else if (element instanceof Edge) {
+            Edge edge = (Edge) element;
+            jsonBuilder.field(elementTypeVisibilityPropertyName, ElasticsearchDocumentType.VERTEX.getKey());
+            getConfig().getScoringStrategy().addFieldsToEdgeDocument(this, jsonBuilder, edge, null, authorizations);
+            jsonBuilder.field(IN_VERTEX_ID_FIELD_NAME, edge.getVertexId(Direction.IN));
+            jsonBuilder.field(OUT_VERTEX_ID_FIELD_NAME, edge.getVertexId(Direction.OUT));
+            jsonBuilder.field(EDGE_LABEL_FIELD_NAME, edge.getLabel());
+        } else {
+            throw new VertexiumException("Unexpected element type " + element.getClass().getName());
+        }
+
+        Map<String, Object> fields = getPropertiesAsFields(graph, element);
+        addFieldsMap(jsonBuilder, fields);
+
+        return jsonBuilder;
+    }
+
+    private String getElementTypeValueFromElement(Element element) {
+        if (element instanceof Vertex) {
+            return ElasticsearchDocumentType.VERTEX.getKey();
+        }
+        if (element instanceof Edge) {
+            return ElasticsearchDocumentType.EDGE.getKey();
+        }
+        throw new VertexiumException("Unhandled element type: " + element.getClass().getName());
+    }
+
+    protected Object convertValueForIndexing(Object obj) {
+        if (obj == null) {
+            return null;
+        }
+        if (obj instanceof BigDecimal) {
+            return ((BigDecimal) obj).doubleValue();
+        }
+        if (obj instanceof BigInteger) {
+            return ((BigInteger) obj).intValue();
+        }
+        return obj;
+    }
+
+    private String addElementTypeVisibilityPropertyToIndex(Graph graph, Element element) throws IOException {
+        String elementTypeVisibilityPropertyName = deflatePropertyName(graph, ELEMENT_TYPE_FIELD_NAME, element.getVisibility());
+        String indexName = getIndexName(element);
+        IndexInfo indexInfo = ensureIndexCreatedAndInitialized(graph, indexName);
+        addPropertyToIndex(graph, indexInfo, elementTypeVisibilityPropertyName, element.getVisibility(), String.class, false);
+        return elementTypeVisibilityPropertyName;
+    }
+
+    private Map<String, Object> getPropertiesAsFields(Graph graph, Element element) throws IOException {
+        Map<String, Object> fieldsMap = new HashMap<>();
+        List<Property> streamingProperties = new ArrayList<>();
+        for (Property property : element.getProperties()) {
+            if (property.getValue() != null && shouldIgnoreType(property.getValue().getClass())) {
+                continue;
+            }
+
+            if (property.getValue() instanceof StreamingPropertyValue) {
+                StreamingPropertyValue spv = (StreamingPropertyValue) property.getValue();
+                if (isStreamingPropertyValueIndexable(graph, property.getName(), spv)) {
+                    streamingProperties.add(property);
+                }
+            } else {
+                addPropertyToFieldMap(graph, property, property.getValue(), fieldsMap);
+            }
+        }
+        addStreamingPropertyValuesToFieldMap(graph, streamingProperties, fieldsMap);
+        return fieldsMap;
+    }
+
+    private void addPropertyToFieldMap(Graph graph, Property property, Object propertyValue, Map<String, Object> propertiesMap) {
+        String propertyName = deflatePropertyName(graph, property);
+        addValuesToFieldMap(graph, propertiesMap, propertyName, propertyValue);
+    }
+
+    private void addValuesToFieldMap(Graph graph, Map<String, Object> propertiesMap, String propertyName, Object propertyValue) {
+        PropertyDefinition propertyDefinition = getPropertyDefinition(graph, propertyName);
+        if (propertyValue instanceof GeoPoint) {
+            convertGeoPoint(graph, propertiesMap, propertyName, (GeoPoint) propertyValue);
+            return;
+        } else if (propertyValue instanceof GeoCircle) {
+            convertGeoCircle(graph, propertiesMap, propertyName, (GeoCircle) propertyValue);
+            return;
+        } else if (propertyValue instanceof StreamingPropertyString) {
+            propertyValue = ((StreamingPropertyString) propertyValue).getPropertyValue();
+        } else if (propertyValue instanceof String) {
+            if (propertyDefinition == null || propertyDefinition.getTextIndexHints().contains(TextIndexHint.EXACT_MATCH)) {
+                addPropertyValueToPropertiesMap(propertiesMap, propertyName + EXACT_MATCH_PROPERTY_NAME_SUFFIX, propertyValue);
+            }
+            if (propertyDefinition == null || propertyDefinition.getTextIndexHints().contains(TextIndexHint.FULL_TEXT)) {
+                addPropertyValueToPropertiesMap(propertiesMap, propertyName, propertyValue);
+            }
+            if (propertyDefinition != null && propertyDefinition.isSortable()) {
+                String s = ((String) propertyValue).substring(0, Math.min(100, ((String) propertyValue).length()));
+                addPropertyValueToPropertiesMap(propertiesMap, propertyDefinition.getPropertyName() + SORT_PROPERTY_NAME_SUFFIX, s);
+            }
+            return;
+        }
+
+        if (propertyValue instanceof DateOnly) {
+            propertyValue = ((DateOnly) propertyValue).getDate();
+        }
+
+        addPropertyValueToPropertiesMap(propertiesMap, propertyName, propertyValue);
+        if (propertyDefinition != null && propertyDefinition.isSortable()) {
+            addPropertyValueToPropertiesMap(propertiesMap, propertyDefinition.getPropertyName() + SORT_PROPERTY_NAME_SUFFIX, propertyValue);
+        }
+    }
+
+    private boolean isStreamingPropertyValueIndexable(Graph graph, String propertyName, StreamingPropertyValue streamingPropertyValue) {
+        if (!streamingPropertyValue.isSearchIndex()) {
+            return false;
+        }
+
+        PropertyDefinition propertyDefinition = getPropertyDefinition(graph, propertyName);
+        if (propertyDefinition != null && !propertyDefinition.getTextIndexHints().contains(TextIndexHint.FULL_TEXT)) {
+            return false;
+        }
+
+        Class valueType = streamingPropertyValue.getValueType();
+        if (valueType == String.class) {
+            return true;
+        } else {
+            throw new VertexiumException("Unhandled StreamingPropertyValue type: " + valueType.getName());
+        }
+    }
+
+    private void addStreamingPropertyValuesToFieldMap(Graph graph, List<Property> properties, Map<String, Object> propertiesMap) {
+        List<StreamingPropertyValue> streamingPropertyValues = properties.stream()
+                .map((property) -> {
+                    if (!(property.getValue() instanceof StreamingPropertyValue)) {
+                        throw new VertexiumException("property with a value that is not a StreamingPropertyValue passed to addStreamingPropertyValuesToFieldMap");
+                    }
+                    return (StreamingPropertyValue) property.getValue();
+                })
+                .collect(Collectors.toList());
+
+        List<InputStream> inputStreams = graph.getStreamingPropertyValueInputStreams(streamingPropertyValues);
+        for (int i = 0; i < properties.size(); i++) {
+            try {
+                String propertyValue = IOUtils.toString(inputStreams.get(i));
+                addPropertyToFieldMap(graph, properties.get(i), new StreamingPropertyString(propertyValue), propertiesMap);
+            } catch (IOException ex) {
+                throw new VertexiumException("could not convert streaming property to string", ex);
+            }
+        }
+    }
+
+    public boolean isServerPluginInstalled() {
+        return serverPluginInstalled;
+    }
+
+    private static class StreamingPropertyString {
+        private final String propertyValue;
+
+        public StreamingPropertyString(String propertyValue) {
+            this.propertyValue = propertyValue;
+        }
+
+        public String getPropertyValue() {
+            return propertyValue;
+        }
+    }
+
+    protected String deflatePropertyName(Graph graph, Property property) {
+        String propertyName = property.getName();
+        Visibility propertyVisibility = property.getVisibility();
+        return deflatePropertyName(graph, propertyName, propertyVisibility);
+    }
+
+    protected String deflateExtendedDataColumnName(Graph graph, ExtendedDataMutation extendedDataMutation) {
+        String columnName = extendedDataMutation.getColumnName();
+        Visibility propertyVisibility = extendedDataMutation.getVisibility();
+        return deflatePropertyName(graph, columnName, propertyVisibility);
+    }
+
+    String deflatePropertyName(Graph graph, String propertyName, Visibility propertyVisibility) {
+        String visibilityHash = getVisibilityHash(graph, propertyName, propertyVisibility);
+        return this.nameSubstitutionStrategy.deflate(propertyName) + "_" + visibilityHash;
+    }
+
+    protected String inflatePropertyName(String string) {
+        Matcher m = PROPERTY_NAME_PATTERN.matcher(string);
+        if (m.matches()) {
+            string = m.group(1);
+        }
+        return nameSubstitutionStrategy.inflate(string);
+    }
+
+    private String inflatePropertyNameWithTypeSuffix(String string) {
+        Matcher m = PROPERTY_NAME_PATTERN.matcher(string);
+        if (m.matches()) {
+            if (m.groupCount() >= 5 && m.group(5) != null) {
+                string = m.group(1) + "_" + m.group(5);
+            } else {
+                string = m.group(1);
+            }
+        }
+        return nameSubstitutionStrategy.inflate(string);
+    }
+
+    public String getPropertyVisibilityHashFromDeflatedPropertyName(String deflatedPropertyName) {
+        Matcher m = PROPERTY_NAME_PATTERN.matcher(deflatedPropertyName);
+        if (m.matches()) {
+            return m.group(3);
+        }
+        throw new VertexiumException("Could not match property name: " + deflatedPropertyName);
+    }
+
+    public String getAggregationName(String name) {
+        Matcher m = AGGREGATION_NAME_PATTERN.matcher(name);
+        if (m.matches()) {
+            return m.group(1);
+        }
+        throw new VertexiumException("Could not get aggregation name from: " + name);
+    }
+
+    public String[] getAllMatchingPropertyNames(Graph graph, String propertyName, Authorizations authorizations) {
+        Collection<String> hashes = this.propertyNameVisibilitiesStore.getHashes(graph, propertyName, authorizations);
+        if (hashes.size() == 0) {
+            return new String[0];
+        }
+        String[] results = new String[hashes.size()];
+        String deflatedPropertyName = this.nameSubstitutionStrategy.deflate(propertyName);
+        int i = 0;
+        for (String hash : hashes) {
+            results[i++] = deflatedPropertyName + "_" + hash;
+        }
+        return results;
+    }
+
+    public Collection<String> getQueryableElementTypeVisibilityPropertyNames(Graph graph, Authorizations authorizations) {
+        Set<String> propertyNames = new HashSet<>();
+        for (String hash : propertyNameVisibilitiesStore.getHashes(graph, ELEMENT_TYPE_FIELD_NAME, authorizations)) {
+            propertyNames.add(ELEMENT_TYPE_FIELD_NAME + "_" + hash);
+        }
+        if (propertyNames.size() == 0) {
+            throw new VertexiumNoMatchingPropertiesException("No queryable " + ELEMENT_TYPE_FIELD_NAME + " for authorizations " + authorizations);
+        }
+        return propertyNames;
+    }
+
+    public Collection<String> getQueryablePropertyNames(Graph graph, Authorizations authorizations) {
+        Set<String> propertyNames = new HashSet<>();
+        for (PropertyDefinition propertyDefinition : graph.getPropertyDefinitions()) {
+            List<String> queryableTypeSuffixes = getQueryableTypeSuffixes(propertyDefinition);
+            if (queryableTypeSuffixes.size() == 0) {
+                continue;
+            }
+            String inflatedPropertyName = inflatePropertyName(propertyDefinition.getPropertyName()); // could be stored deflated
+            String deflatedPropertyName = nameSubstitutionStrategy.deflate(inflatedPropertyName);
+            if (isReservedFieldName(inflatedPropertyName)) {
+                continue;
+            }
+            for (String hash : propertyNameVisibilitiesStore.getHashes(graph, inflatedPropertyName, authorizations)) {
+                for (String typeSuffix : queryableTypeSuffixes) {
+                    propertyNames.add(deflatedPropertyName + "_" + hash + typeSuffix);
+                }
+            }
+        }
+        return propertyNames;
+    }
+
+    private static List<String> getQueryableTypeSuffixes(PropertyDefinition propertyDefinition) {
+        List<String> typeSuffixes = new ArrayList<>();
+        if (propertyDefinition.getDataType() == String.class) {
+            if (propertyDefinition.getTextIndexHints().contains(TextIndexHint.EXACT_MATCH)) {
+                typeSuffixes.add(EXACT_MATCH_PROPERTY_NAME_SUFFIX);
+            }
+            if (propertyDefinition.getTextIndexHints().contains(TextIndexHint.FULL_TEXT)) {
+                typeSuffixes.add("");
+            }
+        } else if (propertyDefinition.getDataType() == GeoPoint.class
+                || propertyDefinition.getDataType() == GeoCircle.class) {
+            typeSuffixes.add("");
+        }
+        return typeSuffixes;
+    }
+
+    protected static boolean isReservedFieldName(String fieldName) {
+        return fieldName.startsWith("__");
+    }
+
+    private String getVisibilityHash(Graph graph, String propertyName, Visibility visibility) {
+        return this.propertyNameVisibilitiesStore.getHash(graph, propertyName, visibility);
+    }
+
+    @Override
+    public void deleteElement(Graph graph, Element element, Authorizations authorizations) {
+        deleteExtendedDataForElement(element);
+
+        String indexName = getIndexName(element);
+        String id = element.getId();
+        if (MUTATION_LOGGER.isTraceEnabled()) {
+            LOGGER.trace("deleting document %s", id);
+        }
+        getClient().delete(
+                getClient()
+                        .prepareDelete(indexName, ELEMENT_TYPE, id)
+                        .request()
+        ).actionGet();
+    }
+
+    private void deleteExtendedDataForElement(Element element) {
+        try {
+            QueryBuilder filter = QueryBuilders.termQuery(EXTENDED_DATA_ELEMENT_ID_FIELD_NAME, element.getId());
+
+            SearchRequestBuilder s = getClient().prepareSearch(getIndicesToQuery())
+                    .setTypes(ELEMENT_TYPE)
+                    .setQuery(QueryBuilders.filteredQuery(QueryBuilders.matchAllQuery(), filter))
+                    .addField(EXTENDED_DATA_ELEMENT_ID_FIELD_NAME)
+                    .addField(EXTENDED_DATA_TABLE_NAME_FIELD_NAME)
+                    .addField(EXTENDED_DATA_TABLE_ROW_ID_FIELD_NAME);
+            for (SearchHit hit : s.execute().get().getHits()) {
+                if (MUTATION_LOGGER.isTraceEnabled()) {
+                    LOGGER.trace("deleting extended data document %s", hit.getId());
+                }
+                getClient().prepareDelete(hit.getIndex(), ELEMENT_TYPE, hit.getId()).execute().actionGet();
+            }
+        } catch (Exception ex) {
+            throw new VertexiumException("Could not delete extended data for element: " + element.getId());
+        }
+    }
+
+    @Override
+    public SearchIndexSecurityGranularity getSearchIndexSecurityGranularity() {
+        return SearchIndexSecurityGranularity.PROPERTY;
+    }
+
+    @Override
+    public GraphQuery queryGraph(Graph graph, String queryString, Authorizations authorizations) {
+        return new ElasticsearchSearchGraphQuery(
+                getClient(),
+                graph,
+                queryString,
+                getConfig().getScoringStrategy(),
+                getIndexSelectionStrategy(),
+                getConfig().getQueryPageSize(),
+                authorizations
+        );
+    }
+
+    @Override
+    public VertexQuery queryVertex(Graph graph, Vertex vertex, String queryString, Authorizations authorizations) {
+        return new ElasticsearchSearchVertexQuery(
+                getClient(),
+                graph,
+                vertex,
+                queryString,
+                getConfig().getScoringStrategy(),
+                getIndexSelectionStrategy(),
+                getConfig().getQueryPageSize(),
+                authorizations
+        );
+    }
+
+    @Override
+    public SimilarToGraphQuery querySimilarTo(Graph graph, String[] similarToFields, String similarToText, Authorizations authorizations) {
+        return new ElasticsearchSearchGraphQuery(
+                getClient(),
+                graph,
+                similarToFields,
+                similarToText,
+                getConfig().getScoringStrategy(),
+                getIndexSelectionStrategy(),
+                getConfig().getQueryPageSize(),
+                authorizations
+        );
+    }
+
+    @Override
+    public boolean isFieldLevelSecuritySupported() {
+        return true;
+    }
+
+    protected boolean addPropertyDefinitionToIndex(Graph graph, IndexInfo indexInfo, String propertyName, Visibility propertyVisibility, PropertyDefinition propertyDefinition) throws IOException {
+        if (propertyDefinition.getDataType() == String.class) {
+            if (propertyDefinition.getTextIndexHints().contains(TextIndexHint.EXACT_MATCH)) {
+                addPropertyToIndex(graph, indexInfo, propertyName + EXACT_MATCH_PROPERTY_NAME_SUFFIX, propertyVisibility, String.class, false, propertyDefinition.getBoost());
+            }
+            if (propertyDefinition.getTextIndexHints().contains(TextIndexHint.FULL_TEXT)) {
+                addPropertyToIndex(graph, indexInfo, propertyName, propertyVisibility, String.class, true, propertyDefinition.getBoost());
+            }
+            if (propertyDefinition.isSortable()) {
+                String sortPropertyName = inflatePropertyName(propertyName) + SORT_PROPERTY_NAME_SUFFIX;
+                addPropertyToIndex(graph, indexInfo, sortPropertyName, null, String.class, false, null);
+            }
+            return true;
+        }
+
+        if (propertyDefinition.getDataType() == GeoPoint.class
+                || propertyDefinition.getDataType() == GeoCircle.class) {
+            addPropertyToIndex(graph, indexInfo, propertyName + GEO_PROPERTY_NAME_SUFFIX, propertyVisibility, propertyDefinition.getDataType(), true, propertyDefinition.getBoost());
+            addPropertyToIndex(graph, indexInfo, propertyName, propertyVisibility, String.class, true, propertyDefinition.getBoost());
+            return true;
+        }
+
+        addPropertyToIndex(graph, indexInfo, propertyName, propertyVisibility, propertyDefinition.getDataType(), true, propertyDefinition.getBoost());
+        return true;
+    }
+
+    protected PropertyDefinition getPropertyDefinition(Graph graph, String propertyName) {
+        propertyName = inflatePropertyNameWithTypeSuffix(propertyName);
+        return graph.getPropertyDefinition(propertyName);
+    }
+
+    public void addPropertyToIndex(Graph graph, IndexInfo indexInfo, Property property) throws IOException {
+        // unlike the super class we need to lookup property definitions based on the property name without
+        // the hash and define the property that way.
+        Object propertyValue = property.getValue();
+
+        PropertyDefinition propertyDefinition = getPropertyDefinition(graph, property.getName());
+        if (propertyDefinition != null) {
+            String deflatedPropertyName = deflatePropertyName(graph, property);
+            addPropertyDefinitionToIndex(graph, indexInfo, deflatedPropertyName, property.getVisibility(), propertyDefinition);
+        } else {
+            addPropertyToIndexInner(graph, indexInfo, property);
+        }
+
+        propertyDefinition = getPropertyDefinition(graph, property.getName() + EXACT_MATCH_PROPERTY_NAME_SUFFIX);
+        if (propertyDefinition != null) {
+            String deflatedPropertyName = deflatePropertyName(graph, property);
+            addPropertyDefinitionToIndex(graph, indexInfo, deflatedPropertyName, property.getVisibility(), propertyDefinition);
+        }
+
+        if (propertyValue instanceof GeoShape) {
+            propertyDefinition = getPropertyDefinition(graph, property.getName() + GEO_PROPERTY_NAME_SUFFIX);
+            if (propertyDefinition != null) {
+                String deflatedPropertyName = deflatePropertyName(graph, property);
+                addPropertyDefinitionToIndex(graph, indexInfo, deflatedPropertyName, property.getVisibility(), propertyDefinition);
+            }
+        }
+    }
+
+    private void addExtendedDataToIndex(Graph graph, IndexInfo indexInfo, ExtendedDataMutation column) throws IOException {
+        // unlike the super class we need to lookup column definitions based on the column name without
+        // the hash and define the column that way.
+        Object columnValue = column.getValue();
+
+        PropertyDefinition propertyDefinition = getPropertyDefinition(graph, column.getColumnName());
+        if (propertyDefinition != null) {
+            String deflatedColumnName = deflateExtendedDataColumnName(graph, column);
+            addPropertyDefinitionToIndex(graph, indexInfo, deflatedColumnName, column.getVisibility(), propertyDefinition);
+        } else {
+            addPropertyToIndexInner(graph, indexInfo, column);
+        }
+
+        propertyDefinition = getPropertyDefinition(graph, column.getColumnName() + EXACT_MATCH_PROPERTY_NAME_SUFFIX);
+        if (propertyDefinition != null) {
+            String deflatedColumnName = deflateExtendedDataColumnName(graph, column);
+            addPropertyDefinitionToIndex(graph, indexInfo, deflatedColumnName, column.getVisibility(), propertyDefinition);
+        }
+
+        if (columnValue instanceof GeoShape) {
+            propertyDefinition = getPropertyDefinition(graph, column.getColumnName() + GEO_PROPERTY_NAME_SUFFIX);
+            if (propertyDefinition != null) {
+                String deflatedPropertyName = deflateExtendedDataColumnName(graph, column);
+                addPropertyDefinitionToIndex(graph, indexInfo, deflatedPropertyName, column.getVisibility(), propertyDefinition);
+            }
+        }
+    }
+
+    public void addPropertyToIndexInner(Graph graph, IndexInfo indexInfo, Property property) throws IOException {
+        String deflatedPropertyName = deflatePropertyName(graph, property);
+        Object propertyValue = property.getValue();
+        Visibility propertyVisibility = property.getVisibility();
+        addPropertyToIndexInner(graph, indexInfo, deflatedPropertyName, propertyValue, propertyVisibility);
+    }
+
+    public void addPropertyToIndexInner(Graph graph, IndexInfo indexInfo, ExtendedDataMutation extendedDataMutation) throws IOException {
+        String deflatedPropertyName = deflateExtendedDataColumnName(graph, extendedDataMutation);
+        Object propertyValue = extendedDataMutation.getValue();
+        Visibility propertyVisibility = extendedDataMutation.getVisibility();
+        addPropertyToIndexInner(graph, indexInfo, deflatedPropertyName, propertyValue, propertyVisibility);
+    }
+
+    private void addPropertyToIndexInner(Graph graph, IndexInfo indexInfo, String deflatedPropertyName, Object propertyValue, Visibility propertyVisibility) throws IOException {
+        if (indexInfo.isPropertyDefined(deflatedPropertyName, propertyVisibility)) {
+            return;
+        }
+
+        Class dataType;
+        if (propertyValue instanceof StreamingPropertyValue) {
+            StreamingPropertyValue streamingPropertyValue = (StreamingPropertyValue) propertyValue;
+            if (!streamingPropertyValue.isSearchIndex()) {
+                return;
+            }
+            dataType = streamingPropertyValue.getValueType();
+            addPropertyToIndex(graph, indexInfo, deflatedPropertyName, propertyVisibility, dataType, true);
+        } else if (propertyValue instanceof String) {
+            dataType = String.class;
+            addPropertyToIndex(graph, indexInfo, deflatedPropertyName + EXACT_MATCH_PROPERTY_NAME_SUFFIX, propertyVisibility, dataType, false);
+            addPropertyToIndex(graph, indexInfo, deflatedPropertyName, propertyVisibility, dataType, true);
+        } else if (propertyValue instanceof GeoPoint) {
+            addPropertyToIndex(graph, indexInfo, deflatedPropertyName + GEO_PROPERTY_NAME_SUFFIX, propertyVisibility, GeoPoint.class, true);
+            addPropertyToIndex(graph, indexInfo, deflatedPropertyName, propertyVisibility, String.class, true);
+        } else if (propertyValue instanceof GeoCircle) {
+            addPropertyToIndex(graph, indexInfo, deflatedPropertyName + GEO_PROPERTY_NAME_SUFFIX, propertyVisibility, GeoCircle.class, true);
+            addPropertyToIndex(graph, indexInfo, deflatedPropertyName, propertyVisibility, String.class, true);
+        } else {
+            checkNotNull(propertyValue, "property value cannot be null for property: " + deflatedPropertyName);
+            dataType = propertyValue.getClass();
+            addPropertyToIndex(graph, indexInfo, deflatedPropertyName, propertyVisibility, dataType, true);
+        }
+    }
+
+    protected void addPropertyToIndex(
+            Graph graph,
+            IndexInfo indexInfo,
+            String propertyName,
+            Visibility propertyVisibility,
+            Class dataType,
+            boolean analyzed,
+            Double boost
+    ) throws IOException {
+        if (indexInfo.isPropertyDefined(propertyName, propertyVisibility)) {
+            return;
+        }
+
+        if (shouldIgnoreType(dataType)) {
+            return;
+        }
+
+        XContentBuilder mapping = XContentFactory.jsonBuilder()
+                .startObject()
+                .startObject(ELEMENT_TYPE)
+                .startObject("properties")
+                .startObject(propertyName);
+
+        addTypeToMapping(mapping, propertyName, dataType, analyzed, boost);
+
+        mapping
+                .endObject()
+                .endObject()
+                .endObject()
+                .endObject();
+        if (LOGGER.isTraceEnabled()) {
+            LOGGER.trace("addPropertyToIndex: %s: %s", dataType.getName(), mapping.string());
+        }
+
+        getClient()
+                .admin()
+                .indices()
+                .preparePutMapping(indexInfo.getIndexName())
+                .setType(ELEMENT_TYPE)
+                .setSource(mapping)
+                .execute()
+                .actionGet();
+
+        addPropertyNameVisibility(graph, indexInfo, propertyName, propertyVisibility);
+        updateMetadata(graph, indexInfo);
+    }
+
+    private void updateMetadata(Graph graph, IndexInfo indexInfo) {
+        try {
+            XContentBuilder mapping = XContentFactory.jsonBuilder()
+                    .startObject()
+                    .startObject(ELEMENT_TYPE);
+            GetMappingsResponse existingMapping = getClient()
+                    .admin()
+                    .indices()
+                    .prepareGetMappings(indexInfo.getIndexName())
+                    .execute()
+                    .actionGet();
+
+            Map<String, Object> existingElementData = existingMapping.mappings()
+                    .get(indexInfo.getIndexName())
+                    .get(ELEMENT_TYPE)
+                    .getSourceAsMap();
+
+            mapping = mapping.startObject("_meta")
+                    .startObject("vertexium");
+            //noinspection unchecked
+            Map<String, Object> properties = (Map<String, Object>) existingElementData.get("properties");
+            for (String propertyName : properties.keySet()) {
+                ElasticsearchPropertyNameInfo p = ElasticsearchPropertyNameInfo.parse(graph, propertyNameVisibilitiesStore, propertyName);
+                if (p == null || p.getPropertyVisibility() == null) {
+                    continue;
+                }
+                mapping.field(propertyName, p.getPropertyVisibility());
+            }
+            mapping.endObject()
+                    .endObject()
+                    .endObject()
+                    .endObject();
+            getClient()
+                    .admin()
+                    .indices()
+                    .preparePutMapping(indexInfo.getIndexName())
+                    .setType(ELEMENT_TYPE)
+                    .setSource(mapping)
+                    .execute()
+                    .actionGet();
+        } catch (IOException ex) {
+            throw new VertexiumException("Could not update mapping", ex);
+        }
+    }
+
+    protected void addPropertyNameVisibility(Graph graph, IndexInfo indexInfo, String propertyName, Visibility propertyVisibility) {
+        String inflatedPropertyName = inflatePropertyName(propertyName);
+        if (propertyVisibility != null) {
+            this.propertyNameVisibilitiesStore.getHash(graph, inflatedPropertyName, propertyVisibility);
+        }
+        indexInfo.addPropertyNameVisibility(inflatedPropertyName, propertyVisibility);
+        indexInfo.addPropertyNameVisibility(propertyName, propertyVisibility);
+    }
+
+    public void addElementToBulkRequest(Graph graph, BulkRequest bulkRequest, IndexInfo indexInfo, Element element, Authorizations authorizations) {
+        try {
+            XContentBuilder json = buildJsonContentFromElement(graph, element, authorizations);
+            UpdateRequest indexRequest = new UpdateRequest(indexInfo.getIndexName(), ELEMENT_TYPE, element.getId()).doc(json);
+            indexRequest.retryOnConflict(MAX_RETRIES);
+            indexRequest.docAsUpsert(true);
+            bulkRequest.add(indexRequest);
+        } catch (IOException ex) {
+            throw new VertexiumException("Could not add element to bulk request", ex);
+        }
+    }
+
+    @Override
+    public Map<Object, Long> getVertexPropertyCountByValue(Graph graph, String propertyName, Authorizations authorizations) {
+        TermQueryBuilder elementTypeFilterBuilder = new TermQueryBuilder(ELEMENT_TYPE_FIELD_NAME, ElasticsearchDocumentType.VERTEX.getKey());
+        FilteredQueryBuilder queryBuilder = QueryBuilders.filteredQuery(
+                QueryBuilders.matchAllQuery(),
+                elementTypeFilterBuilder
+        );
+        SearchRequestBuilder q = getClient().prepareSearch(getIndexNamesAsArray(graph))
+                .setQuery(queryBuilder)
+                .setSearchType(SearchType.COUNT);
+
+        for (String p : getAllMatchingPropertyNames(graph, propertyName, authorizations)) {
+            String countAggName = "count-" + p;
+            PropertyDefinition propertyDefinition = getPropertyDefinition(graph, p);
+            if (propertyDefinition != null && propertyDefinition.getTextIndexHints().contains(TextIndexHint.EXACT_MATCH)) {
+                p = p + EXACT_MATCH_PROPERTY_NAME_SUFFIX;
+            }
+
+            TermsBuilder countAgg = new TermsBuilder(countAggName)
+                    .field(p)
+                    .size(500000);
+            q = q.addAggregation(countAgg);
+        }
+
+        if (ElasticsearchSearchQueryBase.QUERY_LOGGER.isTraceEnabled()) {
+            ElasticsearchSearchQueryBase.QUERY_LOGGER.trace("query: %s", q);
+        }
+        SearchResponse response = getClient().search(q.request()).actionGet();
+        Map<Object, Long> results = new HashMap<>();
+        for (Aggregation agg : response.getAggregations().asList()) {
+            Terms propertyCountResults = (Terms) agg;
+            for (Terms.Bucket propertyCountResult : propertyCountResults.getBuckets()) {
+                String mapKey = ((String) propertyCountResult.getKey()).toLowerCase();
+                Long previousValue = results.get(mapKey);
+                if (previousValue == null) {
+                    previousValue = 0L;
+                }
+                results.put(mapKey, previousValue + propertyCountResult.getDocCount());
+            }
+        }
+        return results;
+    }
+
+    protected IndexInfo ensureIndexCreatedAndInitialized(Graph graph, String indexName) {
+        Map<String, IndexInfo> indexInfos = getIndexInfos(graph);
+        IndexInfo indexInfo = indexInfos.get(indexName);
+        if (indexInfo != null && indexInfo.isElementTypeDefined()) {
+            return indexInfo;
+        }
+
+        synchronized (this) {
+            if (indexInfo == null) {
+                if (!client.admin().indices().prepareExists(indexName).execute().actionGet().isExists()) {
+                    try {
+                        createIndex(indexName);
+                    } catch (IOException e) {
+                        throw new VertexiumException("Could not create index: " + indexName, e);
+                    }
+                }
+
+                indexInfo = createIndexInfo(indexName);
+                indexInfos.put(indexName, indexInfo);
+            }
+
+            ensureMappingsCreated(indexInfo);
+
+            return indexInfo;
+        }
+    }
+
+
+    protected IndexInfo createIndexInfo(String indexName) {
+        return new IndexInfo(indexName);
+    }
+
+    protected void ensureMappingsCreated(IndexInfo indexInfo) {
+        if (!indexInfo.isElementTypeDefined()) {
+            try {
+                XContentBuilder mappingBuilder = XContentFactory.jsonBuilder()
+                        .startObject()
+                        .startObject("_source").field("enabled", true).endObject()
+                        .startObject("_all").field("enabled", isAllFieldEnabled()).endObject()
+                        .startObject("properties");
+                createIndexAddFieldsToElementType(mappingBuilder);
+                XContentBuilder mapping = mappingBuilder.endObject()
+                        .endObject();
+
+                client.admin().indices().preparePutMapping(indexInfo.getIndexName())
+                        .setType(ELEMENT_TYPE)
+                        .setSource(mapping)
+                        .execute()
+                        .actionGet();
+                indexInfo.setElementTypeDefined(true);
+            } catch (Throwable e) {
+                throw new VertexiumException("Could not add mappings to index: " + indexInfo.getIndexName(), e);
+            }
+        }
+    }
+
+    protected void createIndexAddFieldsToElementType(XContentBuilder builder) throws IOException {
+        builder
+                .startObject(ELEMENT_TYPE_FIELD_NAME).field("type", "string").field("store", "true").endObject()
+                .startObject(EXTENDED_DATA_ELEMENT_ID_FIELD_NAME).field("type", "string").field("index", "not_analyzed").field("store", "true").endObject()
+                .startObject(EXTENDED_DATA_TABLE_ROW_ID_FIELD_NAME).field("type", "string").field("index", "not_analyzed").field("store", "true").endObject()
+                .startObject(EXTENDED_DATA_TABLE_NAME_FIELD_NAME).field("type", "string").field("index", "not_analyzed").field("store", "true").endObject()
+                .startObject(VISIBILITY_FIELD_NAME).field("type", "string").field("analyzer", "keyword").field("index", "not_analyzed").field("store", "true").endObject()
+                .startObject(IN_VERTEX_ID_FIELD_NAME).field("type", "string").field("analyzer", "keyword").field("index", "not_analyzed").field("store", "true").endObject()
+                .startObject(OUT_VERTEX_ID_FIELD_NAME).field("type", "string").field("analyzer", "keyword").field("index", "not_analyzed").field("store", "true").endObject()
+                .startObject(EDGE_LABEL_FIELD_NAME).field("type", "string").field("analyzer", "keyword").field("index", "not_analyzed").field("store", "true").endObject()
+        ;
+        getConfig().getScoringStrategy().addFieldsToElementType(builder);
+    }
+
+    @Override
+    public void deleteProperty(Graph graph, Element element, PropertyDescriptor property, Authorizations authorizations) {
+        String fieldName = deflatePropertyName(graph, property.getName(), property.getVisibility());
+        removeFieldsFromDocument(element, fieldName);
+        removeFieldsFromDocument(element, fieldName + "_e");
+    }
+
+    @Override
+    public void deleteProperties(Graph graph, Element element, Collection<PropertyDescriptor> propertyList, Authorizations authorizations) {
+        List<String> fields = new ArrayList<>();
+        for (PropertyDescriptor p : propertyList) {
+            String fieldName = deflatePropertyName(graph, p.getName(), p.getVisibility());
+            fields.add(fieldName);
+            fields.add(fieldName + "_e");
+        }
+        removeFieldsFromDocument(element, fields);
+    }
+
+    @Override
+    public void addElements(Graph graph, Iterable<? extends Element> elements, Authorizations authorizations) {
+        int totalCount = 0;
+        Map<IndexInfo, BulkRequest> bulkRequests = new HashMap<>();
+        for (Element element : elements) {
+            IndexInfo indexInfo = addPropertiesToIndex(graph, element, element.getProperties());
+            BulkRequest bulkRequest = bulkRequests.get(indexInfo);
+            if (bulkRequest == null) {
+                bulkRequest = new BulkRequest();
+                bulkRequests.put(indexInfo, bulkRequest);
+            }
+
+            if (bulkRequest.numberOfActions() >= MAX_BATCH_COUNT || bulkRequest.estimatedSizeInBytes() > MAX_BATCH_SIZE) {
+                LOGGER.debug("adding elements... %d (est size %d)", bulkRequest.numberOfActions(), bulkRequest.estimatedSizeInBytes());
+                totalCount += bulkRequest.numberOfActions();
+                doBulkRequest(bulkRequest);
+                bulkRequest = new BulkRequest();
+                bulkRequests.put(indexInfo, bulkRequest);
+            }
+            addElementToBulkRequest(graph, bulkRequest, indexInfo, element, authorizations);
+
+            getConfig().getScoringStrategy().addElement(this, graph, bulkRequest, indexInfo, element, authorizations);
+        }
+        for (BulkRequest bulkRequest : bulkRequests.values()) {
+            if (bulkRequest.numberOfActions() > 0) {
+                LOGGER.debug("adding elements... %d (est size %d)", bulkRequest.numberOfActions(), bulkRequest.estimatedSizeInBytes());
+                totalCount += bulkRequest.numberOfActions();
+                doBulkRequest(bulkRequest);
+            }
+        }
+        LOGGER.debug("added %d elements", totalCount);
+
+        if (getConfig().isAutoFlush()) {
+            flush(graph);
+        }
+    }
+
+    @Override
+    public MultiVertexQuery queryGraph(Graph graph, String[] vertexIds, String queryString, Authorizations authorizations) {
+        return new DefaultMultiVertexQuery(graph, vertexIds, queryString, authorizations);
+    }
+
+    @Override
+    public boolean isQuerySimilarToTextSupported() {
+        return true;
+    }
+
+    @Override
+    public void flush(Graph graph) {
+        flushFlushObjectQueue();
+        client.admin().indices().prepareRefresh(getIndexNamesAsArray(graph)).execute().actionGet();
+    }
+
+    /**
+     * Helper method to remove fields from source. This method will generate a ES update request. Retries on conflict.
+     *
+     * @param element Element that can be mapped to an ES document
+     * @param fields  fields to remove
+     */
+    private void removeFieldsFromDocument(Element element, Collection<String> fields) {
+        String script = "";
+        Map<String, Object> params = Maps.newHashMap();
+
+        int i = 0;
+        for (String field : fields) {
+            String fieldName = "fieldName" + (i++);
+            script += "ctx._source.remove(" + fieldName + ");";
+            params.put(fieldName, field);
+        }
+        getClient().prepareUpdate()
+                .setIndex(getIndexName(element))
+                .setId(element.getId())
+                .setType(ELEMENT_TYPE)
+                .setScript(
+                        new Script(
+                                script,
+                                ScriptService.ScriptType.INLINE,
+                                null,
+                                params
+                        )
+                )
+                .setRetryOnConflict(MAX_RETRIES)
+                .get();
+    }
+
+    private void removeFieldsFromDocument(Element element, String field) {
+        removeFieldsFromDocument(element, Lists.newArrayList(field));
+    }
+
+    private void flushFlushObjectQueue() {
+        Queue<FlushObject> queue = getFlushObjectQueue();
+        while (queue.size() > 0) {
+            FlushObject flushObject = queue.remove();
+            try {
+                long t = flushObject.retryTime - System.currentTimeMillis();
+                if (t > 0) {
+                    Thread.sleep(t);
+                }
+                flushObject.future.get(30, TimeUnit.SECONDS);
+            } catch (Exception ex) {
+                String message = String.format("Could not write element \"%s\"", flushObject.elementId);
+                if (flushObject.retryCount >= MAX_RETRIES) {
+                    throw new VertexiumException(message, ex);
+                }
+                String logMessage = String.format("%s: %s (retrying: %d/%d)", message, ex.getMessage(), flushObject.retryCount + 1, MAX_RETRIES);
+                if (flushObject.retryCount > 0) { // don't log warn the first time
+                    LOGGER.warn("%s", logMessage);
+                } else {
+                    LOGGER.debug("%s", logMessage);
+                }
+                ListenableActionFuture future = flushObject.actionRequestBuilder.execute();
+                queue.add(new FlushObject(
+                        flushObject.elementId,
+                        flushObject.actionRequestBuilder,
+                        future,
+                        flushObject.retryCount + 1,
+                        System.currentTimeMillis() + (flushObject.retryCount * 100) + random.nextInt(500)
+                ));
+            }
+        }
+        queue.clear();
+    }
+
+    protected String[] getIndexNamesAsArray(Graph graph) {
+        Map<String, IndexInfo> indexInfos = getIndexInfos(graph);
+        if (indexInfos.size() == indexInfosLastSize) {
+            return indexNamesAsArray;
+        }
+        synchronized (this) {
+            Set<String> keys = indexInfos.keySet();
+            indexNamesAsArray = keys.toArray(new String[keys.size()]);
+            indexInfosLastSize = indexInfos.size();
+            return indexNamesAsArray;
+        }
+    }
+
+    @Override
+    public void shutdown() {
+        client.close();
+
+        if (inProcessNode != null) {
+            inProcessNode.close();
+            inProcessNode = null;
+        }
+
+        if (propertyNameVisibilitiesStore instanceof Closeable) {
+            try {
+                ((Closeable) propertyNameVisibilitiesStore).close();
+            } catch (IOException e) {
+                Throwables.propagate(e);
+            }
+        }
+    }
+
+    @SuppressWarnings("unused")
+    protected String[] getIndexNames(PropertyDefinition propertyDefinition) {
+        return indexSelectionStrategy.getIndexNames(this, propertyDefinition);
+    }
+
+    protected String getIndexName(Element element) {
+        return indexSelectionStrategy.getIndexName(this, element);
+    }
+
+    protected String getExtendedDataIndexName(Element element, String tableName, String rowId) {
+        return indexSelectionStrategy.getExtendedDataIndexName(this, element, tableName, rowId);
+    }
+
+    protected String getExtendedDataIndexName(ExtendedDataRowId rowId) {
+        return indexSelectionStrategy.getExtendedDataIndexName(this, rowId);
+    }
+
+    protected String[] getIndicesToQuery() {
+        return indexSelectionStrategy.getIndicesToQuery(this);
+    }
+
+    @Override
+    public boolean isFieldBoostSupported() {
+        return true;
+    }
+
+    private IndexInfo addExtendedDataColumnsToIndex(Graph graph, Element element, String tableName, String rowId, List<ExtendedDataMutation> columns) {
+        try {
+            String indexName = getExtendedDataIndexName(element, tableName, rowId);
+            IndexInfo indexInfo = ensureIndexCreatedAndInitialized(graph, indexName);
+            for (ExtendedDataMutation column : columns) {
+                addExtendedDataToIndex(graph, indexInfo, column);
+            }
+            return indexInfo;
+        } catch (IOException e) {
+            throw new VertexiumException("Could not add properties to index", e);
+        }
+    }
+
+    public IndexInfo addPropertiesToIndex(Graph graph, Element element, Iterable<Property> properties) {
+        try {
+            String indexName = getIndexName(element);
+            IndexInfo indexInfo = ensureIndexCreatedAndInitialized(graph, indexName);
+            for (Property property : properties) {
+                addPropertyToIndex(graph, indexInfo, property);
+            }
+            return indexInfo;
+        } catch (IOException e) {
+            throw new VertexiumException("Could not add properties to index", e);
+        }
+    }
+
+    protected void addPropertyToIndex(Graph graph, IndexInfo indexInfo, String propertyName, Visibility propertyVisibility, Class dataType, boolean analyzed) throws IOException {
+        addPropertyToIndex(graph, indexInfo, propertyName, propertyVisibility, dataType, analyzed, null);
+    }
+
+    protected String deflatePropertyName(String propertyName) {
+        return nameSubstitutionStrategy.deflate(propertyName);
+    }
+
+    protected boolean shouldIgnoreType(Class dataType) {
+        return dataType == byte[].class;
+    }
+
+    protected void addTypeToMapping(XContentBuilder mapping, String propertyName, Class dataType, boolean analyzed, Double boost) throws IOException {
+        if (dataType == String.class) {
+            LOGGER.debug("Registering 'string' type for %s", propertyName);
+            mapping.field("type", "string");
+            if (!analyzed) {
+                mapping.field("index", "not_analyzed");
+                mapping.field("ignore_above", EXACT_MATCH_IGNORE_ABOVE_LIMIT);
+            }
+        } else if (dataType == IpV4Address.class) {
+            LOGGER.debug("Registering 'ip' type for %s", propertyName);
+            mapping.field("type", "ip");
+        } else if (dataType == Float.class || dataType == Float.TYPE) {
+            LOGGER.debug("Registering 'float' type for %s", propertyName);
+            mapping.field("type", "float");
+        } else if (dataType == Double.class || dataType == Double.TYPE) {
+            LOGGER.debug("Registering 'double' type for %s", propertyName);
+            mapping.field("type", "double");
+        } else if (dataType == Byte.class || dataType == Byte.TYPE) {
+            LOGGER.debug("Registering 'byte' type for %s", propertyName);
+            mapping.field("type", "byte");
+        } else if (dataType == Short.class || dataType == Short.TYPE) {
+            LOGGER.debug("Registering 'short' type for %s", propertyName);
+            mapping.field("type", "short");
+        } else if (dataType == Integer.class || dataType == Integer.TYPE) {
+            LOGGER.debug("Registering 'integer' type for %s", propertyName);
+            mapping.field("type", "integer");
+        } else if (dataType == Long.class || dataType == Long.TYPE) {
+            LOGGER.debug("Registering 'long' type for %s", propertyName);
+            mapping.field("type", "long");
+        } else if (dataType == Date.class || dataType == DateOnly.class) {
+            LOGGER.debug("Registering 'date' type for %s", propertyName);
+            mapping.field("type", "date");
+        } else if (dataType == Boolean.class || dataType == Boolean.TYPE) {
+            LOGGER.debug("Registering 'boolean' type for %s", propertyName);
+            mapping.field("type", "boolean");
+        } else if (dataType == GeoPoint.class) {
+            LOGGER.debug("Registering 'geo_point' type for %s", propertyName);
+            mapping.field("type", "geo_point");
+        } else if (dataType == GeoCircle.class) {
+            LOGGER.debug("Registering 'geo_shape' type for %s", propertyName);
+            mapping.field("type", "geo_shape");
+            mapping.field("tree", "quadtree");
+            mapping.field("precision", "100m");
+        } else if (Number.class.isAssignableFrom(dataType)) {
+            LOGGER.debug("Registering 'double' type for %s", propertyName);
+            mapping.field("type", "double");
+        } else {
+            throw new VertexiumException("Unexpected value type for property \"" + propertyName + "\": " + dataType.getName());
+        }
+
+        if (boost != null) {
+            mapping.field("boost", boost.doubleValue());
+        }
+    }
+
+    protected void doBulkRequest(BulkRequest bulkRequest) {
+        BulkResponse response = getClient().bulk(bulkRequest).actionGet();
+        if (response.hasFailures()) {
+            for (BulkItemResponse bulkResponse : response) {
+                if (bulkResponse.isFailed()) {
+                    LOGGER.error("Failed to index %s (message: %s)", bulkResponse.getId(), bulkResponse.getFailureMessage());
+                }
+            }
+            throw new VertexiumException("Could not add element.");
+        }
+    }
+
+    @Override
+    public synchronized void truncate(Graph graph) {
+        LOGGER.warn("Truncate of Elasticsearch is not possible, dropping the indices and recreating instead.");
+        drop(graph);
+    }
+
+    @Override
+    public void drop(Graph graph) {
+        Set<String> indexInfosSet = getIndexInfos(graph).keySet();
+        for (String indexName : indexInfosSet) {
+            try {
+                DeleteIndexRequest deleteRequest = new DeleteIndexRequest(indexName);
+                getClient().admin().indices().delete(deleteRequest).actionGet();
+                getIndexInfos(graph).remove(indexName);
+            } catch (Exception ex) {
+                throw new VertexiumException("Could not delete index " + indexName, ex);
+            }
+            ensureIndexCreatedAndInitialized(graph, indexName);
+        }
+    }
+
+    @SuppressWarnings("unchecked")
+    protected void addPropertyValueToPropertiesMap(Map<String, Object> propertiesMap, String propertyName, Object propertyValue) {
+        Object existingValue = propertiesMap.get(propertyName);
+        if (existingValue == null) {
+            propertiesMap.put(propertyName, propertyValue);
+            return;
+        }
+
+        if (existingValue instanceof List) {
+            ((List) existingValue).add(propertyValue);
+            return;
+        }
+
+        List list = new ArrayList();
+        list.add(existingValue);
+        list.add(propertyValue);
+        propertiesMap.put(propertyName, list);
+    }
+
+    protected void convertGeoPoint(Graph graph, XContentBuilder jsonBuilder, Property property, GeoPoint geoPoint) throws IOException {
+        Map<String, Object> propertyValueMap = new HashMap<>();
+        propertyValueMap.put("lat", geoPoint.getLatitude());
+        propertyValueMap.put("lon", geoPoint.getLongitude());
+        jsonBuilder.field(deflatePropertyName(graph, property) + GEO_PROPERTY_NAME_SUFFIX, propertyValueMap);
+        if (geoPoint.getDescription() != null) {
+            jsonBuilder.field(deflatePropertyName(graph, property), geoPoint.getDescription());
+        }
+    }
+
+    protected void convertGeoPoint(Graph graph, Map<String, Object> propertiesMap, String deflatedPropertyName, GeoPoint geoPoint) {
+        Map<String, Object> propertyValueMap = new HashMap<>();
+        propertyValueMap.put("lat", geoPoint.getLatitude());
+        propertyValueMap.put("lon", geoPoint.getLongitude());
+        addPropertyValueToPropertiesMap(propertiesMap, deflatedPropertyName + GEO_PROPERTY_NAME_SUFFIX, propertyValueMap);
+        if (geoPoint.getDescription() != null) {
+            addPropertyValueToPropertiesMap(propertiesMap, deflatedPropertyName, geoPoint.getDescription());
+        }
+    }
+
+    protected void convertGeoCircle(Graph graph, XContentBuilder jsonBuilder, Property property, GeoCircle geoCircle) throws IOException {
+        Map<String, Object> propertyValueMap = new HashMap<>();
+        propertyValueMap.put("type", "circle");
+        List<Double> coordinates = new ArrayList<>();
+        coordinates.add(geoCircle.getLongitude());
+        coordinates.add(geoCircle.getLatitude());
+        propertyValueMap.put("coordinates", coordinates);
+        propertyValueMap.put("radius", geoCircle.getRadius() + "km");
+        jsonBuilder.field(deflatePropertyName(graph, property) + GEO_PROPERTY_NAME_SUFFIX, propertyValueMap);
+        if (geoCircle.getDescription() != null) {
+            jsonBuilder.field(deflatePropertyName(graph, property), geoCircle.getDescription());
+        }
+    }
+
+    protected void convertGeoCircle(Graph graph, Map<String, Object> propertiesMap, String deflatedPropertyName, GeoCircle geoCircle) {
+        Map<String, Object> propertyValueMap = new HashMap<>();
+        propertyValueMap.put("type", "circle");
+        List<Double> coordinates = new ArrayList<>();
+        coordinates.add(geoCircle.getLongitude());
+        coordinates.add(geoCircle.getLatitude());
+        propertyValueMap.put("coordinates", coordinates);
+        propertyValueMap.put("radius", geoCircle.getRadius() + "km");
+        addPropertyValueToPropertiesMap(propertiesMap, deflatedPropertyName + GEO_PROPERTY_NAME_SUFFIX, propertyValueMap);
+        if (geoCircle.getDescription() != null) {
+            addPropertyValueToPropertiesMap(propertiesMap, deflatedPropertyName, geoCircle.getDescription());
+        }
+    }
+
+    public IndexSelectionStrategy getIndexSelectionStrategy() {
+        return indexSelectionStrategy;
+    }
+
+    public boolean isAuthorizationFilterEnabled() {
+        return getConfig().isAuthorizationFilterEnabled();
+    }
+
+    @SuppressWarnings("unused")
+    protected void createIndex(String indexName) throws IOException {
+        CreateIndexResponse createResponse = client.admin().indices().prepareCreate(indexName)
+                .setSettings(Settings.settingsBuilder()
+                                     .put("number_of_shards", getConfig().getNumberOfShards())
+                                     .put("number_of_replicas", getConfig().getNumberOfReplicas())
+                )
+                .execute().actionGet();
+
+        ClusterHealthResponse health = client.admin().cluster().prepareHealth(indexName)
+                .setWaitForGreenStatus()
+                .execute().actionGet();
+        LOGGER.debug("Index status: %s", health.toString());
+        if (health.isTimedOut()) {
+            LOGGER.warn("timed out waiting for yellow/green index status, for index: %s", indexName);
+        }
+    }
+
+    public Client getClient() {
+        return client;
+    }
+
+    public ElasticsearchSearchIndexConfiguration getConfig() {
+        return config;
+    }
+
+    public boolean isPropertyInIndex(Graph graph, String propertyName) {
+        Map<String, IndexInfo> indexInfos = getIndexInfos(graph);
+        for (Map.Entry<String, IndexInfo> entry : indexInfos.entrySet()) {
+            if (entry.getValue().isPropertyDefined(propertyName)) {
+                return true;
+            }
+        }
+        return false;
+    }
+
+    private class FlushObject {
+        public final String elementId;
+        public final ActionRequestBuilder actionRequestBuilder;
+        public final Future future;
+        public final int retryCount;
+        private final long retryTime;
+
+        FlushObject(
+                String elementId,
+                UpdateRequestBuilder updateRequestBuilder,
+                Future future
+        ) {
+            this(elementId, updateRequestBuilder, future, 0, System.currentTimeMillis());
+        }
+
+        FlushObject(
+                String elementId,
+                ActionRequestBuilder actionRequestBuilder,
+                Future future,
+                int retryCount,
+                long retryTime
+        ) {
+            this.elementId = elementId;
+            this.actionRequestBuilder = actionRequestBuilder;
+            this.future = future;
+            this.retryCount = retryCount;
+            this.retryTime = retryTime;
+        }
+    }
+}

--- a/elasticsearch2/src/main/java/org/vertexium/elasticsearch2/ElasticsearchDocumentType.java
+++ b/elasticsearch2/src/main/java/org/vertexium/elasticsearch2/ElasticsearchDocumentType.java
@@ -1,0 +1,102 @@
+package org.vertexium.elasticsearch2;
+
+import org.elasticsearch.search.SearchHit;
+import org.elasticsearch.search.SearchHitField;
+import org.vertexium.*;
+
+import java.util.ArrayList;
+import java.util.EnumSet;
+import java.util.List;
+
+public enum ElasticsearchDocumentType {
+    VERTEX("vertex"),
+    EDGE("edge"),
+    VERTEX_EXTENDED_DATA("vertexextdata"),
+    EDGE_EXTENDED_DATA("edgeextdata");
+
+    public static final EnumSet<ElasticsearchDocumentType> ELEMENTS = EnumSet.of(VERTEX, EDGE);
+    private final String key;
+
+    ElasticsearchDocumentType(String key) {
+        this.key = key;
+    }
+
+    public String getKey() {
+        return key;
+    }
+
+    public static ElasticsearchDocumentType parse(String s) {
+        if (s.equals(VERTEX.getKey())) {
+            return VERTEX;
+        } else if (s.equals(EDGE.getKey())) {
+            return EDGE;
+        } else if (s.equals(VERTEX_EXTENDED_DATA.getKey())) {
+            return VERTEX_EXTENDED_DATA;
+        } else if (s.equals(EDGE_EXTENDED_DATA.getKey())) {
+            return EDGE_EXTENDED_DATA;
+        }
+        throw new VertexiumException("Could not parse element type: " + s);
+    }
+
+    public ElementType toElementType() {
+        switch (this) {
+            case VERTEX:
+            case VERTEX_EXTENDED_DATA:
+                return ElementType.VERTEX;
+            case EDGE:
+            case EDGE_EXTENDED_DATA:
+                return ElementType.EDGE;
+        }
+        throw new VertexiumException("Unhandled type: " + this);
+    }
+
+    public static EnumSet<ElasticsearchDocumentType> fromVertexiumObjectTypes(EnumSet<VertexiumObjectType> objectTypes) {
+        List<ElasticsearchDocumentType> enums = new ArrayList<>();
+        for (VertexiumObjectType objectType : objectTypes) {
+            switch (objectType) {
+                case VERTEX:
+                    enums.add(VERTEX);
+                    break;
+                case EDGE:
+                    enums.add(EDGE);
+                    break;
+                case EXTENDED_DATA:
+                    enums.add(VERTEX_EXTENDED_DATA);
+                    enums.add(EDGE_EXTENDED_DATA);
+                    break;
+                default:
+                    throw new VertexiumException("Unhandled Vertexium object type: " + objectType);
+            }
+        }
+        return EnumSet.copyOf(enums);
+    }
+
+    public static ElasticsearchDocumentType fromSearchHit(SearchHit searchHit) {
+        SearchHitField elementType = searchHit.getFields().get(Elasticsearch2SearchIndex.ELEMENT_TYPE_FIELD_NAME);
+        if (elementType == null) {
+            return null;
+        }
+        return ElasticsearchDocumentType.parse(elementType.getValue().toString());
+    }
+
+    public static ElasticsearchDocumentType getExtendedDataDocumentTypeFromElement(Element element) {
+        if (element instanceof Vertex) {
+            return ElasticsearchDocumentType.VERTEX_EXTENDED_DATA;
+        }
+        if (element instanceof Edge) {
+            return ElasticsearchDocumentType.EDGE_EXTENDED_DATA;
+        }
+        throw new VertexiumException("Unhandled element type: " + element.getClass().getName());
+    }
+
+    public static ElasticsearchDocumentType getExtendedDataDocumentTypeFromElementType(ElementType elementType) {
+        switch (elementType) {
+            case VERTEX:
+                return VERTEX_EXTENDED_DATA;
+            case EDGE:
+                return EDGE_EXTENDED_DATA;
+            default:
+                throw new VertexiumException("Unhandled element type: " + elementType);
+        }
+    }
+}

--- a/elasticsearch2/src/main/java/org/vertexium/elasticsearch2/ElasticsearchGraphQueryIterable.java
+++ b/elasticsearch2/src/main/java/org/vertexium/elasticsearch2/ElasticsearchGraphQueryIterable.java
@@ -1,0 +1,392 @@
+package org.vertexium.elasticsearch2;
+
+import org.elasticsearch.action.search.SearchResponse;
+import org.elasticsearch.search.SearchHit;
+import org.elasticsearch.search.SearchHits;
+import org.elasticsearch.search.aggregations.Aggregation;
+import org.elasticsearch.search.aggregations.bucket.MultiBucketsAggregation;
+import org.elasticsearch.search.aggregations.bucket.geogrid.GeoHashGrid;
+import org.elasticsearch.search.aggregations.bucket.geogrid.InternalGeoHashGrid;
+import org.elasticsearch.search.aggregations.bucket.histogram.Histogram;
+import org.elasticsearch.search.aggregations.bucket.histogram.InternalHistogram;
+import org.elasticsearch.search.aggregations.bucket.range.InternalRange;
+import org.elasticsearch.search.aggregations.bucket.range.Range;
+import org.elasticsearch.search.aggregations.bucket.terms.InternalTerms;
+import org.elasticsearch.search.aggregations.bucket.terms.Terms;
+import org.elasticsearch.search.aggregations.metrics.percentiles.Percentiles;
+import org.elasticsearch.search.aggregations.metrics.stats.extended.ExtendedStats;
+import org.elasticsearch.search.aggregations.metrics.stats.extended.InternalExtendedStats;
+import org.vertexium.VertexiumException;
+import org.vertexium.VertexiumObject;
+import org.vertexium.elasticsearch2.utils.ElasticsearchDocIdUtils;
+import org.vertexium.query.*;
+import org.vertexium.type.GeoPoint;
+import org.vertexium.type.GeoRect;
+import org.vertexium.util.StreamUtils;
+
+import java.util.ArrayList;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+
+@SuppressWarnings("deprecation")
+public class ElasticsearchGraphQueryIterable<T extends VertexiumObject> extends DefaultGraphQueryIterable<T> implements
+        IterableWithTotalHits<T>,
+        IterableWithSearchTime<T>,
+        IterableWithScores<T>,
+        IterableWithHistogramResults<T>,
+        IterableWithTermsResults<T>,
+        IterableWithGeohashResults<T>,
+        IterableWithStatisticsResults<T> {
+    private final long totalHits;
+    private final long searchTimeInNanoSeconds;
+    private final Map<Object, Double> scores = new HashMap<>();
+    private final Map<String, AggregationResult> aggregationResults;
+
+    public ElasticsearchGraphQueryIterable(
+            ElasticsearchSearchQueryBase query,
+            SearchResponse searchResponse,
+            QueryParameters parameters,
+            Iterable<T> iterable,
+            boolean evaluateQueryString,
+            boolean evaluateHasContainers,
+            boolean evaluateSortContainers,
+            long totalHits,
+            long searchTimeInNanoSeconds,
+            SearchHits hits
+    ) {
+        super(parameters, iterable, evaluateQueryString, evaluateHasContainers, evaluateSortContainers);
+        ElasticsearchSearchQueryBase query1 = query;
+        SearchResponse searchResponse1 = searchResponse;
+        this.totalHits = totalHits;
+        this.searchTimeInNanoSeconds = searchTimeInNanoSeconds;
+        if (hits != null) {
+            for (SearchHit hit : hits.getHits()) {
+                scores.put(ElasticsearchDocIdUtils.fromSearchHit(hit), (double) hit.getScore());
+            }
+        }
+        this.aggregationResults = getAggregationResults(query1, searchResponse1);
+    }
+
+    @Override
+    public long getTotalHits() {
+        return this.totalHits;
+    }
+
+    @Override
+    public Map<Object, Double> getScores() {
+        return this.scores;
+    }
+
+    @Override
+    public long getSearchTimeNanoSeconds() {
+        return this.searchTimeInNanoSeconds;
+    }
+
+    @Override
+    public <TResult extends AggregationResult> TResult getAggregationResult(String name, Class<? extends TResult> resultType) {
+        AggregationResult result = this.aggregationResults.get(name);
+        if (result == null) {
+            return AggregationResult.createEmptyResult(resultType);
+        }
+        if (!resultType.isInstance(result)) {
+            throw new VertexiumException("Could not cast aggregation result of type " + result.getClass().getName() + " to type " + resultType.getName());
+        }
+        return resultType.cast(result);
+    }
+
+    private static Map<String, AggregationResult> getAggregationResults(ElasticsearchSearchQueryBase query, SearchResponse searchResponse) {
+        if (searchResponse == null) {
+            return new HashMap<>();
+        }
+        Map<String, List<Aggregation>> aggsByName = getAggregationResultsByName(query, searchResponse.getAggregations());
+        return reduceAggregationResults(query, aggsByName);
+    }
+
+    private static Map<String, List<Aggregation>> getAggregationResultsByName(ElasticsearchSearchQueryBase query, Iterable<Aggregation> aggs) {
+        Map<String, List<Aggregation>> aggsByName = new HashMap<>();
+        if (aggs == null) {
+            return aggsByName;
+        }
+        for (Aggregation agg : aggs) {
+            String aggName = query.getAggregationName(agg.getName());
+            List<Aggregation> l = aggsByName.get(aggName);
+            if (l == null) {
+                l = new ArrayList<>();
+                aggsByName.put(aggName, l);
+            }
+            l.add(agg);
+        }
+        return aggsByName;
+    }
+
+    private static Map<String, AggregationResult> reduceAggregationResults(ElasticsearchSearchQueryBase query, Map<String, List<Aggregation>> aggsByName) {
+        Map<String, AggregationResult> results = new HashMap<>();
+        for (Map.Entry<String, List<Aggregation>> entry : aggsByName.entrySet()) {
+            results.put(entry.getKey(), reduceAggregationResults(query, entry.getValue()));
+        }
+        return results;
+    }
+
+    private static AggregationResult reduceAggregationResults(ElasticsearchSearchQueryBase query, List<Aggregation> aggs) {
+        if (aggs.size() == 0) {
+            throw new VertexiumException("Cannot reduce zero sized aggregation list");
+        }
+        Aggregation first = aggs.get(0);
+        if (first instanceof HistogramAggregation || first instanceof InternalHistogram) {
+            return reduceHistogramResults(query, aggs);
+        }
+        if (first instanceof RangeAggregation || first instanceof InternalRange) {
+            return reduceRangeResults(query, aggs);
+        }
+        if (first instanceof PercentilesAggregation || first instanceof Percentiles) {
+            return reducePercentilesResults(query, aggs);
+        }
+        if (first instanceof TermsAggregation || first instanceof InternalTerms) {
+            return reduceTermsResults(query, aggs);
+        }
+        if (first instanceof GeohashAggregation || first instanceof InternalGeoHashGrid) {
+            return reduceGeohashResults(query, aggs);
+        }
+        if (first instanceof StatisticsAggregation || first instanceof InternalExtendedStats) {
+            return reduceStatisticsResults(aggs);
+        }
+        throw new VertexiumException("Unhandled aggregation type: " + first.getClass().getName());
+    }
+
+    private static HistogramResult reduceHistogramResults(ElasticsearchSearchQueryBase query, List<Aggregation> aggs) {
+        Map<Object, List<MultiBucketsAggregation.Bucket>> bucketsByKey = new HashMap<>();
+        for (Aggregation agg : aggs) {
+            if (agg instanceof Histogram) {
+                Histogram h = (Histogram) agg;
+                org.vertexium.query.Aggregation queryAgg = query.getAggregationByName(query.getAggregationName(h.getName()));
+                boolean isCalendarFieldQuery = queryAgg != null && queryAgg instanceof CalendarFieldAggregation;
+                for (Histogram.Bucket b : h.getBuckets()) {
+                    if (isCalendarFieldQuery && b.getKey().toString().equals("-1")) {
+                        continue;
+                    }
+                    List<MultiBucketsAggregation.Bucket> l = bucketsByKey.get(b.getKey());
+                    if (l == null) {
+                        l = new ArrayList<>();
+                        bucketsByKey.put(b.getKey(), l);
+                    }
+                    l.add(b);
+                }
+            } else {
+                throw new VertexiumException("Aggregation is not a histogram: " + agg.getClass().getName());
+            }
+        }
+        return new MultiBucketsAggregationReducer<HistogramResult, HistogramBucket>() {
+            @Override
+            protected HistogramBucket createBucket(Object key, long count, Map<String, AggregationResult> nestedResults, List<MultiBucketsAggregation.Bucket> buckets) {
+                return new HistogramBucket(key, count, nestedResults);
+            }
+
+            @Override
+            protected HistogramResult bucketsToResults(List<HistogramBucket> buckets) {
+                return new HistogramResult(buckets);
+            }
+        }.reduce(query, bucketsByKey);
+    }
+
+    private static RangeResult reduceRangeResults(ElasticsearchSearchQueryBase query, List<Aggregation> aggs) {
+        Map<Object, List<MultiBucketsAggregation.Bucket>> bucketsByKey = new HashMap<>();
+        for (Aggregation agg : aggs) {
+            if (agg instanceof Range) {
+                Range r = (Range) agg;
+                for (Range.Bucket b : r.getBuckets()) {
+                    List<MultiBucketsAggregation.Bucket> l = bucketsByKey.get(b.getKey());
+                    if (l == null) {
+                        l = new ArrayList<>();
+                        bucketsByKey.put(b.getKey(), l);
+                    }
+                    l.add(b);
+                }
+            } else {
+                throw new VertexiumException("Aggregation is not a range: " + agg.getClass().getName());
+            }
+        }
+        return new MultiBucketsAggregationReducer<RangeResult, RangeBucket>() {
+            @Override
+            protected RangeBucket createBucket(Object key, long count, Map<String, AggregationResult> nestedResults, List<MultiBucketsAggregation.Bucket> buckets) {
+                return new RangeBucket(key, count, nestedResults);
+            }
+
+            @Override
+            protected RangeResult bucketsToResults(List<RangeBucket> buckets) {
+                return new RangeResult(buckets);
+            }
+        }.reduce(query, bucketsByKey);
+    }
+
+    private static PercentilesResult reducePercentilesResults(ElasticsearchSearchQueryBase query, List<Aggregation> aggs) {
+        List<Percentile> results = new ArrayList<>();
+        if (aggs.size() != 1) {
+            throw new VertexiumException("Unexpected number of aggregations. Expected 1 but found: " + aggs.size());
+        }
+        Aggregation agg = aggs.get(0);
+        if (agg instanceof Percentiles) {
+            Percentiles percentiles = (Percentiles) agg;
+            StreamUtils.stream(percentiles)
+                    .filter(percentile -> !Double.isNaN(percentile.getValue()))
+                    .forEach(percentile -> results.add(new Percentile(percentile.getPercent(), percentile.getValue())));
+        } else {
+            throw new VertexiumException("Aggregation is not a percentile: " + agg.getClass().getName());
+        }
+        return new PercentilesResult(results);
+    }
+
+    private static TermsResult reduceTermsResults(ElasticsearchSearchQueryBase query, List<Aggregation> aggs) {
+        Map<Object, List<MultiBucketsAggregation.Bucket>> bucketsByKey = new HashMap<>();
+        for (Aggregation agg : aggs) {
+            if (agg instanceof Terms) {
+                Terms h = (Terms) agg;
+                for (Terms.Bucket b : h.getBuckets()) {
+                    String mapKey = bucketKeyToString(b.getKey());
+                    List<MultiBucketsAggregation.Bucket> existingBucketByName = bucketsByKey.get(mapKey);
+                    if (existingBucketByName == null) {
+                        existingBucketByName = new ArrayList<>();
+                        bucketsByKey.put(mapKey, existingBucketByName);
+                    }
+                    existingBucketByName.add(b);
+                }
+            } else {
+                throw new VertexiumException("Aggregation is not a terms: " + agg.getClass().getName());
+            }
+        }
+        return new MultiBucketsAggregationReducer<TermsResult, TermsBucket>() {
+            @Override
+            protected TermsBucket createBucket(Object key, long count, Map<String, AggregationResult> nestedResults, List<MultiBucketsAggregation.Bucket> buckets) {
+                return new TermsBucket(key, count, nestedResults);
+            }
+
+            @Override
+            protected TermsResult bucketsToResults(List<TermsBucket> buckets) {
+                return new TermsResult(buckets);
+            }
+        }.reduce(query, bucketsByKey);
+    }
+
+    private abstract static class MultiBucketsAggregationReducer<TResult, TBucket> {
+        public TResult reduce(ElasticsearchSearchQueryBase query, Map<Object, List<MultiBucketsAggregation.Bucket>> bucketsByKey) {
+            List<TBucket> buckets = new ArrayList<>();
+            for (Map.Entry<Object, List<MultiBucketsAggregation.Bucket>> bucketsByKeyEntry : bucketsByKey.entrySet()) {
+                String key = bucketKeyToString(bucketsByKeyEntry.getKey());
+                long count = 0;
+                List<Aggregation> subAggs = new ArrayList<>();
+                for (MultiBucketsAggregation.Bucket b : bucketsByKeyEntry.getValue()) {
+                    count += b.getDocCount();
+                    for (Aggregation subAgg : b.getAggregations()) {
+                        subAggs.add(subAgg);
+                    }
+                }
+                Map<String, AggregationResult> nestedResults = reduceAggregationResults(query, getAggregationResultsByName(query, subAggs));
+                buckets.add(createBucket(key, count, nestedResults, bucketsByKeyEntry.getValue()));
+            }
+            return bucketsToResults(buckets);
+        }
+
+        protected abstract TBucket createBucket(Object key, long count, Map<String, AggregationResult> nestedResults, List<MultiBucketsAggregation.Bucket> buckets);
+
+        protected abstract TResult bucketsToResults(List<TBucket> buckets);
+    }
+
+    private static String bucketKeyToString(Object bucketKey) {
+        if (bucketKey instanceof org.elasticsearch.common.geo.GeoPoint) {
+            String geohash = ((org.elasticsearch.common.geo.GeoPoint) bucketKey).getGeohash();
+            return geohash.replaceAll("0+$", "");
+        }
+        return bucketKey.toString();
+    }
+
+    private static GeohashResult reduceGeohashResults(ElasticsearchSearchQueryBase query, List<Aggregation> aggs) {
+        Map<Object, List<MultiBucketsAggregation.Bucket>> bucketsByKey = new HashMap<>();
+        for (Aggregation agg : aggs) {
+            if (agg instanceof GeoHashGrid) {
+                GeoHashGrid h = (GeoHashGrid) agg;
+                for (GeoHashGrid.Bucket b : h.getBuckets()) {
+                    List<MultiBucketsAggregation.Bucket> existingBucket = bucketsByKey.get(b.getKey());
+                    if (existingBucket == null) {
+                        existingBucket = new ArrayList<>();
+                        bucketsByKey.put(b.getKey(), existingBucket);
+                    }
+                    existingBucket.add(b);
+                }
+            } else {
+                throw new VertexiumException("Aggregation is not a geohash: " + agg.getClass().getName());
+            }
+        }
+        return new MultiBucketsAggregationReducer<GeohashResult, GeohashBucket>() {
+            @Override
+            protected GeohashBucket createBucket(final Object key, long count, Map<String, AggregationResult> nestedResults, List<MultiBucketsAggregation.Bucket> buckets) {
+                GeoPoint geoPoint = getAverageGeoPointFromBuckets(buckets);
+                return new GeohashBucket(key.toString(), count, geoPoint, nestedResults) {
+                    @Override
+                    public GeoRect getGeoCell() {
+                        org.elasticsearch.common.geo.GeoPoint northWest = new org.elasticsearch.common.geo.GeoPoint();
+                        org.elasticsearch.common.geo.GeoPoint southEast = new org.elasticsearch.common.geo.GeoPoint();
+                        GeohashUtils.decodeCell(key.toString(), northWest, southEast);
+                        return new GeoRect(new GeoPoint(northWest.getLat(), northWest.getLon()), new GeoPoint(southEast.getLat(), southEast.getLon()));
+                    }
+                };
+            }
+
+            @Override
+            protected GeohashResult bucketsToResults(List<GeohashBucket> buckets) {
+                return new GeohashResult(buckets);
+            }
+        }.reduce(query, bucketsByKey);
+    }
+
+    private static GeoPoint getAverageGeoPointFromBuckets(List<MultiBucketsAggregation.Bucket> buckets) {
+        List<GeoPoint> geoPoints = new ArrayList<>();
+        for (MultiBucketsAggregation.Bucket b : buckets) {
+            GeoHashGrid.Bucket gb = (GeoHashGrid.Bucket) b;
+            org.elasticsearch.common.geo.GeoPoint gp = (org.elasticsearch.common.geo.GeoPoint) gb.getKey();
+            geoPoints.add(new GeoPoint(gp.getLat(), gp.getLon()));
+        }
+        return GeoPoint.calculateCenter(geoPoints);
+    }
+
+    private static StatisticsResult reduceStatisticsResults(List<Aggregation> aggs) {
+        List<StatisticsResult> results = new ArrayList<>();
+        for (Aggregation agg : aggs) {
+            if (agg instanceof ExtendedStats) {
+                ExtendedStats extendedStats = (ExtendedStats) agg;
+                long count = extendedStats.getCount();
+                double sum = extendedStats.getSum();
+                double min = extendedStats.getMin();
+                double max = extendedStats.getMax();
+                double standardDeviation = extendedStats.getStdDeviation();
+                results.add(new StatisticsResult(count, sum, min, max, standardDeviation));
+            } else {
+                throw new VertexiumException("Aggregation is not a statistics: " + agg.getClass().getName());
+            }
+        }
+        return StatisticsResult.combine(results);
+    }
+
+    @SuppressWarnings("deprecation")
+    @Override
+    public GeohashResult getGeohashResults(String name) {
+        return this.getAggregationResult(name, GeohashResult.class);
+    }
+
+    @SuppressWarnings("deprecation")
+    @Override
+    public HistogramResult getHistogramResults(String name) {
+        return this.getAggregationResult(name, HistogramResult.class);
+    }
+
+    @SuppressWarnings("deprecation")
+    @Override
+    public StatisticsResult getStatisticsResults(String name) {
+        return this.getAggregationResult(name, StatisticsResult.class);
+    }
+
+    @SuppressWarnings("deprecation")
+    @Override
+    public TermsResult getTermsResults(String name) {
+        return this.getAggregationResult(name, TermsResult.class);
+    }
+}

--- a/elasticsearch2/src/main/java/org/vertexium/elasticsearch2/ElasticsearchPropertyNameInfo.java
+++ b/elasticsearch2/src/main/java/org/vertexium/elasticsearch2/ElasticsearchPropertyNameInfo.java
@@ -1,0 +1,48 @@
+package org.vertexium.elasticsearch2;
+
+import org.vertexium.Graph;
+import org.vertexium.Visibility;
+
+import java.util.regex.Matcher;
+import java.util.regex.Pattern;
+
+public class ElasticsearchPropertyNameInfo {
+    public static final Pattern PROPERTY_NAME_PATTERN = Pattern.compile("^(.*?)(_([0-9a-f]{32}))?(_([a-z]))?$");
+    private final String propertyName;
+    private final Visibility propertyVisibility;
+
+    private ElasticsearchPropertyNameInfo(String propertyName, Visibility propertyVisibility) {
+        this.propertyName = propertyName;
+        this.propertyVisibility = propertyVisibility;
+    }
+
+    public String getPropertyName() {
+        return propertyName;
+    }
+
+    public Visibility getPropertyVisibility() {
+        return propertyVisibility;
+    }
+
+    public static ElasticsearchPropertyNameInfo parse(
+            Graph graph,
+            PropertyNameVisibilitiesStore propertyNameVisibilitiesStore,
+            String rawPropertyName
+    ) {
+        Matcher m = PROPERTY_NAME_PATTERN.matcher(rawPropertyName);
+        if (!m.matches()) {
+            return null;
+        }
+
+        String propertyName = m.group(1);
+        String visibilityHash = m.group(2);
+        Visibility propertyVisibility;
+        if (visibilityHash == null) {
+            propertyVisibility = null;
+        } else {
+            visibilityHash = visibilityHash.substring(1); // stop leading _
+            propertyVisibility = propertyNameVisibilitiesStore.getVisibilityFromHash(graph, visibilityHash);
+        }
+        return new ElasticsearchPropertyNameInfo(propertyName, propertyVisibility);
+    }
+}

--- a/elasticsearch2/src/main/java/org/vertexium/elasticsearch2/ElasticsearchSearchGraphQuery.java
+++ b/elasticsearch2/src/main/java/org/vertexium/elasticsearch2/ElasticsearchSearchGraphQuery.java
@@ -1,0 +1,34 @@
+package org.vertexium.elasticsearch2;
+
+import org.elasticsearch.client.Client;
+import org.vertexium.Authorizations;
+import org.vertexium.Graph;
+import org.vertexium.elasticsearch2.score.ScoringStrategy;
+import org.vertexium.query.GraphQuery;
+
+public class ElasticsearchSearchGraphQuery extends ElasticsearchSearchQueryBase implements GraphQuery {
+    public ElasticsearchSearchGraphQuery(
+            Client client,
+            Graph graph,
+            String queryString,
+            ScoringStrategy scoringStrategy,
+            IndexSelectionStrategy indexSelectionStrategy,
+            int pageSize,
+            Authorizations authorizations
+    ) {
+        super(client, graph, queryString, scoringStrategy, indexSelectionStrategy, pageSize, authorizations);
+    }
+
+    public ElasticsearchSearchGraphQuery(
+            Client client,
+            Graph graph,
+            String[] similarToFields,
+            String similarToText,
+            ScoringStrategy scoringStrategy,
+            IndexSelectionStrategy indexSelectionStrategy,
+            int pageSize,
+            Authorizations authorizations
+    ) {
+        super(client, graph, similarToFields, similarToText, scoringStrategy, indexSelectionStrategy, pageSize, authorizations);
+    }
+}

--- a/elasticsearch2/src/main/java/org/vertexium/elasticsearch2/ElasticsearchSearchIndexConfiguration.java
+++ b/elasticsearch2/src/main/java/org/vertexium/elasticsearch2/ElasticsearchSearchIndexConfiguration.java
@@ -1,0 +1,190 @@
+package org.vertexium.elasticsearch2;
+
+import org.vertexium.Graph;
+import org.vertexium.GraphConfiguration;
+import org.vertexium.VertexiumException;
+import org.vertexium.elasticsearch2.score.NopScoringStrategy;
+import org.vertexium.elasticsearch2.score.ScoringStrategy;
+import org.vertexium.id.IdentityNameSubstitutionStrategy;
+import org.vertexium.id.NameSubstitutionStrategy;
+import org.vertexium.util.ConfigurationUtils;
+
+import java.io.File;
+import java.util.HashMap;
+import java.util.Map;
+
+public class ElasticsearchSearchIndexConfiguration {
+    public static final String ES_LOCATIONS = "locations";
+    public static final String INDEX_EDGES = "indexEdges";
+    public static final boolean INDEX_EDGES_DEFAULT = true;
+    public static final boolean AUTO_FLUSH_DEFAULT = false;
+    public static final String CLUSTER_NAME = "clusterName";
+    public static final String CLUSTER_NAME_DEFAULT = null;
+    public static final String PORT = "port";
+    public static final int PORT_DEFAULT = 9300;
+    public static final String NUMBER_OF_SHARDS = "shards";
+    public static final int NUMBER_OF_SHARDS_DEFAULT = 5;
+    public static final int NUMBER_OF_SHARDS_IN_PROCESS_DEFAULT = 1;
+    public static final String NUMBER_OF_REPLICAS = "replicas";
+    public static final int NUMBER_OF_REPLICAS_DEFAULT = 1;
+    public static final int NUMBER_OF_REPLICAS_IN_PROCESS_DEFAULT = 0;
+    public static final String AUTHORIZATION_FILTER_ENABLED = "authorizationFilterEnabled";
+    public static final boolean AUTHORIZATION_FILTER_ENABLED_DEFAULT = true;
+    public static final String SCORING_STRATEGY_CLASS_NAME = "scoringStrategy";
+    public static final Class<? extends ScoringStrategy> SCORING_STRATEGY_CLASS_NAME_DEFAULT = NopScoringStrategy.class;
+    public static final String NAME_SUBSTITUTION_STRATEGY_CLASS_NAME = "nameSubstitutionStrategy";
+    public static final Class<? extends NameSubstitutionStrategy> NAME_SUBSTITUTION_STRATEGY_CLASS_NAME_DEFAULT = IdentityNameSubstitutionStrategy.class;
+    public static final String INDEX_SELECTION_STRATEGY_CLASS_NAME = "indexSelectionStrategy";
+    public static final Class<? extends IndexSelectionStrategy> INDEX_SELECTION_STRATEGY_CLASS_NAME_DEFAULT = DefaultIndexSelectionStrategy.class;
+    public static final String ALL_FIELD_ENABLED = "allFieldEnabled";
+    public static final String IN_PROCESS_NODE = "inProcessNode";
+    public static final boolean IN_PROCESS_NODE_DEFAULT = false;
+    public static final String IN_PROCESS_NODE_DATA_PATH = "inProcessNode.dataPath";
+    public static final String IN_PROCESS_NODE_LOGS_PATH = "inProcessNode.logsPath";
+    public static final String IN_PROCESS_NODE_WORK_PATH = "inProcessNode.workPath";
+    public static final String IN_PROCESS_ADDITIONAL_CONFIG_PREFIX = GraphConfiguration.SEARCH_INDEX_PROP_PREFIX + "." + "inProcessNode.additionalConfig.";
+    public static final String QUERY_PAGE_SIZE = "queryPageSize";
+    public static final int QUERY_PAGE_SIZE_DEFAULT = 500;
+    public static final String ES_CONFIG_FILE = "elasticsearch.configFile";
+    public static final String ES_CONFIG_FILE_DEFAULT = null;
+
+    private GraphConfiguration graphConfiguration;
+    private IndexSelectionStrategy indexSelectionStrategy;
+    private ScoringStrategy scoringStrategy;
+    private NameSubstitutionStrategy nameSubstitutionStrategy;
+
+    public ElasticsearchSearchIndexConfiguration(Graph graph, GraphConfiguration graphConfiguration) {
+        this.graphConfiguration = graphConfiguration;
+        this.scoringStrategy = getScoringStrategy(graph, graphConfiguration);
+        this.nameSubstitutionStrategy = getNameSubstitutionStrategy(graph, graphConfiguration);
+        this.indexSelectionStrategy = getIndexSelectionStrategy(graph, graphConfiguration);
+    }
+
+    public GraphConfiguration getGraphConfiguration() {
+        return graphConfiguration;
+    }
+
+    public ScoringStrategy getScoringStrategy() {
+        return scoringStrategy;
+    }
+
+    public NameSubstitutionStrategy getNameSubstitutionStrategy() {
+        return nameSubstitutionStrategy;
+    }
+
+    public IndexSelectionStrategy getIndexSelectionStrategy() {
+        return indexSelectionStrategy;
+    }
+
+    public boolean isAutoFlush() {
+        return graphConfiguration.getBoolean(GraphConfiguration.AUTO_FLUSH, AUTO_FLUSH_DEFAULT);
+    }
+
+    public boolean isIndexEdges() {
+        return graphConfiguration.getBoolean(GraphConfiguration.SEARCH_INDEX_PROP_PREFIX + "." + INDEX_EDGES, INDEX_EDGES_DEFAULT);
+    }
+
+    public String[] getEsLocations() {
+        String esLocationsString = graphConfiguration.getString(GraphConfiguration.SEARCH_INDEX_PROP_PREFIX + "." + ES_LOCATIONS, null);
+        if (esLocationsString == null) {
+            throw new VertexiumException(GraphConfiguration.SEARCH_INDEX_PROP_PREFIX + "." + ES_LOCATIONS + " is a required configuration parameter");
+        }
+        return esLocationsString.split(",");
+    }
+
+    public String getClusterName() {
+        return graphConfiguration.getString(GraphConfiguration.SEARCH_INDEX_PROP_PREFIX + "." + CLUSTER_NAME, CLUSTER_NAME_DEFAULT);
+    }
+
+    public int getPort() {
+        return graphConfiguration.getInt(GraphConfiguration.SEARCH_INDEX_PROP_PREFIX + "." + PORT, PORT_DEFAULT);
+    }
+
+    private static ScoringStrategy getScoringStrategy(Graph graph, GraphConfiguration config) {
+        String className = config.getString(GraphConfiguration.SEARCH_INDEX_PROP_PREFIX + "." + SCORING_STRATEGY_CLASS_NAME, SCORING_STRATEGY_CLASS_NAME_DEFAULT.getName());
+        return ConfigurationUtils.createProvider(className, graph, config);
+    }
+
+    private static NameSubstitutionStrategy getNameSubstitutionStrategy(Graph graph, GraphConfiguration config) {
+        String className = config.getString(GraphConfiguration.SEARCH_INDEX_PROP_PREFIX + "." + NAME_SUBSTITUTION_STRATEGY_CLASS_NAME, NAME_SUBSTITUTION_STRATEGY_CLASS_NAME_DEFAULT.getName());
+        NameSubstitutionStrategy strategy = ConfigurationUtils.createProvider(className, graph, config);
+        strategy.setup(config.getConfig());
+        return strategy;
+    }
+
+    public static IndexSelectionStrategy getIndexSelectionStrategy(Graph graph, GraphConfiguration config) {
+        String className = config.getString(GraphConfiguration.SEARCH_INDEX_PROP_PREFIX + "." + INDEX_SELECTION_STRATEGY_CLASS_NAME, INDEX_SELECTION_STRATEGY_CLASS_NAME_DEFAULT.getName());
+        IndexSelectionStrategy strategy = ConfigurationUtils.createProvider(className, graph, config);
+        return strategy;
+    }
+
+    public int getNumberOfShards() {
+        int numberOfShardsDefault = getNumberOfShardsDefault();
+        return graphConfiguration.getInt(GraphConfiguration.SEARCH_INDEX_PROP_PREFIX + "." + NUMBER_OF_SHARDS, numberOfShardsDefault);
+    }
+
+    public int getNumberOfShardsDefault() {
+        return isInProcessNode() ? NUMBER_OF_SHARDS_IN_PROCESS_DEFAULT : NUMBER_OF_SHARDS_DEFAULT;
+    }
+
+    public int getNumberOfReplicas() {
+        int numberOfReplicasDefault = getNumberOfReplicasDefault();
+        return graphConfiguration.getInt(GraphConfiguration.SEARCH_INDEX_PROP_PREFIX + "." + NUMBER_OF_REPLICAS, numberOfReplicasDefault);
+    }
+
+    public int getNumberOfReplicasDefault() {
+        return isInProcessNode() ? NUMBER_OF_REPLICAS_IN_PROCESS_DEFAULT : NUMBER_OF_REPLICAS_DEFAULT;
+    }
+
+    public boolean isAuthorizationFilterEnabled() {
+        return graphConfiguration.getBoolean(GraphConfiguration.SEARCH_INDEX_PROP_PREFIX + "." + AUTHORIZATION_FILTER_ENABLED, AUTHORIZATION_FILTER_ENABLED_DEFAULT);
+    }
+
+    public boolean isAllFieldEnabled(boolean defaultAllFieldEnabled) {
+        return graphConfiguration.getBoolean(GraphConfiguration.SEARCH_INDEX_PROP_PREFIX + "." + ALL_FIELD_ENABLED, defaultAllFieldEnabled);
+    }
+
+    public boolean isInProcessNode() {
+        return graphConfiguration.getBoolean(GraphConfiguration.SEARCH_INDEX_PROP_PREFIX + "." + IN_PROCESS_NODE, IN_PROCESS_NODE_DEFAULT);
+    }
+
+    public String getInProcessNodeDataPath() {
+        return graphConfiguration.getString(GraphConfiguration.SEARCH_INDEX_PROP_PREFIX + "." + IN_PROCESS_NODE_DATA_PATH, null);
+    }
+
+    public String getInProcessNodeLogsPath() {
+        return graphConfiguration.getString(GraphConfiguration.SEARCH_INDEX_PROP_PREFIX + "." + IN_PROCESS_NODE_LOGS_PATH, null);
+    }
+
+    public String getInProcessNodeWorkPath() {
+        return graphConfiguration.getString(GraphConfiguration.SEARCH_INDEX_PROP_PREFIX + "." + IN_PROCESS_NODE_WORK_PATH, null);
+    }
+
+    public int getQueryPageSize() {
+        return graphConfiguration.getInt(GraphConfiguration.SEARCH_INDEX_PROP_PREFIX + "." + QUERY_PAGE_SIZE, QUERY_PAGE_SIZE_DEFAULT);
+    }
+
+    public File getEsConfigFile() {
+        String fileName = graphConfiguration.getString(GraphConfiguration.SEARCH_INDEX_PROP_PREFIX + "." + ES_CONFIG_FILE, ES_CONFIG_FILE_DEFAULT);
+        if (fileName == null || fileName.length() == 0) {
+            return null;
+        }
+        return new File(fileName);
+    }
+
+    public Map<String, String> getInProcessNodeAdditionalSettings() {
+        Map<String, String> results = new HashMap<>();
+        for (Object o : graphConfiguration.getConfig().entrySet()) {
+            Map.Entry mapEntry = (Map.Entry) o;
+            if (!(mapEntry.getKey() instanceof String) || !(mapEntry.getValue() instanceof String)) {
+                continue;
+            }
+            String key = (String) mapEntry.getKey();
+            if (key.startsWith(IN_PROCESS_ADDITIONAL_CONFIG_PREFIX)) {
+                String configName = key.substring(IN_PROCESS_ADDITIONAL_CONFIG_PREFIX.length());
+                results.put(configName, (String) mapEntry.getValue());
+            }
+        }
+        return results;
+    }
+}

--- a/elasticsearch2/src/main/java/org/vertexium/elasticsearch2/ElasticsearchSearchQueryBase.java
+++ b/elasticsearch2/src/main/java/org/vertexium/elasticsearch2/ElasticsearchSearchQueryBase.java
@@ -1,0 +1,1146 @@
+package org.vertexium.elasticsearch2;
+
+import com.google.common.base.Joiner;
+import com.google.common.base.Strings;
+import com.google.common.collect.ImmutableMap;
+import com.google.common.collect.Maps;
+import org.apache.lucene.analysis.TokenStream;
+import org.apache.lucene.analysis.standard.StandardAnalyzer;
+import org.apache.lucene.analysis.tokenattributes.CharTermAttribute;
+import org.elasticsearch.action.search.SearchRequestBuilder;
+import org.elasticsearch.action.search.SearchResponse;
+import org.elasticsearch.client.Client;
+import org.elasticsearch.common.geo.builders.ShapeBuilder;
+import org.elasticsearch.common.unit.DistanceUnit;
+import org.elasticsearch.index.IndexNotFoundException;
+import org.elasticsearch.index.query.*;
+import org.elasticsearch.script.Script;
+import org.elasticsearch.search.SearchHit;
+import org.elasticsearch.search.SearchHits;
+import org.elasticsearch.search.aggregations.AbstractAggregationBuilder;
+import org.elasticsearch.search.aggregations.AggregationBuilder;
+import org.elasticsearch.search.aggregations.AggregationBuilders;
+import org.elasticsearch.search.aggregations.bucket.geogrid.GeoHashGridBuilder;
+import org.elasticsearch.search.aggregations.bucket.histogram.DateHistogramBuilder;
+import org.elasticsearch.search.aggregations.bucket.histogram.DateHistogramInterval;
+import org.elasticsearch.search.aggregations.bucket.histogram.HistogramBuilder;
+import org.elasticsearch.search.aggregations.bucket.range.RangeBuilder;
+import org.elasticsearch.search.aggregations.bucket.range.date.DateRangeBuilder;
+import org.elasticsearch.search.aggregations.bucket.terms.TermsBuilder;
+import org.elasticsearch.search.aggregations.metrics.percentiles.PercentilesBuilder;
+import org.elasticsearch.search.aggregations.metrics.stats.extended.ExtendedStatsBuilder;
+import org.elasticsearch.search.sort.SortOrder;
+import org.joda.time.DateTime;
+import org.vertexium.*;
+import org.vertexium.elasticsearch2.score.ScoringStrategy;
+import org.vertexium.elasticsearch2.utils.ElasticsearchExtendedDataIdUtils;
+import org.vertexium.elasticsearch2.utils.PagingIterable;
+import org.vertexium.query.*;
+import org.vertexium.type.GeoCircle;
+import org.vertexium.type.GeoHash;
+import org.vertexium.type.GeoPoint;
+import org.vertexium.type.GeoRect;
+import org.vertexium.util.IterableUtils;
+import org.vertexium.util.JoinIterable;
+import org.vertexium.util.VertexiumLogger;
+import org.vertexium.util.VertexiumLoggerFactory;
+
+import java.io.IOException;
+import java.util.*;
+import java.util.regex.Pattern;
+
+public class ElasticsearchSearchQueryBase extends QueryBase implements
+        GraphQueryWithHistogramAggregation,
+        GraphQueryWithTermsAggregation,
+        GraphQueryWithGeohashAggregation,
+        GraphQueryWithStatisticsAggregation {
+    private static final VertexiumLogger LOGGER = VertexiumLoggerFactory.getLogger(ElasticsearchSearchQueryBase.class);
+    public static final VertexiumLogger QUERY_LOGGER = VertexiumLoggerFactory.getQueryLogger(Query.class);
+    private final Client client;
+    private final boolean evaluateHasContainers;
+    private final boolean evaluateQueryString;
+    private final boolean evaluateSortContainers;
+    private final StandardAnalyzer analyzer;
+    private final ScoringStrategy scoringStrategy;
+    private final IndexSelectionStrategy indexSelectionStrategy;
+    private final int pageSize;
+
+    public ElasticsearchSearchQueryBase(
+            Client client,
+            Graph graph,
+            String queryString,
+            ScoringStrategy scoringStrategy,
+            IndexSelectionStrategy indexSelectionStrategy,
+            int pageSize,
+            Authorizations authorizations
+    ) {
+        super(graph, queryString, authorizations);
+        this.client = client;
+        this.evaluateQueryString = false;
+        this.evaluateHasContainers = true;
+        this.evaluateSortContainers = false;
+        this.pageSize = pageSize;
+        this.scoringStrategy = scoringStrategy;
+        this.analyzer = new StandardAnalyzer();
+        this.indexSelectionStrategy = indexSelectionStrategy;
+    }
+
+    public ElasticsearchSearchQueryBase(
+            Client client,
+            Graph graph,
+            String[] similarToFields,
+            String similarToText,
+            ScoringStrategy scoringStrategy,
+            IndexSelectionStrategy indexSelectionStrategy,
+            int pageSize,
+            Authorizations authorizations
+    ) {
+        super(graph, similarToFields, similarToText, authorizations);
+        this.client = client;
+        this.evaluateQueryString = false;
+        this.evaluateHasContainers = true;
+        this.evaluateSortContainers = false;
+        this.pageSize = pageSize;
+        this.scoringStrategy = scoringStrategy;
+        this.analyzer = new StandardAnalyzer();
+        this.indexSelectionStrategy = indexSelectionStrategy;
+    }
+
+    @Override
+    @Deprecated
+    public GraphQueryWithHistogramAggregation addHistogramAggregation(String aggregationName, String fieldName, String interval, Long minDocumentCount) {
+        addAggregation(new HistogramAggregation(aggregationName, fieldName, interval, minDocumentCount));
+        return this;
+    }
+
+    @Override
+    @Deprecated
+    public GraphQueryWithHistogramAggregation addHistogramAggregation(String aggregationName, String fieldName, String interval) {
+        return addHistogramAggregation(aggregationName, fieldName, interval, null);
+    }
+
+    @Override
+    @Deprecated
+    public GraphQueryWithTermsAggregation addTermsAggregation(String aggregationName, String fieldName) {
+        addAggregation(new TermsAggregation(aggregationName, fieldName));
+        return this;
+    }
+
+    @Override
+    @Deprecated
+    public GraphQueryWithGeohashAggregation addGeohashAggregation(String aggregationName, String fieldName, int precision) {
+        addAggregation(new GeohashAggregation(aggregationName, fieldName, precision));
+        return this;
+    }
+
+    @Override
+    @Deprecated
+    public GraphQueryWithStatisticsAggregation addStatisticsAggregation(String aggregationName, String field) {
+        addAggregation(new StatisticsAggregation(aggregationName, field));
+        return this;
+    }
+
+    @Override
+    public boolean isAggregationSupported(Aggregation agg) {
+        if (agg instanceof HistogramAggregation) {
+            return true;
+        }
+        if (agg instanceof RangeAggregation) {
+            return true;
+        }
+        if (agg instanceof PercentilesAggregation) {
+            return true;
+        }
+        if (agg instanceof TermsAggregation) {
+            return true;
+        }
+        if (agg instanceof GeohashAggregation) {
+            return true;
+        }
+        if (agg instanceof StatisticsAggregation) {
+            return true;
+        }
+        if (agg instanceof CalendarFieldAggregation) {
+            return true;
+        }
+        return false;
+    }
+
+    protected SearchRequestBuilder getSearchRequestBuilder(
+            List<QueryBuilder> filters,
+            QueryBuilder queryBuilder,
+            EnumSet<ElasticsearchDocumentType> elementType,
+            int skip,
+            int limit,
+            boolean includeAggregations
+    ) {
+        AndQueryBuilder filterBuilder = getFilterBuilder(filters);
+        String[] indicesToQuery = getIndexSelectionStrategy().getIndicesToQuery(this, elementType);
+        if (QUERY_LOGGER.isTraceEnabled()) {
+            QUERY_LOGGER.trace("indicesToQuery: %s", Joiner.on(", ").join(indicesToQuery));
+        }
+        SearchRequestBuilder searchRequestBuilder = getClient()
+                .prepareSearch(indicesToQuery)
+                .setTypes(Elasticsearch2SearchIndex.ELEMENT_TYPE)
+                .setQuery(QueryBuilders.filteredQuery(queryBuilder, filterBuilder))
+                .addField(Elasticsearch2SearchIndex.ELEMENT_TYPE_FIELD_NAME)
+                .addField(Elasticsearch2SearchIndex.EXTENDED_DATA_ELEMENT_ID_FIELD_NAME)
+                .addField(Elasticsearch2SearchIndex.EXTENDED_DATA_TABLE_NAME_FIELD_NAME)
+                .addField(Elasticsearch2SearchIndex.EXTENDED_DATA_TABLE_ROW_ID_FIELD_NAME)
+                .setFrom(skip)
+                .setSize(limit);
+        if (includeAggregations) {
+            List<AbstractAggregationBuilder> aggs = getElasticsearchAggregations(getAggregations());
+            for (AbstractAggregationBuilder aggregationBuilder : aggs) {
+                searchRequestBuilder.addAggregation(aggregationBuilder);
+            }
+        }
+        return searchRequestBuilder;
+    }
+
+    protected QueryBuilder createQueryStringQuery(QueryStringQueryParameters queryParameters) {
+        String queryString = queryParameters.getQueryString();
+        if (queryString == null || queryString.equals("*")) {
+            return QueryBuilders.matchAllQuery();
+        }
+        Elasticsearch2SearchIndex es = (Elasticsearch2SearchIndex) ((GraphWithSearchIndex) getGraph()).getSearchIndex();
+        if (es.isServerPluginInstalled()) {
+            return VertexiumQueryStringQueryBuilder.build(queryString, getParameters().getAuthorizations());
+        } else {
+            Collection<String> fields = es.getQueryablePropertyNames(getGraph(), getParameters().getAuthorizations());
+            QueryStringQueryBuilder qs = QueryBuilders.queryStringQuery(queryString);
+            for (String field : fields) {
+                qs = qs.field(field);
+            }
+            return qs;
+        }
+    }
+
+    protected List<QueryBuilder> getFilters(EnumSet<ElasticsearchDocumentType> elementTypes) {
+        List<QueryBuilder> filters = new ArrayList<>();
+        if (elementTypes != null) {
+            addElementTypeFilter(filters, elementTypes);
+        }
+        for (HasContainer has : getParameters().getHasContainers()) {
+            if (has instanceof HasValueContainer) {
+                filters.add(getFiltersForHasValueContainer((HasValueContainer) has));
+            } else if (has instanceof HasPropertyContainer) {
+                filters.add(getFilterForHasPropertyContainer((HasPropertyContainer) has));
+            } else if (has instanceof HasNotPropertyContainer) {
+                filters.add(getFilterForHasNotPropertyContainer((HasNotPropertyContainer) has));
+            } else if (has instanceof HasExtendedData) {
+                filters.add(getFilterForHasExtendedData((HasExtendedData) has));
+            } else {
+                throw new VertexiumException("Unexpected type " + has.getClass().getName());
+            }
+        }
+        if ((elementTypes == null || elementTypes.contains(ElasticsearchDocumentType.EDGE))
+                && getParameters().getEdgeLabels().size() > 0) {
+            String[] edgeLabelsArray = getParameters().getEdgeLabels().toArray(new String[getParameters().getEdgeLabels().size()]);
+            filters.add(QueryBuilders.termsQuery(Elasticsearch2SearchIndex.EDGE_LABEL_FIELD_NAME, edgeLabelsArray));
+        }
+
+        if (getParameters() instanceof QueryStringQueryParameters) {
+            String queryString = ((QueryStringQueryParameters) getParameters()).getQueryString();
+            if (queryString == null || queryString.equals("*")) {
+                Elasticsearch2SearchIndex es = (Elasticsearch2SearchIndex) ((GraphWithSearchIndex) getGraph()).getSearchIndex();
+                Collection<String> fields = es.getQueryableElementTypeVisibilityPropertyNames(getGraph(), getParameters().getAuthorizations());
+                OrQueryBuilder atLeastOneFieldExistsFilter = new OrQueryBuilder();
+                for (String field : fields) {
+                    atLeastOneFieldExistsFilter.add(new ExistsQueryBuilder(field));
+                }
+                filters.add(atLeastOneFieldExistsFilter);
+            }
+        }
+        return filters;
+    }
+
+    protected void applySort(SearchRequestBuilder q) {
+        for (SortContainer sortContainer : getParameters().getSortContainers()) {
+            SortOrder esOrder = sortContainer.direction == SortDirection.ASCENDING ? SortOrder.ASC : SortOrder.DESC;
+            if (Element.ID_PROPERTY_NAME.equals(sortContainer.propertyName)) {
+                q.addSort("_uid", esOrder);
+            } else if (Edge.LABEL_PROPERTY_NAME.equals(sortContainer.propertyName)) {
+                q.addSort(Elasticsearch2SearchIndex.EDGE_LABEL_FIELD_NAME, esOrder);
+            } else {
+                PropertyDefinition propertyDefinition = getGraph().getPropertyDefinition(sortContainer.propertyName);
+                if (propertyDefinition == null) {
+                    continue;
+                }
+                if (!getSearchIndex().isPropertyInIndex(getGraph(), sortContainer.propertyName)) {
+                    continue;
+                }
+                if (!propertyDefinition.isSortable()) {
+                    throw new VertexiumException("Cannot sort on non-sortable fields");
+                }
+                q.addSort(propertyDefinition.getPropertyName() + Elasticsearch2SearchIndex.SORT_PROPERTY_NAME_SUFFIX, esOrder);
+            }
+        }
+    }
+
+    @Override
+    public QueryResultsIterable<? extends VertexiumObject> search(EnumSet<VertexiumObjectType> objectTypes, EnumSet<FetchHint> fetchHints) {
+        return new PagingIterable<VertexiumObject>(getParameters().getSkip(), getParameters().getLimit(), pageSize) {
+            @Override
+            protected ElasticsearchGraphQueryIterable<VertexiumObject> getPageIterable(int skip, int limit, boolean includeAggregations) {
+                long startTime = System.nanoTime();
+                SearchResponse response;
+                try {
+                    response = getSearchResponse(ElasticsearchDocumentType.fromVertexiumObjectTypes(objectTypes), skip, limit, includeAggregations);
+                } catch (IndexNotFoundException ex) {
+                    LOGGER.debug("Index missing: %s (returning empty iterable)", ex.getMessage());
+                    return createEmptyIterable();
+                } catch (VertexiumNoMatchingPropertiesException ex) {
+                    LOGGER.debug("Could not find property: %s (returning empty iterable)", ex.getPropertyName());
+                    return createEmptyIterable();
+                }
+                final SearchHits hits = response.getHits();
+                Ids ids = new Ids(hits);
+                long endTime = System.nanoTime();
+                long searchTime = endTime - startTime;
+                if (LOGGER.isDebugEnabled()) {
+                    LOGGER.debug(
+                            "elasticsearch results (vertices: %d + edges: %d + extended data: %d = %d) of %d (time: %dms)",
+                            ids.getVertexIds().size(),
+                            ids.getEdgeIds().size(),
+                            ids.getExtendedDataIds().size(),
+                            ids.getVertexIds().size() + ids.getEdgeIds().size() + ids.getExtendedDataIds().size(),
+                            hits.getTotalHits(),
+                            (endTime - startTime) / 1000 / 1000
+                    );
+                }
+
+                // since ES doesn't support security we will rely on the graph to provide edge filtering
+                // and rely on the DefaultGraphQueryIterable to provide property filtering
+                QueryParameters filterParameters = getParameters().clone();
+                filterParameters.setSkip(0); // ES already did a skip
+                List<Iterable<? extends VertexiumObject>> items = new ArrayList<>();
+                if (ids.getVertexIds().size() > 0) {
+                    Iterable<? extends VertexiumObject> vertices = getGraph().getVertices(ids.getVertexIds(), fetchHints, filterParameters.getAuthorizations());
+                    items.add(vertices);
+                }
+                if (ids.getEdgeIds().size() > 0) {
+                    Iterable<? extends VertexiumObject> edges = getGraph().getEdges(ids.getEdgeIds(), fetchHints, filterParameters.getAuthorizations());
+                    items.add(edges);
+                }
+                if (ids.getExtendedDataIds().size() > 0) {
+                    Iterable<? extends VertexiumObject> extendedDataRows = getGraph().getExtendedData(ids.getExtendedDataIds(), filterParameters.getAuthorizations());
+                    items.add(extendedDataRows);
+                }
+                Iterable<VertexiumObject> vertexiumObjects = new JoinIterable<>(items);
+                vertexiumObjects = sortVertexiumObjectsByResultOrder(vertexiumObjects, ids.getIds());
+                // TODO instead of passing false here to not evaluate the query string it would be better to support the Lucene query
+                return createIterable(response, filterParameters, vertexiumObjects, evaluateQueryString, evaluateHasContainers, evaluateSortContainers, searchTime, hits);
+            }
+        };
+    }
+
+    private <T extends VertexiumObject> Iterable<T> sortVertexiumObjectsByResultOrder(Iterable<T> vertexiumObjects, List<String> ids) {
+        ImmutableMap<String, T> itemMap = Maps.uniqueIndex(vertexiumObjects, vertexiumObject -> {
+            if (vertexiumObject instanceof Element) {
+                return ((Element) vertexiumObject).getId();
+            } else if (vertexiumObject instanceof ExtendedDataRow) {
+                return ElasticsearchExtendedDataIdUtils.toDocId(((ExtendedDataRow) vertexiumObject).getId());
+            } else {
+                throw new VertexiumException("Unhandled searchable item type: " + vertexiumObject.getClass().getName());
+            }
+        });
+
+        List<T> results = new ArrayList<>();
+        for (String id : ids) {
+            T item = itemMap.get(id);
+            if (item != null) {
+                results.add(item);
+            }
+        }
+        return results;
+    }
+
+    private <T extends VertexiumObject> EmptyElasticsearchGraphQueryIterable<T> createEmptyIterable() {
+        return new EmptyElasticsearchGraphQueryIterable<>(ElasticsearchSearchQueryBase.this, getParameters());
+    }
+
+    protected <T extends VertexiumObject> ElasticsearchGraphQueryIterable<T> createIterable(
+            SearchResponse response,
+            QueryParameters filterParameters,
+            Iterable<T> vertexiumObjects,
+            boolean evaluateQueryString,
+            boolean evaluateHasContainers,
+            boolean evaluateSortContainers,
+            long searchTime,
+            SearchHits hits
+    ) {
+        return new ElasticsearchGraphQueryIterable<>(
+                this,
+                response,
+                filterParameters,
+                vertexiumObjects,
+                evaluateQueryString,
+                evaluateHasContainers,
+                evaluateSortContainers,
+                hits.getTotalHits(),
+                searchTime,
+                hits
+        );
+    }
+
+    private SearchResponse getSearchResponse(EnumSet<ElasticsearchDocumentType> elementType, int skip, int limit, boolean includeAggregations) {
+        if (QUERY_LOGGER.isTraceEnabled()) {
+            QUERY_LOGGER.trace("searching for: " + toString());
+        }
+        List<QueryBuilder> filters = getFilters(elementType);
+        QueryBuilder query = createQuery(getParameters());
+        query = scoringStrategy.updateQuery(query);
+        SearchRequestBuilder q = getSearchRequestBuilder(filters, query, elementType, skip, limit, includeAggregations);
+        applySort(q);
+
+        if (QUERY_LOGGER.isTraceEnabled()) {
+            QUERY_LOGGER.trace("query: %s", q);
+        }
+        return q.execute()
+                .actionGet();
+    }
+
+    protected QueryBuilder getFilterForHasNotPropertyContainer(HasNotPropertyContainer hasNotProperty) {
+        String[] propertyNames;
+        try {
+            propertyNames = getPropertyNames(hasNotProperty.getKey());
+            if (propertyNames.length == 0) {
+                throw new VertexiumNoMatchingPropertiesException(hasNotProperty.getKey());
+            }
+        } catch (VertexiumNoMatchingPropertiesException ex) {
+            // If we can't find a property this means it doesn't exist on any elements so the hasNot query should
+            // match all records.
+            return QueryBuilders.matchAllQuery();
+        }
+        PropertyDefinition propDef = getPropertyDefinition(hasNotProperty.getKey());
+        List<QueryBuilder> filters = new ArrayList<>();
+        for (String propertyName : propertyNames) {
+            filters.add(QueryBuilders.notQuery(QueryBuilders.existsQuery(propertyName)));
+            if (propDef.getDataType().equals(GeoPoint.class)) {
+                filters.add(QueryBuilders.notQuery(QueryBuilders.existsQuery(propertyName + Elasticsearch2SearchIndex.GEO_PROPERTY_NAME_SUFFIX)));
+            } else if (isExactMatchPropertyDefinition(propDef)) {
+                filters.add(QueryBuilders.notQuery(QueryBuilders.existsQuery(propertyName + Elasticsearch2SearchIndex.EXACT_MATCH_PROPERTY_NAME_SUFFIX)));
+            }
+        }
+        return getSingleFilterOrAndTheFilters(filters, hasNotProperty);
+    }
+
+    private QueryBuilder getFilterForHasExtendedData(HasExtendedData has) {
+        List<QueryBuilder> filters = new ArrayList<>();
+        for (HasExtendedDataFilter hasExtendedDataFilter : has.getFilters()) {
+            filters.add(getFilterForHasExtendedDataFilter(hasExtendedDataFilter));
+        }
+        return QueryBuilders.orQuery(filters.toArray(new QueryBuilder[filters.size()]));
+    }
+
+    private QueryBuilder getFilterForHasExtendedDataFilter(HasExtendedDataFilter has) {
+        List<QueryBuilder> filters = new ArrayList<>();
+        if (has.getElementType() != null) {
+            filters.add(QueryBuilders.termQuery(
+                    Elasticsearch2SearchIndex.ELEMENT_TYPE_FIELD_NAME,
+                    ElasticsearchDocumentType.getExtendedDataDocumentTypeFromElementType(has.getElementType()).getKey()
+            ));
+        }
+        if (has.getElementId() != null) {
+            filters.add(QueryBuilders.termQuery(Elasticsearch2SearchIndex.EXTENDED_DATA_ELEMENT_ID_FIELD_NAME, has.getElementId()));
+        }
+        if (has.getTableName() != null) {
+            filters.add(QueryBuilders.termQuery(Elasticsearch2SearchIndex.EXTENDED_DATA_TABLE_NAME_FIELD_NAME, has.getTableName()));
+        }
+        if (filters.size() == 0) {
+            throw new VertexiumException("Cannot include a hasExtendedData clause with all nulls");
+        }
+        return QueryBuilders.andQuery(filters.toArray(new QueryBuilder[filters.size()]));
+    }
+
+    protected QueryBuilder getFilterForHasPropertyContainer(HasPropertyContainer hasProperty) {
+        String[] propertyNames = getPropertyNames(hasProperty.getKey());
+        if (propertyNames.length == 0) {
+            throw new VertexiumNoMatchingPropertiesException(hasProperty.getKey());
+        }
+        PropertyDefinition propDef = getPropertyDefinition(hasProperty.getKey());
+        if (propDef == null) {
+            throw new VertexiumException("Could not find property definition for property name: " + hasProperty.getKey());
+        }
+        List<QueryBuilder> filters = new ArrayList<>();
+        for (String propertyName : propertyNames) {
+            filters.add(QueryBuilders.existsQuery(propertyName));
+            if (propDef.getDataType().equals(GeoPoint.class)) {
+                filters.add(QueryBuilders.existsQuery(propertyName + Elasticsearch2SearchIndex.GEO_PROPERTY_NAME_SUFFIX));
+            } else if (isExactMatchPropertyDefinition(propDef)) {
+                filters.add(QueryBuilders.existsQuery(propertyName + Elasticsearch2SearchIndex.EXACT_MATCH_PROPERTY_NAME_SUFFIX));
+            }
+        }
+        return getSingleFilterOrOrTheFilters(filters, hasProperty);
+    }
+
+    protected QueryBuilder getFiltersForHasValueContainer(HasValueContainer has) {
+        if (has.predicate instanceof Compare) {
+            return getFilterForComparePredicate((Compare) has.predicate, has);
+        } else if (has.predicate instanceof Contains) {
+            return getFilterForContainsPredicate((Contains) has.predicate, has);
+        } else if (has.predicate instanceof TextPredicate) {
+            return getFilterForTextPredicate((TextPredicate) has.predicate, has);
+        } else if (has.predicate instanceof GeoCompare) {
+            return getFilterForGeoComparePredicate((GeoCompare) has.predicate, has);
+        } else {
+            throw new VertexiumException("Unexpected predicate type " + has.predicate.getClass().getName());
+        }
+    }
+
+    protected QueryBuilder getFilterForGeoComparePredicate(GeoCompare compare, HasValueContainer has) {
+        String[] keys = getPropertyNames(has.key);
+        if (keys.length == 0) {
+            throw new VertexiumNoMatchingPropertiesException(has.key);
+        }
+        List<QueryBuilder> filters = new ArrayList<>();
+        for (String key : keys) {
+            String propertyName = key + Elasticsearch2SearchIndex.GEO_PROPERTY_NAME_SUFFIX;
+            switch (compare) {
+                case WITHIN:
+                    Object value = has.value;
+                    if (value instanceof GeoHash) {
+                        value = ((GeoHash) value).toGeoRect();
+                    }
+
+                    if (value instanceof GeoCircle) {
+                        GeoCircle geoCircle = (GeoCircle) value;
+                        double lat = geoCircle.getLatitude();
+                        double lon = geoCircle.getLongitude();
+                        double distance = geoCircle.getRadius();
+
+                        String inflatedPropertyName = getSearchIndex().inflatePropertyName(propertyName);
+                        PropertyDefinition propertyDefinition = getGraph().getPropertyDefinition(inflatedPropertyName);
+                        if (propertyDefinition != null && propertyDefinition.getDataType() == GeoCircle.class) {
+                            ShapeBuilder shapeBuilder = ShapeBuilder.newCircleBuilder()
+                                    .center(lon, lat)
+                                    .radius(distance, DistanceUnit.KILOMETERS);
+                            filters
+                                    .add(new GeoShapeQueryBuilder(propertyName, shapeBuilder));
+                        } else {
+                            filters
+                                    .add(QueryBuilders
+                                                 .geoDistanceQuery(propertyName)
+                                                 .point(lat, lon)
+                                                 .distance(distance, DistanceUnit.KILOMETERS));
+                        }
+                    } else if (value instanceof GeoRect) {
+                        GeoRect geoRect = (GeoRect) value;
+                        double nwLat = geoRect.getNorthWest().getLatitude();
+                        double nwLon = geoRect.getNorthWest().getLongitude();
+                        double seLat = geoRect.getSouthEast().getLatitude();
+                        double seLon = geoRect.getSouthEast().getLongitude();
+
+                        String inflatedPropertyName = getSearchIndex().inflatePropertyName(propertyName);
+                        PropertyDefinition propertyDefinition = getGraph().getPropertyDefinition(inflatedPropertyName);
+                        if (propertyDefinition != null && propertyDefinition.getDataType() == GeoCircle.class) {
+                            ShapeBuilder shapeBuilder = ShapeBuilder.newPolygon()
+                                    .point(nwLon, nwLat)
+                                    .point(seLon, nwLat)
+                                    .point(seLon, seLat)
+                                    .point(nwLon, seLat)
+                                    .close();
+                            filters
+                                    .add(new GeoShapeQueryBuilder(propertyName, shapeBuilder));
+                        } else {
+                            filters
+                                    .add(QueryBuilders
+                                                 .geoBoundingBoxQuery(propertyName)
+                                                 .topLeft(nwLat, nwLon)
+                                                 .bottomRight(seLat, seLon));
+                        }
+                    } else {
+                        throw new VertexiumException("Unexpected has value type " + value.getClass().getName());
+                    }
+                    break;
+                default:
+                    throw new VertexiumException("Unexpected GeoCompare predicate " + has.predicate);
+            }
+        }
+        return getSingleFilterOrOrTheFilters(filters, has);
+    }
+
+    private QueryBuilder getSingleFilterOrOrTheFilters(List<QueryBuilder> filters, HasContainer has) {
+        if (filters.size() > 1) {
+            return QueryBuilders.orQuery(filters.toArray(new QueryBuilder[filters.size()]));
+        } else if (filters.size() == 1) {
+            return filters.get(0);
+        } else {
+            throw new VertexiumException("Unexpected filter count, expected at least 1 filter for: " + has);
+        }
+    }
+
+    private QueryBuilder getSingleFilterOrAndTheFilters(List<QueryBuilder> filters, HasContainer has) {
+        if (filters.size() > 1) {
+            return QueryBuilders.andQuery(filters.toArray(new QueryBuilder[filters.size()]));
+        } else if (filters.size() == 1) {
+            return filters.get(0);
+        } else {
+            throw new VertexiumException("Unexpected filter count, expected at least 1 filter for: " + has);
+        }
+    }
+
+    protected QueryBuilder getFilterForTextPredicate(TextPredicate compare, HasValueContainer has) {
+        Object value = has.value;
+        String[] keys = getPropertyNames(has.key);
+        if (keys.length == 0) {
+            throw new VertexiumNoMatchingPropertiesException(has.key);
+        }
+        List<QueryBuilder> filters = new ArrayList<>();
+        for (String key : keys) {
+            if (value instanceof String) {
+                value = ((String) value).toLowerCase(); // using the standard analyzer all strings are lower-cased.
+            }
+            switch (compare) {
+                case CONTAINS:
+                    if (value instanceof String) {
+                        String[] terms = splitStringIntoTerms((String) value);
+                        filters.add(QueryBuilders.termsQuery(key, terms));
+                    } else {
+                        filters.add(QueryBuilders.termQuery(key, value));
+                    }
+                    break;
+                default:
+                    throw new VertexiumException("Unexpected text predicate " + has.predicate);
+            }
+        }
+        return getSingleFilterOrOrTheFilters(filters, has);
+    }
+
+    protected QueryBuilder getFilterForContainsPredicate(Contains contains, HasValueContainer has) {
+        String[] keys = getPropertyNames(has.key);
+        if (keys.length == 0) {
+            if (contains.equals(Contains.NOT_IN)) {
+                return QueryBuilders.matchAllQuery();
+            }
+            throw new VertexiumNoMatchingPropertiesException(has.key);
+        }
+        List<QueryBuilder> filters = new ArrayList<>();
+        for (String key : keys) {
+            if (has.value instanceof Iterable) {
+                has.value = IterableUtils.toArray((Iterable<?>) has.value, Object.class);
+            }
+            if (has.value instanceof String
+                    || has.value instanceof String[]
+                    || (has.value instanceof Object[] && ((Object[]) has.value).length > 0 && ((Object[]) has.value)[0] instanceof String)
+                    ) {
+                key = key + Elasticsearch2SearchIndex.EXACT_MATCH_PROPERTY_NAME_SUFFIX;
+            }
+            switch (contains) {
+                case IN:
+                    filters.add(QueryBuilders.termsQuery(key, (Object[]) has.value));
+                    break;
+                case NOT_IN:
+                    filters.add(QueryBuilders.notQuery(QueryBuilders.termsQuery(key, (Object[]) has.value)));
+                    break;
+                default:
+                    throw new VertexiumException("Unexpected Contains predicate " + has.predicate);
+            }
+        }
+        return getSingleFilterOrOrTheFilters(filters, has);
+    }
+
+    protected QueryBuilder getFilterForComparePredicate(Compare compare, HasValueContainer has) {
+        Object value = has.value;
+        String[] keys = getPropertyNames(has.key);
+        if (keys.length == 0) {
+            if (compare.equals(Compare.NOT_EQUAL)) {
+                return QueryBuilders.matchAllQuery();
+            }
+            throw new VertexiumNoMatchingPropertiesException(has.key);
+        }
+        List<QueryBuilder> filters = new ArrayList<>();
+        for (String key : keys) {
+            if (value instanceof String || value instanceof String[]) {
+                key = key + Elasticsearch2SearchIndex.EXACT_MATCH_PROPERTY_NAME_SUFFIX;
+            }
+            switch (compare) {
+                case EQUAL:
+                    if (value instanceof DateOnly) {
+                        DateOnly dateOnlyValue = ((DateOnly) value);
+                        String lower = dateOnlyValue.toString() + "T00:00:00.000Z";
+                        String upper = dateOnlyValue.toString() + "T23:59:59.999Z";
+                        filters.add(QueryBuilders.rangeQuery(key).gte(lower).lte(upper));
+                    } else {
+                        filters.add(QueryBuilders.termQuery(key, value));
+                    }
+                    break;
+                case GREATER_THAN_EQUAL:
+                    filters.add(QueryBuilders.rangeQuery(key).gte(value));
+                    break;
+                case GREATER_THAN:
+                    filters.add(QueryBuilders.rangeQuery(key).gt(value));
+                    break;
+                case LESS_THAN_EQUAL:
+                    filters.add(QueryBuilders.rangeQuery(key).lte(value));
+                    break;
+                case LESS_THAN:
+                    filters.add(QueryBuilders.rangeQuery(key).lt(value));
+                    break;
+                case NOT_EQUAL:
+                    addNotFilter(filters, key, value);
+                    break;
+                default:
+                    throw new VertexiumException("Unexpected Compare predicate " + has.predicate);
+            }
+        }
+        return getSingleFilterOrOrTheFilters(filters, has);
+    }
+
+    protected String[] getPropertyNames(String propertyName) {
+        return getSearchIndex().getAllMatchingPropertyNames(getGraph(), propertyName, getParameters().getAuthorizations());
+    }
+
+    protected Elasticsearch2SearchIndex getSearchIndex() {
+        return (Elasticsearch2SearchIndex) ((GraphWithSearchIndex) getGraph()).getSearchIndex();
+    }
+
+    protected void addElementTypeFilter(List<QueryBuilder> filters, EnumSet<ElasticsearchDocumentType> elementType) {
+        if (elementType != null) {
+            filters.add(createElementTypeFilter(elementType));
+        }
+    }
+
+    protected TermsQueryBuilder createElementTypeFilter(EnumSet<ElasticsearchDocumentType> elementType) {
+        List<String> values = new ArrayList<>();
+        for (ElasticsearchDocumentType et : elementType) {
+            values.add(et.getKey());
+        }
+        return QueryBuilders.termsQuery(
+                Elasticsearch2SearchIndex.ELEMENT_TYPE_FIELD_NAME,
+                values.toArray(new String[values.size()])
+        );
+    }
+
+    protected void addNotFilter(List<QueryBuilder> filters, String key, Object value) {
+        filters.add(QueryBuilders.notQuery(QueryBuilders.termQuery(key, value)));
+    }
+
+    protected AndQueryBuilder getFilterBuilder(List<QueryBuilder> filters) {
+        return QueryBuilders.andQuery(filters.toArray(new QueryBuilder[filters.size()]));
+    }
+
+    private String[] splitStringIntoTerms(String value) {
+        try {
+            List<String> results = new ArrayList<>();
+            try (TokenStream tokens = analyzer.tokenStream("", value)) {
+                CharTermAttribute term = tokens.getAttribute(CharTermAttribute.class);
+                tokens.reset();
+                while (tokens.incrementToken()) {
+                    String t = term.toString().trim();
+                    if (t.length() > 0) {
+                        results.add(t);
+                    }
+                }
+            }
+            return results.toArray(new String[results.size()]);
+        } catch (IOException e) {
+            throw new VertexiumException("Could not tokenize string: " + value, e);
+        }
+    }
+
+    protected QueryBuilder createQuery(QueryParameters queryParameters) {
+        if (queryParameters instanceof QueryStringQueryParameters) {
+            return createQueryStringQuery((QueryStringQueryParameters) queryParameters);
+        } else if (queryParameters instanceof SimilarToTextQueryParameters) {
+            return createSimilarToTextQuery((SimilarToTextQueryParameters) queryParameters);
+        } else {
+            throw new VertexiumException("Query parameters not supported of type: " + queryParameters.getClass().getName());
+        }
+    }
+
+    protected QueryBuilder createSimilarToTextQuery(SimilarToTextQueryParameters queryParameters) {
+        SimilarToTextQueryParameters similarTo = queryParameters;
+        List<String> allFields = new ArrayList<>();
+        String[] fields = similarTo.getFields();
+        for (String field : fields) {
+            Collections.addAll(allFields, getPropertyNames(field));
+        }
+        MoreLikeThisQueryBuilder q = QueryBuilders.moreLikeThisQuery(allFields.toArray(new String[allFields.size()]))
+                .likeText(similarTo.getText());
+        if (similarTo.getMinTermFrequency() != null) {
+            q.minTermFreq(similarTo.getMinTermFrequency());
+        }
+        if (similarTo.getMaxQueryTerms() != null) {
+            q.maxQueryTerms(similarTo.getMaxQueryTerms());
+        }
+        if (similarTo.getMinDocFrequency() != null) {
+            q.minDocFreq(similarTo.getMinDocFrequency());
+        }
+        if (similarTo.getMaxDocFrequency() != null) {
+            q.maxDocFreq(similarTo.getMaxDocFrequency());
+        }
+        if (similarTo.getBoost() != null) {
+            q.boost(similarTo.getBoost());
+        }
+        return q;
+    }
+
+    public Client getClient() {
+        return client;
+    }
+
+    protected List<AbstractAggregationBuilder> getElasticsearchAggregations(Iterable<Aggregation> aggregations) {
+        List<AbstractAggregationBuilder> aggs = new ArrayList<>();
+        for (Aggregation agg : aggregations) {
+            if (agg instanceof HistogramAggregation) {
+                aggs.addAll(getElasticsearchHistogramAggregations((HistogramAggregation) agg));
+            } else if (agg instanceof RangeAggregation) {
+                aggs.addAll(getElasticsearchRangeAggregations((RangeAggregation) agg));
+            } else if (agg instanceof PercentilesAggregation) {
+                aggs.addAll(getElasticsearchPercentilesAggregations((PercentilesAggregation) agg));
+            } else if (agg instanceof TermsAggregation) {
+                aggs.addAll(getElasticsearchTermsAggregations((TermsAggregation) agg));
+            } else if (agg instanceof GeohashAggregation) {
+                aggs.addAll(getElasticsearchGeohashAggregations((GeohashAggregation) agg));
+            } else if (agg instanceof StatisticsAggregation) {
+                aggs.addAll(getElasticsearchStatisticsAggregations((StatisticsAggregation) agg));
+            } else if (agg instanceof CalendarFieldAggregation) {
+                aggs.addAll(getElasticsearchCalendarFieldAggregation((CalendarFieldAggregation) agg));
+            } else {
+                throw new VertexiumException("Could not add aggregation of type: " + agg.getClass().getName());
+            }
+        }
+        return aggs;
+    }
+
+    protected List<AggregationBuilder> getElasticsearchGeohashAggregations(GeohashAggregation agg) {
+        List<AggregationBuilder> aggs = new ArrayList<>();
+        for (String propertyName : getPropertyNames(agg.getFieldName())) {
+            String visibilityHash = getSearchIndex().getPropertyVisibilityHashFromDeflatedPropertyName(propertyName);
+            String aggName = createAggregationName(agg.getAggregationName(), visibilityHash);
+            GeoHashGridBuilder geoHashAgg = AggregationBuilders.geohashGrid(aggName);
+            geoHashAgg.field(propertyName + Elasticsearch2SearchIndex.GEO_PROPERTY_NAME_SUFFIX);
+            geoHashAgg.precision(agg.getPrecision());
+            aggs.add(geoHashAgg);
+        }
+        return aggs;
+    }
+
+    protected List<AbstractAggregationBuilder> getElasticsearchStatisticsAggregations(StatisticsAggregation agg) {
+        List<AbstractAggregationBuilder> aggs = new ArrayList<>();
+        for (String propertyName : getPropertyNames(agg.getFieldName())) {
+            String visibilityHash = getSearchIndex().getPropertyVisibilityHashFromDeflatedPropertyName(propertyName);
+            String aggName = createAggregationName(agg.getAggregationName(), visibilityHash);
+            ExtendedStatsBuilder statsAgg = AggregationBuilders.extendedStats(aggName);
+            statsAgg.field(propertyName);
+            aggs.add(statsAgg);
+        }
+        return aggs;
+    }
+
+    protected List<AbstractAggregationBuilder> getElasticsearchPercentilesAggregations(PercentilesAggregation agg) {
+        String propertyName = getSearchIndex().deflatePropertyName(getGraph(), agg.getFieldName(), agg.getVisibility());
+        String visibilityHash = getSearchIndex().getPropertyVisibilityHashFromDeflatedPropertyName(propertyName);
+        String aggName = createAggregationName(agg.getAggregationName(), visibilityHash);
+        PercentilesBuilder percentilesAgg = AggregationBuilders.percentiles(aggName);
+        percentilesAgg.field(propertyName);
+        if (agg.getPercents() != null && agg.getPercents().length > 0) {
+            percentilesAgg.percentiles(agg.getPercents());
+        }
+        return Collections.singletonList(percentilesAgg);
+    }
+
+    private String createAggregationName(String aggName, String visibilityHash) {
+        if (visibilityHash != null && visibilityHash.length() > 0) {
+            return aggName + "_" + visibilityHash;
+        }
+        return aggName;
+    }
+
+    protected List<AggregationBuilder> getElasticsearchTermsAggregations(TermsAggregation agg) {
+        List<AggregationBuilder> termsAggs = new ArrayList<>();
+        String fieldName = agg.getPropertyName();
+        if (Edge.LABEL_PROPERTY_NAME.equals(fieldName)) {
+            TermsBuilder termsAgg = AggregationBuilders.terms(createAggregationName(agg.getAggregationName(), "0"));
+            termsAgg.field(fieldName);
+            termsAggs.add(termsAgg);
+        } else {
+            PropertyDefinition propertyDefinition = getPropertyDefinition(fieldName);
+            for (String propertyName : getPropertyNames(fieldName)) {
+                if (isExactMatchPropertyDefinition(propertyDefinition)) {
+                    propertyName = propertyName + Elasticsearch2SearchIndex.EXACT_MATCH_PROPERTY_NAME_SUFFIX;
+                }
+
+                String visibilityHash = getSearchIndex().getPropertyVisibilityHashFromDeflatedPropertyName(propertyName);
+                TermsBuilder termsAgg = AggregationBuilders.terms(createAggregationName(agg.getAggregationName(), visibilityHash));
+                termsAgg.field(propertyName);
+                if (agg.getSize() != null) {
+                    termsAgg.size(agg.getSize());
+                }
+
+                for (AbstractAggregationBuilder subAgg : getElasticsearchAggregations(agg.getNestedAggregations())) {
+                    termsAgg.subAggregation(subAgg);
+                }
+
+                termsAggs.add(termsAgg);
+            }
+        }
+        return termsAggs;
+    }
+
+    private boolean isExactMatchPropertyDefinition(PropertyDefinition propertyDefinition) {
+        return propertyDefinition != null
+                && propertyDefinition.getDataType().equals(String.class)
+                && propertyDefinition.getTextIndexHints().contains(TextIndexHint.EXACT_MATCH);
+    }
+
+    private Collection<? extends AbstractAggregationBuilder> getElasticsearchCalendarFieldAggregation(CalendarFieldAggregation agg) {
+        List<AggregationBuilder> aggs = new ArrayList<>();
+        PropertyDefinition propertyDefinition = getPropertyDefinition(agg.getPropertyName());
+        if (propertyDefinition == null) {
+            throw new VertexiumException("Could not find mapping for property: " + agg.getPropertyName());
+        }
+        Class propertyDataType = propertyDefinition.getDataType();
+        for (String propertyName : getPropertyNames(agg.getPropertyName())) {
+            String visibilityHash = getSearchIndex().getPropertyVisibilityHashFromDeflatedPropertyName(propertyName);
+            String aggName = createAggregationName(agg.getAggregationName(), visibilityHash);
+            if (propertyDataType == Date.class) {
+                HistogramBuilder histAgg = AggregationBuilders.histogram(aggName);
+                histAgg.interval(1);
+                if (agg.getMinDocumentCount() != null) {
+                    histAgg.minDocCount(agg.getMinDocumentCount());
+                } else {
+                    histAgg.minDocCount(1L);
+                }
+                Script script = new Script(getCalendarFieldAggregationScript(agg, propertyName));
+                histAgg.script(script);
+
+                for (AbstractAggregationBuilder subAgg : getElasticsearchAggregations(agg.getNestedAggregations())) {
+                    histAgg.subAggregation(subAgg);
+                }
+
+                aggs.add(histAgg);
+            } else {
+                throw new VertexiumException("Only dates are supported for hour of day aggregations");
+            }
+        }
+        return aggs;
+    }
+
+    private String getCalendarFieldAggregationScript(CalendarFieldAggregation agg, String propertyName) {
+        String prefix = "d = doc['" + propertyName + "']; ";
+        switch (agg.getCalendarField()) {
+            case Calendar.DAY_OF_MONTH:
+                return prefix + "d ? d.date.toDateTime(DateTimeZone.forID(\"" + agg.getTimeZone().getID() + "\")).get(DateTimeFieldType.dayOfMonth()) : -1";
+            case Calendar.DAY_OF_WEEK:
+                return prefix + "d = (d ? (d.date.toDateTime(DateTimeZone.forID(\"" + agg.getTimeZone().getID() + "\")).get(DateTimeFieldType.dayOfWeek()) + 1) : -1); return d > 7 ? d - 7 : d;";
+            case Calendar.HOUR_OF_DAY:
+                return prefix + "d ? d.date.toDateTime(DateTimeZone.forID(\"" + agg.getTimeZone().getID() + "\")).get(DateTimeFieldType.hourOfDay()) : -1";
+            case Calendar.MONTH:
+                return prefix + "d ? (d.date.toDateTime(DateTimeZone.forID(\"" + agg.getTimeZone().getID() + "\")).get(DateTimeFieldType.monthOfYear()) - 1) : -1";
+            case Calendar.YEAR:
+                return prefix + "d ? d.date.toDateTime(DateTimeZone.forID(\"" + agg.getTimeZone().getID() + "\")).get(DateTimeFieldType.year()) : -1";
+            default:
+                LOGGER.warn("Slow operation toGregorianCalendar() for calendar field: %d", agg.getCalendarField());
+                return prefix + "d ? d.date.toDateTime(DateTimeZone.forID(\"" + agg.getTimeZone().getID() + "\")).toGregorianCalendar().get(" + agg.getCalendarField() + ") : -1";
+        }
+    }
+
+    protected List<AggregationBuilder> getElasticsearchHistogramAggregations(HistogramAggregation agg) {
+        List<AggregationBuilder> aggs = new ArrayList<>();
+        PropertyDefinition propertyDefinition = getPropertyDefinition(agg.getFieldName());
+        if (propertyDefinition == null) {
+            throw new VertexiumException("Could not find mapping for property: " + agg.getFieldName());
+        }
+        Class propertyDataType = propertyDefinition.getDataType();
+        for (String propertyName : getPropertyNames(agg.getFieldName())) {
+            String visibilityHash = getSearchIndex().getPropertyVisibilityHashFromDeflatedPropertyName(propertyName);
+            String aggName = createAggregationName(agg.getAggregationName(), visibilityHash);
+            if (propertyDataType == Date.class) {
+                DateHistogramBuilder dateAgg = AggregationBuilders.dateHistogram(aggName);
+                dateAgg.field(propertyName);
+                String interval = agg.getInterval();
+                if (Pattern.matches("^[0-9\\.]+$", interval)) {
+                    interval += "ms";
+                }
+                dateAgg.interval(new DateHistogramInterval(interval));
+                dateAgg.minDocCount(1L);
+                if (agg.getMinDocumentCount() != null) {
+                    dateAgg.minDocCount(agg.getMinDocumentCount());
+                }
+                if (agg.getExtendedBounds() != null) {
+                    HistogramAggregation.ExtendedBounds<?> bounds = agg.getExtendedBounds();
+                    if (bounds.getMinMaxType().isAssignableFrom(Long.class)) {
+                        dateAgg.extendedBounds((Long) bounds.getMin(), (Long) bounds.getMax());
+                    } else if (bounds.getMinMaxType().isAssignableFrom(Date.class)) {
+                        dateAgg.extendedBounds(new DateTime(bounds.getMin()), new DateTime(bounds.getMax()));
+                    } else if (bounds.getMinMaxType().isAssignableFrom(String.class)) {
+                        dateAgg.extendedBounds((String) bounds.getMin(), (String) bounds.getMax());
+                    } else {
+                        throw new VertexiumException("Unhandled extended bounds type. Expected Long, String, or Date. Found: " + bounds.getMinMaxType().getName());
+                    }
+                }
+
+                for (AbstractAggregationBuilder subAgg : getElasticsearchAggregations(agg.getNestedAggregations())) {
+                    dateAgg.subAggregation(subAgg);
+                }
+
+                aggs.add(dateAgg);
+            } else {
+                HistogramBuilder histogramAgg = AggregationBuilders.histogram(aggName);
+                histogramAgg.field(propertyName);
+                histogramAgg.interval(Long.parseLong(agg.getInterval()));
+                histogramAgg.minDocCount(1L);
+                if (agg.getMinDocumentCount() != null) {
+                    histogramAgg.minDocCount(agg.getMinDocumentCount());
+                }
+                if (agg.getExtendedBounds() != null) {
+                    HistogramAggregation.ExtendedBounds<?> bounds = agg.getExtendedBounds();
+                    if (bounds.getMinMaxType().isAssignableFrom(Long.class)) {
+                        histogramAgg.extendedBounds((Long) bounds.getMin(), (Long) bounds.getMax());
+                    } else {
+                        throw new VertexiumException("Unhandled extended bounds type. Expected Long. Found: " + bounds.getMinMaxType().getName());
+                    }
+                }
+
+                for (AbstractAggregationBuilder subAgg : getElasticsearchAggregations(agg.getNestedAggregations())) {
+                    histogramAgg.subAggregation(subAgg);
+                }
+
+                aggs.add(histogramAgg);
+            }
+        }
+        return aggs;
+    }
+
+    protected List<AggregationBuilder> getElasticsearchRangeAggregations(RangeAggregation agg) {
+        List<AggregationBuilder> aggs = new ArrayList<>();
+        PropertyDefinition propertyDefinition = getPropertyDefinition(agg.getFieldName());
+        if (propertyDefinition == null) {
+            throw new VertexiumException("Could not find mapping for property: " + agg.getFieldName());
+        }
+        Class propertyDataType = propertyDefinition.getDataType();
+        for (String propertyName : getPropertyNames(agg.getFieldName())) {
+            String visibilityHash = getSearchIndex().getPropertyVisibilityHashFromDeflatedPropertyName(propertyName);
+            String aggName = createAggregationName(agg.getAggregationName(), visibilityHash);
+            if (propertyDataType == Date.class) {
+                DateRangeBuilder dateRangeBuilder = AggregationBuilders.dateRange(aggName);
+                dateRangeBuilder.field(propertyName);
+
+                if (!Strings.isNullOrEmpty(agg.getFormat())) {
+                    dateRangeBuilder.format(agg.getFormat());
+                }
+
+                for (RangeAggregation.Range range : agg.getRanges()) {
+                    dateRangeBuilder.addRange(range.getKey(), range.getFrom(), range.getTo());
+                }
+
+                for (AbstractAggregationBuilder subAgg : getElasticsearchAggregations(agg.getNestedAggregations())) {
+                    dateRangeBuilder.subAggregation(subAgg);
+                }
+
+                aggs.add(dateRangeBuilder);
+            } else {
+                RangeBuilder rangeBuilder = AggregationBuilders.range(aggName);
+                rangeBuilder.field(propertyName);
+
+                if (!Strings.isNullOrEmpty(agg.getFormat())) {
+                    throw new VertexiumException("Invalid use of format for property: " + agg.getFieldName() +
+                                                         ". Format is only valid for date properties");
+                }
+
+                for (RangeAggregation.Range range : agg.getRanges()) {
+                    Object from = range.getFrom();
+                    Object to = range.getTo();
+                    if ((from != null && !(from instanceof Number)) || (to != null && !(to instanceof Number))) {
+                        throw new VertexiumException("Invalid range for property: " + agg.getFieldName() +
+                                                             ". Both to and from must be Numeric.");
+                    }
+                    rangeBuilder.addRange(
+                            range.getKey(),
+                            from == null ? Double.MIN_VALUE : ((Number) from).doubleValue(),
+                            to == null ? Double.MAX_VALUE : ((Number) to).doubleValue()
+                    );
+                }
+
+                for (AbstractAggregationBuilder subAgg : getElasticsearchAggregations(agg.getNestedAggregations())) {
+                    rangeBuilder.subAggregation(subAgg);
+                }
+
+                aggs.add(rangeBuilder);
+            }
+        }
+        return aggs;
+    }
+
+    protected PropertyDefinition getPropertyDefinition(String propertyName) {
+        return getGraph().getPropertyDefinition(propertyName);
+    }
+
+    protected IndexSelectionStrategy getIndexSelectionStrategy() {
+        return indexSelectionStrategy;
+    }
+
+    public String getAggregationName(String name) {
+        return getSearchIndex().getAggregationName(name);
+    }
+
+    @Override
+    public String toString() {
+        return this.getClass().getName() + "{" +
+                "parameters=" + getParameters() +
+                ", evaluateHasContainers=" + evaluateHasContainers +
+                ", evaluateQueryString=" + evaluateQueryString +
+                ", evaluateSortContainers=" + evaluateSortContainers +
+                ", pageSize=" + pageSize +
+                '}';
+    }
+
+    private static class Ids {
+        private final List<String> vertexIds;
+        private final List<String> edgeIds;
+        private final List<String> ids;
+        private final List<ExtendedDataRowId> extendedDataIds;
+
+        public Ids(SearchHits hits) {
+            vertexIds = new ArrayList<>();
+            edgeIds = new ArrayList<>();
+            extendedDataIds = new ArrayList<>();
+            ids = new ArrayList<>();
+            for (SearchHit hit : hits) {
+                ElasticsearchDocumentType dt = ElasticsearchDocumentType.fromSearchHit(hit);
+                if (dt == null) {
+                    continue;
+                }
+                String id = hit.getId();
+                switch (dt) {
+                    case VERTEX:
+                        ids.add(id);
+                        vertexIds.add(id);
+                        break;
+                    case EDGE:
+                        ids.add(id);
+                        edgeIds.add(id);
+                        break;
+                    case VERTEX_EXTENDED_DATA:
+                    case EDGE_EXTENDED_DATA:
+                        ids.add(id);
+                        extendedDataIds.add(ElasticsearchExtendedDataIdUtils.fromSearchHit(hit));
+                        break;
+                    default:
+                        LOGGER.warn("Unhandled document type: %s", dt);
+                        break;
+                }
+            }
+        }
+
+        public List<String> getVertexIds() {
+            return vertexIds;
+        }
+
+        public List<String> getEdgeIds() {
+            return edgeIds;
+        }
+
+        public List<String> getIds() {
+            return ids;
+        }
+
+        public List<ExtendedDataRowId> getExtendedDataIds() {
+            return extendedDataIds;
+        }
+    }
+}
+

--- a/elasticsearch2/src/main/java/org/vertexium/elasticsearch2/ElasticsearchSearchVertexQuery.java
+++ b/elasticsearch2/src/main/java/org/vertexium/elasticsearch2/ElasticsearchSearchVertexQuery.java
@@ -1,0 +1,99 @@
+package org.vertexium.elasticsearch2;
+
+import org.elasticsearch.client.Client;
+import org.elasticsearch.index.query.QueryBuilder;
+import org.elasticsearch.index.query.QueryBuilders;
+import org.vertexium.Authorizations;
+import org.vertexium.Direction;
+import org.vertexium.Graph;
+import org.vertexium.Vertex;
+import org.vertexium.elasticsearch2.score.ScoringStrategy;
+import org.vertexium.query.VertexQuery;
+
+import java.util.ArrayList;
+import java.util.EnumSet;
+import java.util.List;
+
+import static org.vertexium.util.IterableUtils.toArray;
+
+public class ElasticsearchSearchVertexQuery extends ElasticsearchSearchQueryBase implements VertexQuery {
+    private final Vertex sourceVertex;
+
+    public ElasticsearchSearchVertexQuery(
+            Client client,
+            Graph graph,
+            Vertex sourceVertex,
+            String queryString,
+            ScoringStrategy scoringStrategy,
+            IndexSelectionStrategy indexSelectionStrategy,
+            int pageSize,
+            Authorizations authorizations
+    ) {
+        super(client, graph, queryString, scoringStrategy, indexSelectionStrategy, pageSize, authorizations);
+        this.sourceVertex = sourceVertex;
+    }
+
+    @Override
+    protected List<QueryBuilder> getFilters(EnumSet<ElasticsearchDocumentType> elementTypes) {
+        List<QueryBuilder> filters = super.getFilters(elementTypes);
+
+        List<QueryBuilder> relatedFilters = new ArrayList<>();
+
+        if (elementTypes.contains(ElasticsearchDocumentType.VERTEX)
+                || elementTypes.contains(ElasticsearchDocumentType.VERTEX_EXTENDED_DATA)) {
+            relatedFilters.add(getVertexFilter(elementTypes));
+        }
+
+        if (elementTypes.contains(ElasticsearchDocumentType.EDGE)
+                || elementTypes.contains(ElasticsearchDocumentType.EDGE_EXTENDED_DATA)) {
+            relatedFilters.add(getEdgeFilter());
+        }
+
+        filters.add(orFilters(relatedFilters));
+
+        return filters;
+    }
+
+    private QueryBuilder getEdgeFilter() {
+        QueryBuilder inVertexIdFilter = QueryBuilders.termQuery(Elasticsearch2SearchIndex.IN_VERTEX_ID_FIELD_NAME, sourceVertex.getId());
+        QueryBuilder outVertexIdFilter = QueryBuilders.termQuery(Elasticsearch2SearchIndex.OUT_VERTEX_ID_FIELD_NAME, sourceVertex.getId());
+        return QueryBuilders.orQuery(inVertexIdFilter, outVertexIdFilter);
+    }
+
+    private QueryBuilder getVertexFilter(EnumSet<ElasticsearchDocumentType> elementTypes) {
+        List<QueryBuilder> filters = new ArrayList<>();
+        List<String> edgeLabels = getParameters().getEdgeLabels();
+        String[] edgeLabelsArray = edgeLabels == null || edgeLabels.size() == 0
+                ? null
+                : edgeLabels.toArray(new String[edgeLabels.size()]);
+        Iterable<String> vertexIds = sourceVertex.getVertexIds(
+                Direction.BOTH,
+                edgeLabelsArray,
+                getParameters().getAuthorizations()
+        );
+        String[] ids = toArray(vertexIds, String.class);
+
+        if (elementTypes.contains(ElasticsearchDocumentType.VERTEX)) {
+            filters.add(QueryBuilders.idsQuery().ids(ids));
+        }
+
+        if (elementTypes.contains(ElasticsearchDocumentType.VERTEX_EXTENDED_DATA)) {
+            for (String vertexId : ids) {
+                filters.add(QueryBuilders.andQuery(
+                        QueryBuilders.termQuery(Elasticsearch2SearchIndex.ELEMENT_TYPE_FIELD_NAME, ElasticsearchDocumentType.VERTEX_EXTENDED_DATA.getKey()),
+                        QueryBuilders.termQuery(Elasticsearch2SearchIndex.EXTENDED_DATA_ELEMENT_ID_FIELD_NAME, vertexId)
+                ));
+            }
+        }
+
+        return orFilters(filters);
+    }
+
+    private QueryBuilder orFilters(List<QueryBuilder> filters) {
+        if (filters.size() == 1) {
+            return filters.get(0);
+        } else {
+            return QueryBuilders.orQuery(filters.toArray(new QueryBuilder[filters.size()]));
+        }
+    }
+}

--- a/elasticsearch2/src/main/java/org/vertexium/elasticsearch2/EmptyElasticsearchGraphQueryIterable.java
+++ b/elasticsearch2/src/main/java/org/vertexium/elasticsearch2/EmptyElasticsearchGraphQueryIterable.java
@@ -1,0 +1,12 @@
+package org.vertexium.elasticsearch2;
+
+import org.vertexium.VertexiumObject;
+import org.vertexium.query.QueryParameters;
+
+import java.util.ArrayList;
+
+public class EmptyElasticsearchGraphQueryIterable<T extends VertexiumObject> extends ElasticsearchGraphQueryIterable<T> {
+    public EmptyElasticsearchGraphQueryIterable(ElasticsearchSearchQueryBase query, QueryParameters parameters) {
+        super(query, null, parameters, new ArrayList<T>(), false, false, false, 0, 0, null);
+    }
+}

--- a/elasticsearch2/src/main/java/org/vertexium/elasticsearch2/GeohashUtils.java
+++ b/elasticsearch2/src/main/java/org/vertexium/elasticsearch2/GeohashUtils.java
@@ -1,0 +1,115 @@
+package org.vertexium.elasticsearch2;
+
+import org.vertexium.VertexiumException;
+
+class GeohashUtils {
+    private static final int[] BITS = {16, 8, 4, 2, 1};
+
+    public static void decodeCell(String key, org.elasticsearch.common.geo.GeoPoint northWest, org.elasticsearch.common.geo.GeoPoint southEast) {
+        try {
+            double[] interval = decodeCell(key);
+            northWest.reset(interval[1], interval[2]);
+            southEast.reset(interval[0], interval[3]);
+        } catch (Exception e) {
+            throw new VertexiumException("Could not decode cell", e);
+        }
+    }
+
+    private static double[] decodeCell(String geohash) {
+        double[] interval = {-90.0, 90.0, -180.0, 180.0};
+        boolean isEven = true;
+
+        for (int i = 0; i < geohash.length(); i++) {
+            final int cd = decode(geohash.charAt(i));
+
+            for (int mask : BITS) {
+                if (isEven) {
+                    if ((cd & mask) != 0) {
+                        interval[2] = (interval[2] + interval[3]) / 2D;
+                    } else {
+                        interval[3] = (interval[2] + interval[3]) / 2D;
+                    }
+                } else {
+                    if ((cd & mask) != 0) {
+                        interval[0] = (interval[0] + interval[1]) / 2D;
+                    } else {
+                        interval[1] = (interval[0] + interval[1]) / 2D;
+                    }
+                }
+                isEven = !isEven;
+            }
+        }
+        return interval;
+    }
+
+    private static int decode(char geo) {
+        switch (geo) {
+            case '0':
+                return 0;
+            case '1':
+                return 1;
+            case '2':
+                return 2;
+            case '3':
+                return 3;
+            case '4':
+                return 4;
+            case '5':
+                return 5;
+            case '6':
+                return 6;
+            case '7':
+                return 7;
+            case '8':
+                return 8;
+            case '9':
+                return 9;
+            case 'b':
+                return 10;
+            case 'c':
+                return 11;
+            case 'd':
+                return 12;
+            case 'e':
+                return 13;
+            case 'f':
+                return 14;
+            case 'g':
+                return 15;
+            case 'h':
+                return 16;
+            case 'j':
+                return 17;
+            case 'k':
+                return 18;
+            case 'm':
+                return 19;
+            case 'n':
+                return 20;
+            case 'p':
+                return 21;
+            case 'q':
+                return 22;
+            case 'r':
+                return 23;
+            case 's':
+                return 24;
+            case 't':
+                return 25;
+            case 'u':
+                return 26;
+            case 'v':
+                return 27;
+            case 'w':
+                return 28;
+            case 'x':
+                return 29;
+            case 'y':
+                return 30;
+            case 'z':
+                return 31;
+            default:
+                throw new VertexiumException("the character '" + geo + "' is not a valid geohash character");
+        }
+    }
+}

--- a/elasticsearch2/src/main/java/org/vertexium/elasticsearch2/IndexInfo.java
+++ b/elasticsearch2/src/main/java/org/vertexium/elasticsearch2/IndexInfo.java
@@ -1,0 +1,78 @@
+package org.vertexium.elasticsearch2;
+
+import org.vertexium.Visibility;
+
+import java.util.HashMap;
+import java.util.HashSet;
+import java.util.Map;
+import java.util.Set;
+
+public class IndexInfo {
+    private final String indexName;
+    private boolean elementTypeDefined;
+    private Map<String, PropertyInfo> propertyInfos = new HashMap<>();
+
+    public IndexInfo(String indexName) {
+        this.indexName = indexName;
+    }
+
+    public String getIndexName() {
+        return indexName;
+    }
+
+    @Override
+    public int hashCode() {
+        return getIndexName().hashCode();
+    }
+
+    @Override
+    public boolean equals(Object obj) {
+        if (!(obj instanceof IndexInfo)) {
+            return false;
+        }
+        IndexInfo otherIndexInfo = (IndexInfo) obj;
+        return getIndexName().equals(otherIndexInfo.getIndexName());
+    }
+
+    public boolean isElementTypeDefined() {
+        return elementTypeDefined;
+    }
+
+    public void setElementTypeDefined(boolean elementTypeDefined) {
+        this.elementTypeDefined = elementTypeDefined;
+    }
+
+    public void addPropertyNameVisibility(String propertyName, Visibility visibility) {
+        PropertyInfo propertyInfo = propertyInfos.get(propertyName);
+        if (propertyInfo == null) {
+            propertyInfo = new PropertyInfo();
+            propertyInfos.put(propertyName, propertyInfo);
+        }
+        propertyInfo.addVisibility(visibility);
+    }
+
+    public boolean isPropertyDefined(String propertyName, Visibility visibility) {
+        PropertyInfo propertyInfo = propertyInfos.get(propertyName);
+        if (propertyInfo == null) {
+            return false;
+        }
+        return propertyInfo.hasVisibility(visibility);
+    }
+
+    public boolean isPropertyDefined(String propertyName) {
+        PropertyInfo propertyInfo = propertyInfos.get(propertyName);
+        return propertyInfo != null;
+    }
+
+    private static class PropertyInfo {
+        private Set<Visibility> visibilities = new HashSet<>();
+
+        public void addVisibility(Visibility visibility) {
+            visibilities.add(visibility);
+        }
+
+        public boolean hasVisibility(Visibility visibility) {
+            return visibilities.contains(visibility);
+        }
+    }
+}

--- a/elasticsearch2/src/main/java/org/vertexium/elasticsearch2/IndexSelectionStrategy.java
+++ b/elasticsearch2/src/main/java/org/vertexium/elasticsearch2/IndexSelectionStrategy.java
@@ -1,0 +1,25 @@
+package org.vertexium.elasticsearch2;
+
+import org.vertexium.Element;
+import org.vertexium.ExtendedDataRowId;
+import org.vertexium.PropertyDefinition;
+
+import java.util.EnumSet;
+
+public interface IndexSelectionStrategy {
+    String[] getIndicesToQuery(Elasticsearch2SearchIndex es);
+
+    String getIndexName(Elasticsearch2SearchIndex es, Element element);
+
+    String[] getIndexNames(Elasticsearch2SearchIndex es, PropertyDefinition propertyDefinition);
+
+    boolean isIncluded(Elasticsearch2SearchIndex es, String indexName);
+
+    String[] getManagedIndexNames(Elasticsearch2SearchIndex es);
+
+    String[] getIndicesToQuery(ElasticsearchSearchQueryBase query, EnumSet<ElasticsearchDocumentType> elementType);
+
+    String getExtendedDataIndexName(Elasticsearch2SearchIndex es, Element element, String tableName, String rowId);
+
+    String getExtendedDataIndexName(Elasticsearch2SearchIndex es, ExtendedDataRowId rowId);
+}

--- a/elasticsearch2/src/main/java/org/vertexium/elasticsearch2/MetadataTablePropertyNameVisibilitiesStore.java
+++ b/elasticsearch2/src/main/java/org/vertexium/elasticsearch2/MetadataTablePropertyNameVisibilitiesStore.java
@@ -1,0 +1,88 @@
+package org.vertexium.elasticsearch2;
+
+import com.google.common.hash.Hashing;
+import org.vertexium.Authorizations;
+import org.vertexium.Graph;
+import org.vertexium.GraphMetadataEntry;
+import org.vertexium.Visibility;
+import org.vertexium.util.VertexiumLogger;
+import org.vertexium.util.VertexiumLoggerFactory;
+
+import java.nio.charset.Charset;
+import java.util.*;
+
+public class MetadataTablePropertyNameVisibilitiesStore extends PropertyNameVisibilitiesStore {
+    private static final VertexiumLogger LOGGER = VertexiumLoggerFactory.getLogger(MetadataTablePropertyNameVisibilitiesStore.class);
+    public static final String PROPERTY_NAME_VISIBILITY_TO_HASH_PREFIX = "propertyNameVisibility.";
+    public static final String HASH_TO_VISIBILITY = "visibilityHash.";
+    private static final Charset UTF8 = Charset.forName("utf8");
+    private Map<String, Visibility> visibilityCache = new HashMap<>();
+
+    public Collection<String> getHashes(Graph graph, String propertyName, Authorizations authorizations) {
+        List<String> results = new ArrayList<>();
+        String prefix = getPropertyNameVisibilityToHashPrefix(propertyName);
+        for (GraphMetadataEntry metadata : graph.getMetadataWithPrefix(prefix)) {
+            String visibilityString = metadata.getKey().substring(prefix.length());
+            Visibility visibility = getVisibility(visibilityString);
+            if (authorizations.canRead(visibility)) {
+                String hash = (String) metadata.getValue();
+                results.add(hash);
+            }
+        }
+        return results;
+    }
+
+    private Visibility getVisibility(String visibilityString) {
+        Visibility visibility = visibilityCache.get(visibilityString);
+        if (visibility == null) {
+            visibility = new Visibility(visibilityString);
+            visibilityCache.put(visibilityString, visibility);
+        }
+        return visibility;
+    }
+
+    public String getHash(Graph graph, String propertyName, Visibility visibility) {
+        String visibilityString = visibility.getVisibilityString();
+        String propertyNameVisibilityToHashKey = getMetadataKey(propertyName, visibilityString);
+        String hash = (String) graph.getMetadata(propertyNameVisibilityToHashKey);
+        if (hash != null) {
+            saveHashToVisibility(graph, hash, visibilityString);
+            return hash;
+        }
+
+        hash = Hashing.murmur3_128().hashString(visibilityString, UTF8).toString();
+        graph.setMetadata(propertyNameVisibilityToHashKey, hash);
+        saveHashToVisibility(graph, hash, visibilityString);
+        return hash;
+    }
+
+    private void saveHashToVisibility(Graph graph, String hash, String visibilityString) {
+        String hashToVisibilityKey = getHashToVisibilityKey(hash);
+        String foundVisibilityString = (String) graph.getMetadata(hashToVisibilityKey);
+        if (foundVisibilityString == null) {
+            graph.setMetadata(hashToVisibilityKey, visibilityString);
+        }
+    }
+
+    @Override
+    public Visibility getVisibilityFromHash(Graph graph, String visibilityHash) {
+        String visibilityString = (String) graph.getMetadata(getHashToVisibilityKey(visibilityHash));
+        if (visibilityString == null) {
+            LOGGER.warn("Could not find visibility matching the hash \"%s\" in the metadata table.", visibilityHash);
+            return null;
+        }
+        return new Visibility(visibilityString);
+    }
+
+    private String getHashToVisibilityKey(String visibilityHash) {
+        return HASH_TO_VISIBILITY + visibilityHash;
+    }
+
+    private String getPropertyNameVisibilityToHashPrefix(String propertyName) {
+        return PROPERTY_NAME_VISIBILITY_TO_HASH_PREFIX + propertyName + ".";
+    }
+
+    private String getMetadataKey(String propertyName, String visibilityString) {
+        return getPropertyNameVisibilityToHashPrefix(propertyName) + visibilityString;
+    }
+}

--- a/elasticsearch2/src/main/java/org/vertexium/elasticsearch2/PropertyNameVisibilitiesStore.java
+++ b/elasticsearch2/src/main/java/org/vertexium/elasticsearch2/PropertyNameVisibilitiesStore.java
@@ -1,0 +1,15 @@
+package org.vertexium.elasticsearch2;
+
+import org.vertexium.Authorizations;
+import org.vertexium.Graph;
+import org.vertexium.Visibility;
+
+import java.util.Collection;
+
+public abstract class PropertyNameVisibilitiesStore {
+    public abstract Collection<String> getHashes(Graph graph, String propertyName, Authorizations authorizations);
+
+    public abstract String getHash(Graph graph, String propertyName, Visibility visibility);
+
+    public abstract Visibility getVisibilityFromHash(Graph graph, String visibilityHash);
+}

--- a/elasticsearch2/src/main/java/org/vertexium/elasticsearch2/VertexiumNoMatchingPropertiesException.java
+++ b/elasticsearch2/src/main/java/org/vertexium/elasticsearch2/VertexiumNoMatchingPropertiesException.java
@@ -1,0 +1,16 @@
+package org.vertexium.elasticsearch2;
+
+import org.vertexium.VertexiumException;
+
+public class VertexiumNoMatchingPropertiesException extends VertexiumException {
+    private String propertyName;
+
+    public VertexiumNoMatchingPropertiesException(String propertyName) {
+        super("Could not find matching property name: " + propertyName);
+        this.propertyName = propertyName;
+    }
+
+    public String getPropertyName() {
+        return propertyName;
+    }
+}

--- a/elasticsearch2/src/main/java/org/vertexium/elasticsearch2/VertexiumQueryStringQueryBuilder.java
+++ b/elasticsearch2/src/main/java/org/vertexium/elasticsearch2/VertexiumQueryStringQueryBuilder.java
@@ -1,0 +1,36 @@
+package org.vertexium.elasticsearch2;
+
+import org.elasticsearch.common.xcontent.ToXContent;
+import org.elasticsearch.common.xcontent.XContentBuilder;
+import org.elasticsearch.index.query.QueryBuilder;
+import org.vertexium.Authorizations;
+
+import java.io.IOException;
+
+public class VertexiumQueryStringQueryBuilder extends QueryBuilder {
+    private final String queryString;
+    private final Authorizations authorizations;
+
+    private VertexiumQueryStringQueryBuilder(String queryString, Authorizations authorizations) {
+        this.queryString = queryString;
+        this.authorizations = authorizations;
+    }
+
+    public static VertexiumQueryStringQueryBuilder build(String queryString, Authorizations authorizations) {
+        return new VertexiumQueryStringQueryBuilder(queryString, authorizations);
+    }
+
+    @Override
+    protected void doXContent(XContentBuilder builder, ToXContent.Params params) throws IOException {
+        builder.startObject("vertexium_query_string");
+        builder.field("query", queryString);
+
+        builder.startArray("authorizations");
+        for (String authorization : authorizations.getAuthorizations()) {
+            builder.value(authorization);
+        }
+        builder.endArray();
+
+        builder.endObject();
+    }
+}

--- a/elasticsearch2/src/main/java/org/vertexium/elasticsearch2/score/EdgeCountScoringStrategy.java
+++ b/elasticsearch2/src/main/java/org/vertexium/elasticsearch2/score/EdgeCountScoringStrategy.java
@@ -1,0 +1,148 @@
+package org.vertexium.elasticsearch2.score;
+
+import com.google.common.collect.ImmutableMap;
+import org.elasticsearch.action.bulk.BulkRequest;
+import org.elasticsearch.action.get.GetResponse;
+import org.elasticsearch.common.xcontent.XContentBuilder;
+import org.elasticsearch.index.query.QueryBuilder;
+import org.elasticsearch.index.query.QueryBuilders;
+import org.elasticsearch.index.query.functionscore.ScoreFunctionBuilder;
+import org.elasticsearch.index.query.functionscore.ScoreFunctionBuilders;
+import org.elasticsearch.script.Script;
+import org.elasticsearch.script.ScriptService;
+import org.vertexium.*;
+import org.vertexium.elasticsearch2.Elasticsearch2SearchIndex;
+import org.vertexium.elasticsearch2.IndexInfo;
+import org.vertexium.elasticsearch2.utils.GetResponseUtil;
+import org.vertexium.search.SearchIndex;
+
+import java.io.IOException;
+import java.util.List;
+
+public class EdgeCountScoringStrategy extends ScoringStrategy {
+    private final EdgeCountScoringStrategyConfiguration config;
+
+    public EdgeCountScoringStrategy(GraphConfiguration config) {
+        super(config);
+        this.config = new EdgeCountScoringStrategyConfiguration(config);
+    }
+
+    public EdgeCountScoringStrategyConfiguration getConfig() {
+        return config;
+    }
+
+    @Override
+    public void addElement(SearchIndex searchIndex, Graph graph, Element element, Authorizations authorizations) {
+        if (!getConfig().isUpdateEdgeBoost()) {
+            return;
+        }
+        if (!(element instanceof Edge)) {
+            return;
+        }
+
+        Element vOut = ((Edge) element).getVertex(Direction.OUT, authorizations);
+        if (vOut != null) {
+            searchIndex.addElement(graph, vOut, authorizations);
+        }
+
+        Element vIn = ((Edge) element).getVertex(Direction.IN, authorizations);
+        if (vIn != null) {
+            searchIndex.addElement(graph, vIn, authorizations);
+        }
+    }
+
+    @Override
+    public int addElement(Elasticsearch2SearchIndex searchIndex, Graph graph, BulkRequest bulkRequest, IndexInfo indexInfo, Element element, Authorizations authorizations) {
+        int totalCount = 0;
+
+        if (!getConfig().isUpdateEdgeBoost()) {
+            return totalCount;
+        }
+        if (!(element instanceof Edge)) {
+            return totalCount;
+        }
+
+        Element vOut = ((Edge) element).getVertex(Direction.OUT, authorizations);
+        if (vOut != null) {
+            searchIndex.addElementToBulkRequest(graph, bulkRequest, indexInfo, vOut, authorizations);
+            totalCount++;
+        }
+
+        Element vIn = ((Edge) element).getVertex(Direction.IN, authorizations);
+        if (vIn != null) {
+            searchIndex.addElementToBulkRequest(graph, bulkRequest, indexInfo, vIn, authorizations);
+            totalCount++;
+        }
+
+        return totalCount;
+    }
+
+    @Override
+    public void addFieldsToElementType(XContentBuilder builder) throws IOException {
+        builder
+                .startObject(EdgeCountScoringStrategyConfiguration.IN_EDGE_COUNT_FIELD_NAME).field("type", "integer").field("store", "true").endObject()
+                .startObject(EdgeCountScoringStrategyConfiguration.OUT_EDGE_COUNT_FIELD_NAME).field("type", "integer").field("store", "true").endObject()
+        ;
+    }
+
+    @Override
+    public List<String> getFieldNames() {
+        List<String> fieldNames = super.getFieldNames();
+        fieldNames.add(EdgeCountScoringStrategyConfiguration.IN_EDGE_COUNT_FIELD_NAME);
+        fieldNames.add(EdgeCountScoringStrategyConfiguration.OUT_EDGE_COUNT_FIELD_NAME);
+        return fieldNames;
+    }
+
+    @Override
+    public QueryBuilder updateQuery(QueryBuilder query) {
+        if (!getConfig().isUseEdgeBoost()) {
+            return query;
+        }
+
+        Script script = new Script(
+                getConfig().getScoreFormula(),
+                ScriptService.ScriptType.INLINE,
+                null,
+                ImmutableMap.of(
+                        "inEdgeMultiplier", getConfig().getInEdgeBoost(),
+                        "outEdgeMultiplier", getConfig().getOutEdgeBoost()
+                ));
+        ScoreFunctionBuilder scoreFunction = ScoreFunctionBuilders.scriptFunction(script);
+
+        return QueryBuilders.functionScoreQuery(query, scoreFunction);
+    }
+
+    @Override
+    public boolean addFieldsToVertexDocument(SearchIndex searchIndex, XContentBuilder jsonBuilder, Vertex vertex, GetResponse existingDocument, Authorizations authorizations) throws IOException {
+        if (existingDocument != null && !getConfig().isUpdateEdgeBoost()) {
+            return false;
+        }
+
+        boolean changed = false;
+
+        int inEdgeCount = vertex.getEdgeCount(Direction.IN, authorizations);
+        Long existingInEdgeCount = existingDocument == null ? null : GetResponseUtil.getFieldValueLong(existingDocument, EdgeCountScoringStrategyConfiguration.IN_EDGE_COUNT_FIELD_NAME);
+        if (existingInEdgeCount == null || existingInEdgeCount.intValue() != inEdgeCount) {
+            jsonBuilder.field(EdgeCountScoringStrategyConfiguration.IN_EDGE_COUNT_FIELD_NAME, inEdgeCount);
+            changed = true;
+        } else {
+            jsonBuilder.field(EdgeCountScoringStrategyConfiguration.IN_EDGE_COUNT_FIELD_NAME, existingInEdgeCount.intValue());
+        }
+
+        int outEdgeCount = vertex.getEdgeCount(Direction.OUT, authorizations);
+        Long existingOutEdgeCount = existingDocument == null ? null : GetResponseUtil.getFieldValueLong(existingDocument, EdgeCountScoringStrategyConfiguration.OUT_EDGE_COUNT_FIELD_NAME);
+        if (existingOutEdgeCount == null || existingOutEdgeCount.intValue() != outEdgeCount) {
+            jsonBuilder.field(EdgeCountScoringStrategyConfiguration.OUT_EDGE_COUNT_FIELD_NAME, outEdgeCount);
+            changed = true;
+        } else {
+            jsonBuilder.field(EdgeCountScoringStrategyConfiguration.OUT_EDGE_COUNT_FIELD_NAME, existingOutEdgeCount.intValue());
+        }
+
+        return changed;
+    }
+
+    @Override
+    public boolean addFieldsToEdgeDocument(SearchIndex searchIndex, XContentBuilder jsonBuilder, Edge edge, GetResponse existingDocument, Authorizations authorizations) throws IOException {
+        return false;
+    }
+}

--- a/elasticsearch2/src/main/java/org/vertexium/elasticsearch2/score/EdgeCountScoringStrategyConfiguration.java
+++ b/elasticsearch2/src/main/java/org/vertexium/elasticsearch2/score/EdgeCountScoringStrategyConfiguration.java
@@ -1,0 +1,90 @@
+package org.vertexium.elasticsearch2.score;
+
+import org.vertexium.GraphConfiguration;
+import org.vertexium.util.VertexiumLogger;
+import org.vertexium.util.VertexiumLoggerFactory;
+
+public class EdgeCountScoringStrategyConfiguration {
+    private static final VertexiumLogger LOGGER = VertexiumLoggerFactory.getLogger(EdgeCountScoringStrategyConfiguration.class);
+    public static final String IN_EDGE_COUNT_FIELD_NAME = "__inEdgeCount";
+    public static final String OUT_EDGE_COUNT_FIELD_NAME = "__outEdgeCount";
+    public static final String CONFIG_USE_EDGE_BOOST = "useEdgeBoost";
+    public static final boolean DEFAULT_USE_EDGE_BOOST = true;
+    public static final String CONFIG_UPDATE_EDGE_BOOST = "updateEdgeBoost";
+    public static final boolean DEFAULT_UPDATE_EDGE_BOOST = true;
+    public static final String CONFIG_IN_EDGE_BOOST = "inEdgeBoost";
+    public static final double DEFAULT_IN_EDGE_BOOST = 1.2;
+    public static final String CONFIG_OUT_EDGE_BOOST = "outEdgeBoost";
+    public static final double DEFAULT_OUT_EDGE_BOOST = 1.1;
+    public static final String CONFIG_SCORE_FORMULA = "formula";
+    public static final String DEFAULT_SCORE_FORMULA = "_score " +
+            " * sqrt( " +
+            "    1" +
+            "    + (inEdgeMultiplier * doc['" + IN_EDGE_COUNT_FIELD_NAME + "'].value) " +
+            "    + (outEdgeMultiplier * doc['" + OUT_EDGE_COUNT_FIELD_NAME + "'].value) " +
+            "   )";
+
+    private final boolean useEdgeBoost;
+    private final boolean updateEdgeBoost;
+    private final double inEdgeBoost;
+    private final double outEdgeBoost;
+    private final String scoreFormula;
+
+    public EdgeCountScoringStrategyConfiguration(GraphConfiguration config) {
+        useEdgeBoost = getUseEdgeBoost(config);
+        updateEdgeBoost = getUpdateEdgeBoost(config);
+        inEdgeBoost = getInEdgeBoost(config);
+        outEdgeBoost = getOutEdgeBoost(config);
+        scoreFormula = getScoreFormula(config);
+    }
+
+    public boolean isUseEdgeBoost() {
+        return useEdgeBoost;
+    }
+
+    public boolean isUpdateEdgeBoost() {
+        return isUseEdgeBoost() && updateEdgeBoost;
+    }
+
+    public double getInEdgeBoost() {
+        return inEdgeBoost;
+    }
+
+    public double getOutEdgeBoost() {
+        return outEdgeBoost;
+    }
+
+    public String getScoreFormula() {
+        return scoreFormula;
+    }
+
+    private static boolean getUseEdgeBoost(GraphConfiguration config) {
+        boolean useEdgeBoost = config.getBoolean(GraphConfiguration.SEARCH_INDEX_PROP_PREFIX + "." + CONFIG_USE_EDGE_BOOST, DEFAULT_USE_EDGE_BOOST);
+        LOGGER.info("Use edge boost: %b", useEdgeBoost);
+        return useEdgeBoost;
+    }
+
+    private static boolean getUpdateEdgeBoost(GraphConfiguration config) {
+        boolean updateEdgeBoost = config.getBoolean(GraphConfiguration.SEARCH_INDEX_PROP_PREFIX + "." + CONFIG_UPDATE_EDGE_BOOST, DEFAULT_UPDATE_EDGE_BOOST);
+        LOGGER.info("Update edge boost: %b", updateEdgeBoost);
+        return updateEdgeBoost;
+    }
+
+    private static double getOutEdgeBoost(GraphConfiguration config) {
+        double outEdgeBoost = config.getDouble(GraphConfiguration.SEARCH_INDEX_PROP_PREFIX + "." + CONFIG_OUT_EDGE_BOOST, DEFAULT_OUT_EDGE_BOOST);
+        LOGGER.info("Out Edge Boost: %f", outEdgeBoost);
+        return outEdgeBoost;
+    }
+
+    private static double getInEdgeBoost(GraphConfiguration config) {
+        double inEdgeBoost = config.getDouble(GraphConfiguration.SEARCH_INDEX_PROP_PREFIX + "." + CONFIG_IN_EDGE_BOOST, DEFAULT_IN_EDGE_BOOST);
+        LOGGER.info("In Edge Boost: %f", inEdgeBoost);
+        return inEdgeBoost;
+    }
+
+    private static String getScoreFormula(GraphConfiguration config) {
+        String scoreFormula = config.getString(GraphConfiguration.SEARCH_INDEX_PROP_PREFIX + "." + CONFIG_SCORE_FORMULA, DEFAULT_SCORE_FORMULA);
+        LOGGER.info("Score formula: %s", scoreFormula);
+        return scoreFormula;
+    }
+}

--- a/elasticsearch2/src/main/java/org/vertexium/elasticsearch2/score/NopScoringStrategy.java
+++ b/elasticsearch2/src/main/java/org/vertexium/elasticsearch2/score/NopScoringStrategy.java
@@ -1,0 +1,48 @@
+package org.vertexium.elasticsearch2.score;
+
+import org.elasticsearch.action.bulk.BulkRequest;
+import org.elasticsearch.action.get.GetResponse;
+import org.elasticsearch.common.xcontent.XContentBuilder;
+import org.elasticsearch.index.query.QueryBuilder;
+import org.vertexium.*;
+import org.vertexium.elasticsearch2.Elasticsearch2SearchIndex;
+import org.vertexium.elasticsearch2.IndexInfo;
+import org.vertexium.search.SearchIndex;
+
+import java.io.IOException;
+
+public class NopScoringStrategy extends ScoringStrategy {
+    public NopScoringStrategy(GraphConfiguration graphConfiguration) {
+        super(graphConfiguration);
+    }
+
+    @Override
+    public void addElement(SearchIndex searchIndex, Graph graph, Element element, Authorizations authorizations) {
+
+    }
+
+    @Override
+    public boolean addFieldsToVertexDocument(SearchIndex searchIndex, XContentBuilder jsonBuilder, Vertex vertex, GetResponse existingDocument, Authorizations authorizations) throws IOException {
+        return false;
+    }
+
+    @Override
+    public boolean addFieldsToEdgeDocument(SearchIndex searchIndex, XContentBuilder jsonBuilder, Edge edge, GetResponse existingDocument, Authorizations authorizations) throws IOException {
+        return false;
+    }
+
+    @Override
+    public int addElement(Elasticsearch2SearchIndex searchIndex, Graph graph, BulkRequest bulkRequest, IndexInfo indexInfo, Element element, Authorizations authorizations) {
+        return 0;
+    }
+
+    @Override
+    public void addFieldsToElementType(XContentBuilder builder) throws IOException {
+
+    }
+
+    @Override
+    public QueryBuilder updateQuery(QueryBuilder query) {
+        return query;
+    }
+}

--- a/elasticsearch2/src/main/java/org/vertexium/elasticsearch2/score/ScoringStrategy.java
+++ b/elasticsearch2/src/main/java/org/vertexium/elasticsearch2/score/ScoringStrategy.java
@@ -1,0 +1,51 @@
+package org.vertexium.elasticsearch2.score;
+
+import org.elasticsearch.action.bulk.BulkRequest;
+import org.elasticsearch.action.get.GetResponse;
+import org.elasticsearch.common.xcontent.XContentBuilder;
+import org.elasticsearch.index.query.QueryBuilder;
+import org.vertexium.*;
+import org.vertexium.elasticsearch2.Elasticsearch2SearchIndex;
+import org.vertexium.elasticsearch2.IndexInfo;
+import org.vertexium.mutation.ExtendedDataMutation;
+import org.vertexium.search.SearchIndex;
+
+import java.io.IOException;
+import java.util.ArrayList;
+import java.util.List;
+
+public abstract class ScoringStrategy {
+    private final GraphConfiguration graphConfiguration;
+
+    protected ScoringStrategy(GraphConfiguration graphConfiguration) {
+        this.graphConfiguration = graphConfiguration;
+    }
+
+    protected GraphConfiguration getGraphConfiguration() {
+        return graphConfiguration;
+    }
+
+    public abstract void addElement(SearchIndex searchIndex, Graph graph, Element element, Authorizations authorizations);
+
+    public abstract boolean addFieldsToVertexDocument(SearchIndex searchIndex, XContentBuilder jsonBuilder, Vertex vertex, GetResponse existingDocument, Authorizations authorizations) throws IOException;
+
+    public abstract boolean addFieldsToEdgeDocument(SearchIndex searchIndex, XContentBuilder jsonBuilder, Edge edge, GetResponse existingDocument, Authorizations authorizations) throws IOException;
+
+    public abstract int addElement(Elasticsearch2SearchIndex searchIndex, Graph graph, BulkRequest bulkRequest, IndexInfo indexInfo, Element element, Authorizations authorizations);
+
+    public abstract void addFieldsToElementType(XContentBuilder builder) throws IOException;
+
+    public abstract QueryBuilder updateQuery(QueryBuilder query);
+
+    public List<String> getFieldNames() {
+        return new ArrayList<>();
+    }
+
+    public void addElementExtendedData(Elasticsearch2SearchIndex searchIndex, Graph graph, Element element, String tableName, String rowId, List<ExtendedDataMutation> columns, Authorizations authorizations) {
+
+    }
+
+    public void addFieldsToExtendedDataDocument(Elasticsearch2SearchIndex searchIndex, XContentBuilder jsonBuilder, Element element, Object o, String tableName, String rowId, List<ExtendedDataMutation> columns, Authorizations authorizations) {
+
+    }
+}

--- a/elasticsearch2/src/main/java/org/vertexium/elasticsearch2/utils/ElasticsearchDocIdUtils.java
+++ b/elasticsearch2/src/main/java/org/vertexium/elasticsearch2/utils/ElasticsearchDocIdUtils.java
@@ -1,0 +1,24 @@
+package org.vertexium.elasticsearch2.utils;
+
+import org.elasticsearch.search.SearchHit;
+import org.vertexium.VertexiumException;
+import org.vertexium.elasticsearch2.ElasticsearchDocumentType;
+
+public class ElasticsearchDocIdUtils {
+    public static Object fromSearchHit(SearchHit searchHit) {
+        ElasticsearchDocumentType dt = ElasticsearchDocumentType.fromSearchHit(searchHit);
+        if (dt == null) {
+            return null;
+        }
+        switch (dt) {
+            case EDGE:
+            case VERTEX:
+                return searchHit.getId();
+            case EDGE_EXTENDED_DATA:
+            case VERTEX_EXTENDED_DATA:
+                return ElasticsearchExtendedDataIdUtils.fromSearchHit(searchHit);
+            default:
+                throw new VertexiumException("Unhandled document type: " + dt);
+        }
+    }
+}

--- a/elasticsearch2/src/main/java/org/vertexium/elasticsearch2/utils/ElasticsearchExtendedDataIdUtils.java
+++ b/elasticsearch2/src/main/java/org/vertexium/elasticsearch2/utils/ElasticsearchExtendedDataIdUtils.java
@@ -1,0 +1,54 @@
+package org.vertexium.elasticsearch2.utils;
+
+import org.elasticsearch.search.SearchHit;
+import org.elasticsearch.search.SearchHitField;
+import org.vertexium.Element;
+import org.vertexium.ElementType;
+import org.vertexium.ExtendedDataRowId;
+import org.vertexium.VertexiumException;
+import org.vertexium.elasticsearch2.Elasticsearch2SearchIndex;
+import org.vertexium.elasticsearch2.ElasticsearchDocumentType;
+
+public class ElasticsearchExtendedDataIdUtils {
+    public static final String SEPARATOR = ":";
+
+    public static String createForElement(Element element, String tableName, String rowId) {
+        return create(element.getId(), tableName, rowId);
+    }
+
+    public static String toDocId(ExtendedDataRowId id) {
+        return create(id.getElementId(), id.getTableName(), id.getRowId());
+    }
+
+    public static String create(String elementId, String tableName, String rowId) {
+        return elementId + SEPARATOR + tableName + SEPARATOR + rowId;
+    }
+
+    public static ExtendedDataRowId fromSearchHit(SearchHit hit) {
+        SearchHitField elementTypeField = hit.getFields().get(Elasticsearch2SearchIndex.ELEMENT_TYPE_FIELD_NAME);
+        if (elementTypeField == null) {
+            throw new VertexiumException("Could not find field: " + Elasticsearch2SearchIndex.ELEMENT_TYPE_FIELD_NAME);
+        }
+        ElementType elementType = ElasticsearchDocumentType.parse(elementTypeField.getValue().toString()).toElementType();
+
+        SearchHitField elementIdField = hit.getFields().get(Elasticsearch2SearchIndex.EXTENDED_DATA_ELEMENT_ID_FIELD_NAME);
+        if (elementIdField == null) {
+            throw new VertexiumException("Could not find field: " + Elasticsearch2SearchIndex.EXTENDED_DATA_ELEMENT_ID_FIELD_NAME);
+        }
+        String elementId = elementIdField.getValue();
+
+        SearchHitField tableNameField = hit.getFields().get(Elasticsearch2SearchIndex.EXTENDED_DATA_TABLE_NAME_FIELD_NAME);
+        if (tableNameField == null) {
+            throw new VertexiumException("Could not find field: " + Elasticsearch2SearchIndex.EXTENDED_DATA_TABLE_NAME_FIELD_NAME);
+        }
+        String tableName = tableNameField.getValue();
+
+        SearchHitField rowIdField = hit.getFields().get(Elasticsearch2SearchIndex.EXTENDED_DATA_TABLE_ROW_ID_FIELD_NAME);
+        if (rowIdField == null) {
+            throw new VertexiumException("Could not find field: " + Elasticsearch2SearchIndex.EXTENDED_DATA_TABLE_ROW_ID_FIELD_NAME);
+        }
+        String rowId = rowIdField.getValue();
+
+        return new ExtendedDataRowId(elementType, elementId, tableName, rowId);
+    }
+}

--- a/elasticsearch2/src/main/java/org/vertexium/elasticsearch2/utils/GetResponseUtil.java
+++ b/elasticsearch2/src/main/java/org/vertexium/elasticsearch2/utils/GetResponseUtil.java
@@ -1,0 +1,26 @@
+package org.vertexium.elasticsearch2.utils;
+
+import org.elasticsearch.action.get.GetResponse;
+import org.elasticsearch.index.get.GetField;
+
+public class GetResponseUtil {
+    public static String getFieldValueString(GetResponse getResponse, String fieldName) {
+        GetField field = getResponse.getField(fieldName);
+        if (field == null) {
+            return null;
+        }
+        return (String) field.getValue();
+    }
+
+    public static Long getFieldValueLong(GetResponse getResponse, String fieldName) {
+        GetField field = getResponse.getField(fieldName);
+        if (field == null) {
+            return null;
+        }
+        Object value = field.getValue();
+        if (value instanceof Integer) {
+            return ((Integer) value).longValue();
+        }
+        return (Long) value;
+    }
+}

--- a/elasticsearch2/src/main/java/org/vertexium/elasticsearch2/utils/PagingIterable.java
+++ b/elasticsearch2/src/main/java/org/vertexium/elasticsearch2/utils/PagingIterable.java
@@ -1,0 +1,166 @@
+package org.vertexium.elasticsearch2.utils;
+
+import org.vertexium.Element;
+import org.vertexium.VertexiumException;
+import org.vertexium.VertexiumObject;
+import org.vertexium.elasticsearch2.ElasticsearchGraphQueryIterable;
+import org.vertexium.query.*;
+
+import java.io.IOException;
+import java.util.Iterator;
+import java.util.Map;
+import java.util.NoSuchElementException;
+
+public abstract class PagingIterable<T extends VertexiumObject> implements
+        Iterable<T>,
+        IterableWithTotalHits<T>,
+        IterableWithScores<T>,
+        IterableWithHistogramResults<T>,
+        IterableWithTermsResults<T>,
+        IterableWithGeohashResults<T>,
+        IterableWithStatisticsResults<T>,
+        QueryResultsIterable<T> {
+    private final long skip;
+    private final Long limit;
+    private boolean isFirstCallToIterator;
+    private final ElasticsearchGraphQueryIterable<T> firstIterable;
+    private final int pageSize;
+
+    public PagingIterable(long skip, Long limit, int pageSize) {
+        this.skip = skip;
+        this.limit = limit;
+        this.pageSize = pageSize;
+
+        // This is a bit of a hack. Because the underlying iterable is the iterable with geohash results, histogram results, etc.
+        //   we need to grab the first iterable to get the results out.
+        int firstIterableLimit = Math.min(pageSize, limit == null ? Integer.MAX_VALUE : limit.intValue());
+        this.firstIterable = getPageIterable((int) this.skip, firstIterableLimit, true);
+        this.isFirstCallToIterator = true;
+    }
+
+    @Override
+    public GeohashResult getGeohashResults(String name) {
+        return this.firstIterable.getGeohashResults(name);
+    }
+
+    @Override
+    public HistogramResult getHistogramResults(String name) {
+        return this.firstIterable.getHistogramResults(name);
+    }
+
+    @Override
+    public StatisticsResult getStatisticsResults(String name) {
+        return this.firstIterable.getStatisticsResults(name);
+    }
+
+    @Override
+    public TermsResult getTermsResults(String name) {
+        return this.firstIterable.getTermsResults(name);
+    }
+
+    @Override
+    public Map<Object, Double> getScores() {
+        return this.firstIterable.getScores();
+    }
+
+    @Override
+    public void close() throws IOException {
+
+    }
+
+    @Override
+    public <TResult extends AggregationResult> TResult getAggregationResult(String name, Class<? extends TResult> resultType) {
+        return this.firstIterable.getAggregationResult(name, resultType);
+    }
+
+    @Override
+    public long getTotalHits() {
+        return this.firstIterable.getTotalHits();
+    }
+
+    protected abstract ElasticsearchGraphQueryIterable<T> getPageIterable(int skip, int limit, boolean includeAggregations);
+
+    @Override
+    public Iterator<T> iterator() {
+        MyIterator<T> it = new MyIterator<>(isFirstCallToIterator ? firstIterable : null, skip, limit, pageSize, new GetPageIterableFunction<T>() {
+            @Override
+            public ElasticsearchGraphQueryIterable<T> getPageIterable(int skip, int limit, boolean includeAggregations) {
+                return PagingIterable.this.getPageIterable(skip, limit, includeAggregations);
+            }
+        });
+        isFirstCallToIterator = false;
+        return it;
+    }
+
+    private interface GetPageIterableFunction<T extends VertexiumObject> {
+        ElasticsearchGraphQueryIterable<T> getPageIterable(int skip, int limit, boolean includeAggregations);
+    }
+
+    private static class MyIterator<T extends VertexiumObject> implements Iterator<T> {
+        private ElasticsearchGraphQueryIterable<T> firstIterable;
+        private final int pageSize;
+        private final GetPageIterableFunction<T> getPageIterableFunction;
+        private int nextSkip;
+        private int limit;
+        private int currentIteratorCount;
+        private Iterator<T> currentIterator;
+
+        public MyIterator(ElasticsearchGraphQueryIterable<T> firstIterable, long skip, Long limit, int pageSize, GetPageIterableFunction<T> getPageIterableFunction) {
+            this.firstIterable = firstIterable;
+            this.pageSize = pageSize;
+            this.getPageIterableFunction = getPageIterableFunction;
+            this.nextSkip = (int) skip;
+            this.limit = (int) (limit == null ? Integer.MAX_VALUE : limit);
+            this.currentIterator = getNextIterator();
+        }
+
+        @Override
+        public boolean hasNext() {
+            while (true) {
+                if (currentIterator == null) {
+                    if (currentIteratorCount == 0) {
+                        return false;
+                    }
+                    currentIterator = getNextIterator();
+                    if (currentIterator == null) {
+                        return false;
+                    }
+                }
+                if (currentIterator.hasNext()) {
+                    return true;
+                }
+                currentIterator = null;
+            }
+        }
+
+        @Override
+        public T next() {
+            if (hasNext()) {
+                limit--;
+                currentIteratorCount++;
+                return currentIterator.next();
+            }
+            throw new NoSuchElementException();
+        }
+
+        private Iterator<T> getNextIterator() {
+            if (limit <= 0) {
+                return null;
+            }
+            int limit = Math.min(pageSize, this.limit);
+            currentIteratorCount = 0;
+            if (firstIterable == null) {
+                firstIterable = getPageIterableFunction.getPageIterable(nextSkip, limit, false);
+            }
+            Iterator<T> it = firstIterable.iterator();
+            firstIterable = null;
+            nextSkip += limit;
+            return it;
+        }
+
+        @Override
+        public void remove() {
+            throw new VertexiumException("remove not implemented");
+        }
+    }
+}

--- a/elasticsearch2/src/test/java/org/vertexium/elasticsearch2/Elasticsearch2SearchIndexSimpleSubstitutionTest.java
+++ b/elasticsearch2/src/test/java/org/vertexium/elasticsearch2/Elasticsearch2SearchIndexSimpleSubstitutionTest.java
@@ -1,0 +1,29 @@
+package org.vertexium.elasticsearch2;
+
+import com.google.common.base.Joiner;
+import org.vertexium.Graph;
+import org.vertexium.id.SimpleSubstitutionUtils;
+
+import java.util.HashMap;
+import java.util.Map;
+
+public class Elasticsearch2SearchIndexSimpleSubstitutionTest extends Elasticsearch2SearchIndexTestBase {
+    private final String PROP1_PROPERTY_NAME = "prop1";
+    private final String PROP1_SUBSTITUTION_NAME = "p1";
+    private final String PROP_LARGE_PROPERTY_NAME = "propLarge";
+    private final String PROP_LARGE_SUBSTITUTION_NAME = "pL";
+    private final String PROP_SMALL_PROPERTY_NAME = "propSmall";
+    private final String PROP_SMALL_SUBSTITUTION_NAME = "pS";
+
+    @Override
+    protected Graph createGraph() throws Exception {
+        Map<String, String> substitutionMap = new HashMap();
+        substitutionMap.put(Joiner.on('.').join(new String[]{SimpleSubstitutionUtils.SUBSTITUTION_MAP_PREFIX, "0", SimpleSubstitutionUtils.KEY_IDENTIFIER}), PROP1_PROPERTY_NAME);
+        substitutionMap.put(Joiner.on('.').join(new String[]{SimpleSubstitutionUtils.SUBSTITUTION_MAP_PREFIX, "0", SimpleSubstitutionUtils.VALUE_IDENTIFIER}), PROP1_SUBSTITUTION_NAME);
+        substitutionMap.put(Joiner.on('.').join(new String[]{SimpleSubstitutionUtils.SUBSTITUTION_MAP_PREFIX, "1", SimpleSubstitutionUtils.KEY_IDENTIFIER}), PROP_LARGE_PROPERTY_NAME);
+        substitutionMap.put(Joiner.on('.').join(new String[]{SimpleSubstitutionUtils.SUBSTITUTION_MAP_PREFIX, "1", SimpleSubstitutionUtils.VALUE_IDENTIFIER}), PROP_LARGE_SUBSTITUTION_NAME);
+        substitutionMap.put(Joiner.on('.').join(new String[]{SimpleSubstitutionUtils.SUBSTITUTION_MAP_PREFIX, "2", SimpleSubstitutionUtils.KEY_IDENTIFIER}), PROP_SMALL_PROPERTY_NAME);
+        substitutionMap.put(Joiner.on('.').join(new String[]{SimpleSubstitutionUtils.SUBSTITUTION_MAP_PREFIX, "2", SimpleSubstitutionUtils.VALUE_IDENTIFIER}), PROP_SMALL_SUBSTITUTION_NAME);
+        return super.createGraph(substitutionMap);
+    }
+}

--- a/elasticsearch2/src/test/java/org/vertexium/elasticsearch2/Elasticsearch2SearchIndexTest.java
+++ b/elasticsearch2/src/test/java/org/vertexium/elasticsearch2/Elasticsearch2SearchIndexTest.java
@@ -1,0 +1,5 @@
+package org.vertexium.elasticsearch2;
+
+public class Elasticsearch2SearchIndexTest extends Elasticsearch2SearchIndexTestBase {
+
+}

--- a/elasticsearch2/src/test/java/org/vertexium/elasticsearch2/Elasticsearch2SearchIndexTestBase.java
+++ b/elasticsearch2/src/test/java/org/vertexium/elasticsearch2/Elasticsearch2SearchIndexTestBase.java
@@ -1,0 +1,176 @@
+package org.vertexium.elasticsearch2;
+
+import org.codelibs.elasticsearch.runner.ElasticsearchClusterRunner;
+import org.elasticsearch.action.admin.cluster.state.ClusterStateResponse;
+import org.elasticsearch.common.transport.InetSocketTransportAddress;
+import org.junit.*;
+import org.vertexium.*;
+import org.vertexium.elasticsearch2.score.EdgeCountScoringStrategy;
+import org.vertexium.elasticsearch2.score.EdgeCountScoringStrategyConfiguration;
+import org.vertexium.elasticsearch2.score.ScoringStrategy;
+import org.vertexium.inmemory.InMemoryAuthorizations;
+import org.vertexium.inmemory.InMemoryGraph;
+import org.vertexium.inmemory.InMemoryGraphConfiguration;
+import org.vertexium.query.QueryResultsIterable;
+import org.vertexium.query.SortDirection;
+import org.vertexium.test.GraphTestBase;
+import org.vertexium.util.VertexiumLogger;
+import org.vertexium.util.VertexiumLoggerFactory;
+
+import java.io.File;
+import java.io.IOException;
+import java.lang.reflect.Field;
+import java.util.HashMap;
+import java.util.Map;
+import java.util.UUID;
+
+import static org.codelibs.elasticsearch.runner.ElasticsearchClusterRunner.newConfigs;
+import static org.vertexium.util.IterableUtils.count;
+
+public abstract class Elasticsearch2SearchIndexTestBase extends GraphTestBase {
+    private static final VertexiumLogger LOGGER = VertexiumLoggerFactory.getLogger(Elasticsearch2SearchIndexTestBase.class);
+    public static final String ES_INDEX_NAME = "vertexium-test";
+    public static final String ES_CLUSTER_NAME = "vertexium-test-cluster";
+    public static final String ES_EXTENDED_DATA_INDEX_NAME_PREFIX = "vertexium-test-";
+    private static ElasticsearchClusterRunner runner;
+
+    @Override
+    protected Authorizations createAuthorizations(String... auths) {
+        return new InMemoryAuthorizations(auths);
+    }
+
+    @BeforeClass
+    public static void beforeClass() throws Exception {
+        File tempDir = new File(System.getProperty("java.io.tmpdir"));
+        File basePath = new File(tempDir, "vertexium-test-" + UUID.randomUUID().toString());
+        LOGGER.info("base path: %s", basePath);
+
+        runner = new ElasticsearchClusterRunner();
+        runner.onBuild((i, builder) ->
+                               builder
+                                       .put("script.inline", "true")
+                                       .put("cluster.name", ES_CLUSTER_NAME)
+                                       .put("plugin.types", "org.elasticsearch.script.groovy.GroovyPlugin")
+        ).build(
+                newConfigs()
+                        .basePath(basePath.getAbsolutePath())
+                        .numOfNode(1)
+        );
+
+        runner.ensureGreen();
+    }
+
+    @Before
+    @Override
+    public void before() throws Exception {
+        String[] indices = runner.admin().indices().prepareGetIndex().execute().get().indices();
+        for (String index : indices) {
+            if (index.equals(ES_INDEX_NAME) || index.startsWith(ES_EXTENDED_DATA_INDEX_NAME_PREFIX)) {
+                LOGGER.info("deleting test index: %s", index);
+                runner.admin().indices().prepareDelete(index).execute().actionGet();
+            }
+        }
+        super.before();
+    }
+
+    @After
+    public void after() throws Exception {
+        super.after();
+    }
+
+    @AfterClass
+    public static void afterClass() throws IOException {
+        if (runner != null) {
+            runner.close();
+            runner.clean();
+        }
+    }
+
+    @Override
+    protected Graph createGraph() throws Exception {
+        return createGraph(new HashMap());
+    }
+
+    protected Graph createGraph(Map additionalConfiguration) throws Exception {
+        Map<String, Object> config = new HashMap<>();
+        config.put(GraphConfiguration.AUTO_FLUSH, true);
+        config.put(GraphConfiguration.SEARCH_INDEX_PROP_PREFIX, Elasticsearch2SearchIndex.class.getName());
+        config.put(GraphConfiguration.SEARCH_INDEX_PROP_PREFIX + "." + DefaultIndexSelectionStrategy.CONFIG_INDEX_NAME, ES_INDEX_NAME);
+        config.put(GraphConfiguration.SEARCH_INDEX_PROP_PREFIX + "." + DefaultIndexSelectionStrategy.CONFIG_EXTENDED_DATA_INDEX_NAME_PREFIX, ES_EXTENDED_DATA_INDEX_NAME_PREFIX);
+        config.put(GraphConfiguration.SEARCH_INDEX_PROP_PREFIX + "." + ElasticsearchSearchIndexConfiguration.SCORING_STRATEGY_CLASS_NAME, EdgeCountScoringStrategy.class.getName());
+        config.put(GraphConfiguration.SEARCH_INDEX_PROP_PREFIX + "." + ElasticsearchSearchIndexConfiguration.CLUSTER_NAME, ES_CLUSTER_NAME);
+        config.put(GraphConfiguration.SEARCH_INDEX_PROP_PREFIX + "." + ElasticsearchSearchIndexConfiguration.ES_LOCATIONS, getLocation());
+        config.put(GraphConfiguration.SEARCH_INDEX_PROP_PREFIX + "." + ElasticsearchSearchIndexConfiguration.NUMBER_OF_SHARDS, 1);
+        config.put(GraphConfiguration.SEARCH_INDEX_PROP_PREFIX + "." + ElasticsearchSearchIndexConfiguration.NUMBER_OF_REPLICAS, 0);
+        config.putAll(additionalConfiguration);
+        InMemoryGraphConfiguration configuration = new InMemoryGraphConfiguration(config);
+        return InMemoryGraph.create(configuration);
+    }
+
+    private String getLocation() {
+        ClusterStateResponse responsee = runner.node().client().admin().cluster().prepareState().execute().actionGet();
+        InetSocketTransportAddress address = (InetSocketTransportAddress)
+                responsee.getState().getNodes().getNodes().values().iterator().next().value.getAddress();
+        return "localhost:" + address.address().getPort();
+    }
+
+    private Elasticsearch2SearchIndex getSearchIndex() {
+        return (Elasticsearch2SearchIndex) ((GraphWithSearchIndex) graph).getSearchIndex();
+    }
+
+    @Override
+    protected boolean isEdgeBoostSupported() {
+        return true;
+    }
+
+    @Override
+    protected boolean disableUpdateEdgeCountInSearchIndex(Graph graph) {
+        Elasticsearch2SearchIndex searchIndex = (Elasticsearch2SearchIndex) ((GraphWithSearchIndex) graph).getSearchIndex();
+        ElasticsearchSearchIndexConfiguration config = searchIndex.getConfig();
+        ScoringStrategy scoringStrategy = config.getScoringStrategy();
+        if (!(scoringStrategy instanceof EdgeCountScoringStrategy)) {
+            return false;
+        }
+
+        EdgeCountScoringStrategyConfiguration edgeCountScoringStrategyConfig = ((EdgeCountScoringStrategy) scoringStrategy).getConfig();
+
+        try {
+            Field updateEdgeBoostField = edgeCountScoringStrategyConfig.getClass().getDeclaredField("updateEdgeBoost");
+            updateEdgeBoostField.setAccessible(true);
+            updateEdgeBoostField.set(edgeCountScoringStrategyConfig, false);
+        } catch (Exception e) {
+            throw new VertexiumException("Failed to update 'updateEdgeBoost' field", e);
+        }
+
+        return true;
+    }
+
+    protected boolean isFieldNamesInQuerySupported() {
+        return false;
+    }
+
+    @Override
+    protected boolean disableEdgeIndexing(Graph graph) {
+        Elasticsearch2SearchIndex searchIndex = (Elasticsearch2SearchIndex) ((GraphWithSearchIndex) graph).getSearchIndex();
+        searchIndex.getConfig().getGraphConfiguration().set(GraphConfiguration.SEARCH_INDEX_PROP_PREFIX + "." + ElasticsearchSearchIndexConfiguration.INDEX_EDGES, "false");
+        return true;
+    }
+
+    @Override
+    protected boolean isLuceneQueriesSupported() {
+        return true;
+    }
+
+    @Test
+    @Override
+    public void testGraphQuerySortOnPropertyThatHasNoValuesInTheIndex() {
+        super.testGraphQuerySortOnPropertyThatHasNoValuesInTheIndex();
+
+        getSearchIndex().clearIndexInfoCache();
+
+        QueryResultsIterable<Vertex> vertices
+                = graph.query(AUTHORIZATIONS_A).sort("age", SortDirection.ASCENDING).vertices();
+        Assert.assertEquals(2, count(vertices));
+    }
+}
+

--- a/elasticsearch2/src/test/java/org/vertexium/elasticsearch2/utils/ConsoleAppender.java
+++ b/elasticsearch2/src/test/java/org/vertexium/elasticsearch2/utils/ConsoleAppender.java
@@ -1,0 +1,7 @@
+package org.vertexium.elasticsearch2.utils;
+
+public class ConsoleAppender extends org.apache.log4j.ConsoleAppender {
+    @Override
+    public synchronized void close() {
+    }
+}

--- a/elasticsearch2/src/test/resources/.gitignore
+++ b/elasticsearch2/src/test/resources/.gitignore
@@ -1,0 +1,1 @@
+vertexium-elasticsearch2-plugin.zip

--- a/elasticsearch2/src/test/resources/log4j.xml
+++ b/elasticsearch2/src/test/resources/log4j.xml
@@ -1,0 +1,37 @@
+<?xml version="1.0" encoding="UTF-8" ?>
+<!DOCTYPE log4j:configuration SYSTEM "log4j.dtd" [
+<!ENTITY logDir "/opt/lumify/logs">
+
+<!-- Pattern: %d{yyyy-MM-dd HH:mm:ss.SSS/zzz} %-5p [%c{3}] %m%n -->
+<!ENTITY pattern "&#37;d{yyyy-MM-dd HH:mm:ss.SSS/zzz} &#37;-5p [&#37;c{3}] &#37;m&#37;n">
+]
+>
+
+<log4j:configuration xmlns:log4j="http://jakarta.apache.org/log4j/">
+    <appender name="console" class="org.vertexium.elasticsearch2.utils.ConsoleAppender">
+        <layout class="org.apache.log4j.PatternLayout">
+            <param name="ConversionPattern" value="&pattern;" />
+        </layout>
+    </appender>
+
+    <logger name="org.vertexium.query.Query.QUERY" additivity="false">
+        <level value="TRACE" />
+        <appender-ref ref="console" />
+    </logger>
+    <logger name="org.vertexium.search.SearchIndex.MUTATION" additivity="false">
+        <level value="TRACE" />
+        <appender-ref ref="console" />
+    </logger>
+    <logger name="org.vertexium" additivity="false">
+        <level value="DEBUG" />
+        <appender-ref ref="console" />
+    </logger>
+    <logger name="org.vertexium.query.Query.QUERY" additivity="false">
+        <level value="TRACE" />
+        <appender-ref ref="console" />
+    </logger>
+    <root>
+        <level value="WARN" />
+        <appender-ref ref="console" />
+    </root>
+</log4j:configuration>

--- a/examples/aggregations/pom.xml
+++ b/examples/aggregations/pom.xml
@@ -3,7 +3,7 @@
     <parent>
         <groupId>org.vertexium.examples</groupId>
         <artifactId>vertexium-examples</artifactId>
-        <version>2.5.4-SNAPSHOT</version>
+        <version>2.6.0-SNAPSHOT</version>
     </parent>
     <modelVersion>4.0.0</modelVersion>
 

--- a/examples/example-base/pom.xml
+++ b/examples/example-base/pom.xml
@@ -3,7 +3,7 @@
     <parent>
         <groupId>org.vertexium.examples</groupId>
         <artifactId>vertexium-examples</artifactId>
-        <version>2.5.4-SNAPSHOT</version>
+        <version>2.6.0-SNAPSHOT</version>
     </parent>
     <modelVersion>4.0.0</modelVersion>
 

--- a/examples/pom.xml
+++ b/examples/pom.xml
@@ -3,7 +3,7 @@
     <parent>
         <artifactId>vertexium-root</artifactId>
         <groupId>org.vertexium</groupId>
-        <version>2.5.4-SNAPSHOT</version>
+        <version>2.6.0-SNAPSHOT</version>
     </parent>
     <modelVersion>4.0.0</modelVersion>
 

--- a/inmemory/pom.xml
+++ b/inmemory/pom.xml
@@ -3,7 +3,7 @@
     <parent>
         <artifactId>vertexium-root</artifactId>
         <groupId>org.vertexium</groupId>
-        <version>2.5.4-SNAPSHOT</version>
+        <version>2.6.0-SNAPSHOT</version>
     </parent>
     <modelVersion>4.0.0</modelVersion>
 

--- a/kryo-serializer/pom.xml
+++ b/kryo-serializer/pom.xml
@@ -3,7 +3,7 @@
     <parent>
         <artifactId>vertexium-root</artifactId>
         <groupId>org.vertexium</groupId>
-        <version>2.5.4-SNAPSHOT</version>
+        <version>2.6.0-SNAPSHOT</version>
     </parent>
     <modelVersion>4.0.0</modelVersion>
 

--- a/pom.xml
+++ b/pom.xml
@@ -11,7 +11,7 @@
     <groupId>org.vertexium</groupId>
     <artifactId>vertexium-root</artifactId>
     <packaging>pom</packaging>
-    <version>2.5.4-SNAPSHOT</version>
+    <version>2.6.0-SNAPSHOT</version>
     <name>Vertexium</name>
     <description>
         Vertexium is an API to manipulate graphs, similar to blueprints. Unlike blueprints, every Vertexium method
@@ -66,7 +66,7 @@
         <commons-codec.version>1.8</commons-codec.version>
         <jcommander.version>1.35</jcommander.version>
         <cache2k.version>0.21.1</cache2k.version>
-        <google-guava.version>17.0</google-guava.version>
+        <google-guava.version>18.0</google-guava.version>
         <commons-lang3.version>3.1</commons-lang3.version>
         <apache.curator.version>2.8.0</apache.curator.version>
         <recurrent.version>0.3.2</recurrent.version>
@@ -83,12 +83,18 @@
         <maven.plugin.jarjar.version>1.9</maven.plugin.jarjar.version>
         <maven.plugin.deploy.version>2.8.2</maven.plugin.deploy.version>
 
-        <!-- used by: elasticsearch -->
-        <elasticsearch.version>1.7.5</elasticsearch.version>
         <!-- used by: elasticsearch main for dynamic scripting, and test for boost formulas -->
         <groovy.version>2.4.5</groovy.version>
+
         <!-- used by: elasticsearch geo_shape type -->
         <jts.version>1.13</jts.version>
+
+        <!-- used by: elasticsearch-* -->
+        <elasticsearch.version>1.7.5</elasticsearch.version>
+
+        <!-- used by: elasticsearch2* -->
+        <elasticsearch2.version>2.4.4</elasticsearch2.version>
+        <jna.version>4.1.0</jna.version>
 
         <!-- used by: accumulo* -->
         <accumulo.version>1.7.2</accumulo.version>
@@ -371,6 +377,8 @@
 
         <module>elasticsearch-singledocument</module>
         <module>elasticsearch-singledocument-plugin</module>
+        <module>elasticsearch2</module>
+        <module>elasticsearch2-plugin</module>
 
         <module>inmemory</module>
 

--- a/security/pom.xml
+++ b/security/pom.xml
@@ -3,7 +3,7 @@
     <parent>
         <artifactId>vertexium-root</artifactId>
         <groupId>org.vertexium</groupId>
-        <version>2.5.4-SNAPSHOT</version>
+        <version>2.6.0-SNAPSHOT</version>
     </parent>
     <modelVersion>4.0.0</modelVersion>
 

--- a/sql/pom.xml
+++ b/sql/pom.xml
@@ -3,7 +3,7 @@
     <parent>
         <artifactId>vertexium-root</artifactId>
         <groupId>org.vertexium</groupId>
-        <version>2.5.4-SNAPSHOT</version>
+        <version>2.6.0-SNAPSHOT</version>
     </parent>
     <modelVersion>4.0.0</modelVersion>
 

--- a/test/pom.xml
+++ b/test/pom.xml
@@ -3,7 +3,7 @@
     <parent>
         <artifactId>vertexium-root</artifactId>
         <groupId>org.vertexium</groupId>
-        <version>2.5.4-SNAPSHOT</version>
+        <version>2.6.0-SNAPSHOT</version>
     </parent>
     <modelVersion>4.0.0</modelVersion>
 

--- a/test/src/main/java/org/vertexium/test/GraphTestBase.java
+++ b/test/src/main/java/org/vertexium/test/GraphTestBase.java
@@ -5,10 +5,10 @@ import com.google.common.collect.ImmutableMap;
 import com.google.common.collect.ImmutableSet;
 import com.google.common.collect.Lists;
 import org.apache.commons.io.IOUtils;
-import org.junit.After;
-import org.junit.Assert;
-import org.junit.Before;
-import org.junit.Test;
+import org.junit.*;
+import org.junit.rules.TestRule;
+import org.junit.rules.TestWatcher;
+import org.junit.runner.Description;
 import org.junit.runner.RunWith;
 import org.junit.runners.JUnit4;
 import org.vertexium.*;
@@ -101,6 +101,14 @@ public abstract class GraphTestBase {
             graph = null;
         }
     }
+
+    // Need this to given occasional output so Travis doesn't fail the build for no output
+    @Rule
+    public TestRule watcher = new TestWatcher() {
+        protected void starting(Description description) {
+            System.out.println("Starting test: " + description.getMethodName());
+        }
+    };
 
     @Test
     public void testAddVertexWithId() {

--- a/tools/pom.xml
+++ b/tools/pom.xml
@@ -3,7 +3,7 @@
     <parent>
         <artifactId>vertexium-root</artifactId>
         <groupId>org.vertexium</groupId>
-        <version>2.5.4-SNAPSHOT</version>
+        <version>2.6.0-SNAPSHOT</version>
     </parent>
     <modelVersion>4.0.0</modelVersion>
 

--- a/xstream-serializer/pom.xml
+++ b/xstream-serializer/pom.xml
@@ -3,7 +3,7 @@
     <parent>
         <artifactId>vertexium-root</artifactId>
         <groupId>org.vertexium</groupId>
-        <version>2.5.4-SNAPSHOT</version>
+        <version>2.6.0-SNAPSHOT</version>
     </parent>
     <modelVersion>4.0.0</modelVersion>
 


### PR DESCRIPTION
I decided to keep this old ES 1.x stuff in place and we can eventually deprecate it but for now this is mostly a copy of the ES 1.x code with the minimum amount of changes needed for 2.x. As a result if you load it in IntelliJ you will notice the use of quite a few deprecated methods, as we move forward we can start fixing those and replacing them with the newer calls. Until we deprecate 1.x any changes made to 1.x or 2.x will need to be applied to the other as well.