### PR TITLE
Changed: Remove property metadata from default fetch hints

### DIFF
--- a/accumulo/src/main/java/org/vertexium/accumulo/AccumuloEdge.java
+++ b/accumulo/src/main/java/org/vertexium/accumulo/AccumuloEdge.java
@@ -47,6 +47,7 @@ public class AccumuloEdge extends AccumuloElement implements Edge {
             Iterable<Visibility> hiddenVisibilities,
             ImmutableSet<String> extendedDataTableNames,
             long timestamp,
+            EnumSet<FetchHint> fetchHints,
             Authorizations authorizations
     ) {
         super(
@@ -59,6 +60,7 @@ public class AccumuloEdge extends AccumuloElement implements Edge {
                 hiddenVisibilities,
                 extendedDataTableNames,
                 timestamp,
+                fetchHints,
                 authorizations
         );
         this.outVertexId = outVertexId;
@@ -67,7 +69,13 @@ public class AccumuloEdge extends AccumuloElement implements Edge {
         this.newEdgeLabel = newEdgeLabel;
     }
 
-    public static Edge createFromIteratorValue(AccumuloGraph graph, Key key, Value value, Authorizations authorizations) {
+    public static Edge createFromIteratorValue(
+            AccumuloGraph graph,
+            Key key,
+            Value value,
+            EnumSet<FetchHint> fetchHints,
+            Authorizations authorizations
+    ) {
         try {
             String edgeId;
             Visibility vertexVisibility;
@@ -92,7 +100,7 @@ public class AccumuloEdge extends AccumuloElement implements Edge {
                     return new Visibility(input.toString());
                 }
             });
-            properties = DataInputStreamUtils.decodeProperties(graph, in);
+            properties = DataInputStreamUtils.decodeProperties(graph, in, fetchHints);
             ImmutableSet<String> extendedDataTableNames = DataInputStreamUtils.decodeStringSet(in);
             String inVertexId = DataInputStreamUtils.decodeText(in).toString();
             String outVertexId = DataInputStreamUtils.decodeText(in).toString();
@@ -112,6 +120,7 @@ public class AccumuloEdge extends AccumuloElement implements Edge {
                     hiddenVisibilities,
                     extendedDataTableNames,
                     timestamp,
+                    fetchHints,
                     authorizations
             );
         } catch (IOException ex) {
@@ -142,7 +151,7 @@ public class AccumuloEdge extends AccumuloElement implements Edge {
 
     @Override
     public Vertex getVertex(Direction direction, Authorizations authorizations) {
-        return getVertex(direction, FetchHint.ALL, authorizations);
+        return getVertex(direction, FetchHint.DEFAULT, authorizations);
     }
 
     @Override
@@ -157,7 +166,7 @@ public class AccumuloEdge extends AccumuloElement implements Edge {
 
     @Override
     public Vertex getOtherVertex(String myVertexId, Authorizations authorizations) {
-        return getOtherVertex(myVertexId, FetchHint.ALL, authorizations);
+        return getOtherVertex(myVertexId, FetchHint.DEFAULT, authorizations);
     }
 
     @Override
@@ -167,7 +176,7 @@ public class AccumuloEdge extends AccumuloElement implements Edge {
 
     @Override
     public EdgeVertices getVertices(Authorizations authorizations) {
-        return getVertices(FetchHint.ALL, authorizations);
+        return getVertices(FetchHint.DEFAULT, authorizations);
     }
 
     @Override

--- a/accumulo/src/main/java/org/vertexium/accumulo/AccumuloElement.java
+++ b/accumulo/src/main/java/org/vertexium/accumulo/AccumuloElement.java
@@ -8,6 +8,7 @@ import org.vertexium.accumulo.iterator.ElementIterator;
 import org.vertexium.mutation.*;
 
 import java.io.Serializable;
+import java.util.EnumSet;
 
 public abstract class AccumuloElement extends ElementBase implements Serializable, HasTimestamp {
     private static final long serialVersionUID = 1L;
@@ -38,6 +39,7 @@ public abstract class AccumuloElement extends ElementBase implements Serializabl
             Iterable<Visibility> hiddenVisibilities,
             ImmutableSet<String> extendedDataTableNames,
             long timestamp,
+            EnumSet<FetchHint> fetchHints,
             Authorizations authorizations
     ) {
         super(
@@ -50,6 +52,7 @@ public abstract class AccumuloElement extends ElementBase implements Serializabl
                 hiddenVisibilities,
                 extendedDataTableNames,
                 timestamp,
+                fetchHints,
                 authorizations
         );
     }

--- a/accumulo/src/main/java/org/vertexium/accumulo/LazyMutableProperty.java
+++ b/accumulo/src/main/java/org/vertexium/accumulo/LazyMutableProperty.java
@@ -4,10 +4,7 @@ import org.vertexium.*;
 import org.vertexium.property.MutableProperty;
 import org.vertexium.property.StreamingPropertyValueRef;
 
-import java.util.ArrayList;
-import java.util.Collection;
-import java.util.HashSet;
-import java.util.Set;
+import java.util.*;
 
 public class LazyMutableProperty extends MutableProperty {
     private final AccumuloGraph graph;
@@ -15,6 +12,7 @@ public class LazyMutableProperty extends MutableProperty {
     private final String propertyKey;
     private final String propertyName;
     private long timestamp;
+    private final EnumSet<FetchHint> fetchHints;
     private Set<Visibility> hiddenVisibilities;
     private byte[] propertyValue;
     private LazyPropertyMetadata metadata;
@@ -31,7 +29,8 @@ public class LazyMutableProperty extends MutableProperty {
             LazyPropertyMetadata metadata,
             Set<Visibility> hiddenVisibilities,
             Visibility visibility,
-            long timestamp
+            long timestamp,
+            EnumSet<FetchHint> fetchHints
     ) {
         this.graph = graph;
         this.vertexiumSerializer = vertexiumSerializer;
@@ -42,6 +41,7 @@ public class LazyMutableProperty extends MutableProperty {
         this.visibility = visibility;
         this.hiddenVisibilities = hiddenVisibilities;
         this.timestamp = timestamp;
+        this.fetchHints = fetchHints;
     }
 
     @Override
@@ -121,6 +121,7 @@ public class LazyMutableProperty extends MutableProperty {
 
     @Override
     public Metadata getMetadata() {
+        FetchHint.checkFetchHints(fetchHints, FetchHint.PROPERTY_METADATA);
         if (cachedMetadata == null) {
             if (metadata == null) {
                 cachedMetadata = new Metadata();

--- a/accumulo/src/main/java/org/vertexium/accumulo/mapreduce/AccumuloEdgeInputFormat.java
+++ b/accumulo/src/main/java/org/vertexium/accumulo/mapreduce/AccumuloEdgeInputFormat.java
@@ -15,7 +15,6 @@ import org.vertexium.accumulo.AccumuloEdge;
 import org.vertexium.accumulo.AccumuloGraph;
 import org.vertexium.accumulo.iterator.EdgeIterator;
 import org.vertexium.accumulo.iterator.model.EdgeElementData;
-import org.vertexium.accumulo.iterator.model.FetchHint;
 import org.vertexium.mutation.PropertyDeleteMutation;
 import org.vertexium.mutation.PropertySoftDeleteMutation;
 
@@ -24,7 +23,7 @@ import java.util.EnumSet;
 import java.util.Map;
 
 public class AccumuloEdgeInputFormat extends AccumuloElementInputFormatBase<Edge> {
-    private static EdgeIterator edgeIterator = new EdgeIterator(AccumuloGraph.toIteratorFetchHints(org.vertexium.FetchHint.ALL));
+    private static EdgeIterator edgeIterator = new EdgeIterator(AccumuloGraph.toIteratorFetchHints(org.vertexium.FetchHint.DEFAULT));
 
     public static void setInputInfo(Job job, AccumuloGraph graph, String instanceName, String zooKeepers, String principal, AuthenticationToken token, String[] authorizations) throws AccumuloSecurityException {
         String tableName = graph.getEdgesTableName();
@@ -32,15 +31,19 @@ public class AccumuloEdgeInputFormat extends AccumuloElementInputFormatBase<Edge
     }
 
     @Override
-    protected Edge createElementFromRow(AccumuloGraph graph, PeekingIterator<Map.Entry<Key, Value>> row, Authorizations authorizations) {
+    protected Edge createElementFromRow(
+            AccumuloGraph graph,
+            PeekingIterator<Map.Entry<Key, Value>> row,
+            Authorizations authorizations
+    ) {
         try {
-            EnumSet<FetchHint> fetchHints = AccumuloGraph.toIteratorFetchHints(org.vertexium.FetchHint.ALL);
+            EnumSet<org.vertexium.FetchHint> fetchHints = org.vertexium.FetchHint.DEFAULT;
             EdgeElementData edgeElementData = edgeIterator.createElementDataFromRows(row);
             if (edgeElementData == null) {
                 return null;
             }
             Visibility visibility = AccumuloGraph.accumuloVisibilityToVisibility(AccumuloGraph.visibilityToAccumuloVisibility(edgeElementData.visibility.toString()));
-            Iterable<Property> properties = makePropertiesFromElementData(graph, edgeElementData, fetchHints);
+            Iterable<Property> properties = makePropertiesFromElementData(graph, edgeElementData, AccumuloGraph.toIteratorFetchHints(fetchHints));
             Iterable<PropertyDeleteMutation> propertyDeleteMutations = null;
             Iterable<PropertySoftDeleteMutation> propertySoftDeleteMutations = null;
             Iterable<Visibility> hiddenVisibilities = Iterables.transform(edgeElementData.hiddenVisibilities, new Function<Text, Visibility>() {
@@ -67,6 +70,7 @@ public class AccumuloEdgeInputFormat extends AccumuloElementInputFormatBase<Edge
                     hiddenVisibilities,
                     extendedDataTableNames,
                     edgeElementData.timestamp,
+                    fetchHints,
                     authorizations
             );
         } catch (Throwable ex) {

--- a/accumulo/src/main/java/org/vertexium/accumulo/mapreduce/AccumuloElementInputFormatBase.java
+++ b/accumulo/src/main/java/org/vertexium/accumulo/mapreduce/AccumuloElementInputFormatBase.java
@@ -136,7 +136,8 @@ public abstract class AccumuloElementInputFormatBase<TValue extends Element> ext
                 metadata,
                 hiddenVisibilities,
                 visibility,
-                property.timestamp
+                property.timestamp,
+                FetchHint.ALL_INCLUDING_HIDDEN
         );
     }
 }

--- a/accumulo/src/main/java/org/vertexium/accumulo/mapreduce/AccumuloVertexInputFormat.java
+++ b/accumulo/src/main/java/org/vertexium/accumulo/mapreduce/AccumuloVertexInputFormat.java
@@ -14,7 +14,6 @@ import org.vertexium.*;
 import org.vertexium.accumulo.AccumuloGraph;
 import org.vertexium.accumulo.AccumuloVertex;
 import org.vertexium.accumulo.iterator.VertexIterator;
-import org.vertexium.accumulo.iterator.model.FetchHint;
 import org.vertexium.accumulo.iterator.model.VertexElementData;
 import org.vertexium.mutation.PropertyDeleteMutation;
 import org.vertexium.mutation.PropertySoftDeleteMutation;
@@ -25,7 +24,7 @@ import java.util.Iterator;
 import java.util.Map;
 
 public class AccumuloVertexInputFormat extends AccumuloElementInputFormatBase<Vertex> {
-    private static VertexIterator vertexIterator = new VertexIterator(AccumuloGraph.toIteratorFetchHints(org.vertexium.FetchHint.ALL));
+    private static VertexIterator vertexIterator = new VertexIterator(AccumuloGraph.toIteratorFetchHints(org.vertexium.FetchHint.DEFAULT));
 
     public static void setInputInfo(Job job, AccumuloGraph graph, String instanceName, String zooKeepers, String principal, AuthenticationToken token, String[] authorizations) throws AccumuloSecurityException {
         String tableName = graph.getVerticesTableName();
@@ -39,13 +38,13 @@ public class AccumuloVertexInputFormat extends AccumuloElementInputFormatBase<Ve
 
     public static Vertex createVertex(AccumuloGraph graph, Iterator<Map.Entry<Key, Value>> row, Authorizations authorizations) {
         try {
-            EnumSet<FetchHint> fetchHints = AccumuloGraph.toIteratorFetchHints(org.vertexium.FetchHint.ALL);
+            EnumSet<org.vertexium.FetchHint> fetchHints = org.vertexium.FetchHint.DEFAULT;
             VertexElementData vertexElementData = vertexIterator.createElementDataFromRows(row);
             if (vertexElementData == null) {
                 return null;
             }
             Visibility visibility = AccumuloGraph.accumuloVisibilityToVisibility(AccumuloGraph.visibilityToAccumuloVisibility(vertexElementData.visibility.toString()));
-            Iterable<Property> properties = makePropertiesFromElementData(graph, vertexElementData, fetchHints);
+            Iterable<Property> properties = makePropertiesFromElementData(graph, vertexElementData, AccumuloGraph.toIteratorFetchHints(fetchHints));
             Iterable<PropertyDeleteMutation> propertyDeleteMutations = null;
             Iterable<PropertySoftDeleteMutation> propertySoftDeleteMutations = null;
             Iterable<Visibility> hiddenVisibilities = Iterables.transform(vertexElementData.hiddenVisibilities, new Function<Text, Visibility>() {
@@ -70,6 +69,7 @@ public class AccumuloVertexInputFormat extends AccumuloElementInputFormatBase<Ve
                     vertexElementData.inEdges,
                     vertexElementData.outEdges,
                     vertexElementData.timestamp,
+                    fetchHints,
                     authorizations
             );
         } catch (Throwable ex) {

--- a/accumulo/src/main/java/org/vertexium/accumulo/mapreduce/ElementMapper.java
+++ b/accumulo/src/main/java/org/vertexium/accumulo/mapreduce/ElementMapper.java
@@ -130,6 +130,7 @@ public abstract class ElementMapper<KEYIN, VALUEIN, KEYOUT, VALUEOUT> extends Ma
                         hiddenVisibilities,
                         getExtendedDataTableNames(),
                         timestampLong,
+                        FetchHint.ALL_INCLUDING_HIDDEN,
                         authorizations
                 );
             }
@@ -197,6 +198,7 @@ public abstract class ElementMapper<KEYIN, VALUEIN, KEYOUT, VALUEOUT> extends Ma
                         null,
                         getExtendedDataTableNames(),
                         timestampLong,
+                        FetchHint.ALL_INCLUDING_HIDDEN,
                         authorizations
                 );
                 return edge;
@@ -237,6 +239,7 @@ public abstract class ElementMapper<KEYIN, VALUEIN, KEYOUT, VALUEOUT> extends Ma
                         null,
                         getExtendedDataTableNames(),
                         timestampLong,
+                        FetchHint.ALL_INCLUDING_HIDDEN,
                         authorizations
                 );
                 return edge;

--- a/accumulo/src/main/java/org/vertexium/accumulo/util/DataInputStreamUtils.java
+++ b/accumulo/src/main/java/org/vertexium/accumulo/util/DataInputStreamUtils.java
@@ -18,10 +18,7 @@ import org.vertexium.id.NameSubstitutionStrategy;
 import javax.annotation.Nullable;
 import java.io.DataInputStream;
 import java.io.IOException;
-import java.util.ArrayList;
-import java.util.Arrays;
-import java.util.List;
-import java.util.Set;
+import java.util.*;
 
 public class DataInputStreamUtils {
     public static Text decodeText(DataInputStream in) throws IOException {
@@ -56,7 +53,11 @@ public class DataInputStreamUtils {
         return results.build();
     }
 
-    public static Iterable<Property> decodeProperties(AccumuloGraph graph, final DataInputStream in) throws IOException {
+    public static Iterable<Property> decodeProperties(
+            AccumuloGraph graph,
+            DataInputStream in,
+            EnumSet<org.vertexium.FetchHint> fetchHints
+    ) throws IOException {
         List<Property> results = new ArrayList<>();
         while (true) {
             int propId = in.read();
@@ -96,7 +97,8 @@ public class DataInputStreamUtils {
                     metadata,
                     propertyHiddenVisibilities,
                     propertyVisibility,
-                    propertyTimestamp
+                    propertyTimestamp,
+                    fetchHints
             ));
         }
         return results;

--- a/accumulo/src/test/java/org/vertexium/accumulo/AccumuloGraphTestBase.java
+++ b/accumulo/src/test/java/org/vertexium/accumulo/AccumuloGraphTestBase.java
@@ -178,7 +178,7 @@ public abstract class AccumuloGraphTestBase extends GraphTestBase {
         assertEquals(0, IterableUtils.count(v1.getEdges(Direction.IN, AUTHORIZATIONS_A)));
         assertEquals(0, IterableUtils.count(v1.getEdges(Direction.OUT, AUTHORIZATIONS_A)));
 
-        v1 = graph.getVertex("v1", FetchHint.ALL, AUTHORIZATIONS_A);
+        v1 = graph.getVertex("v1", FetchHint.DEFAULT, AUTHORIZATIONS_A);
         assertNotNull(v1);
         assertEquals(1, IterableUtils.count(v1.getProperties()));
         assertEquals(1, IterableUtils.count(v1.getEdges(Direction.IN, AUTHORIZATIONS_A)));
@@ -214,7 +214,7 @@ public abstract class AccumuloGraphTestBase extends GraphTestBase {
         assertEquals("v1", e1.getVertexId(Direction.OUT));
         assertEquals("v2", e1.getVertexId(Direction.IN));
 
-        e1 = graph.getEdge("e1", FetchHint.ALL, AUTHORIZATIONS_A);
+        e1 = graph.getEdge("e1", FetchHint.DEFAULT, AUTHORIZATIONS_A);
         assertEquals(1, IterableUtils.count(e1.getProperties()));
         assertEquals("v1", e1.getVertexId(Direction.OUT));
         assertEquals("v2", e1.getVertexId(Direction.IN));
@@ -237,16 +237,16 @@ public abstract class AccumuloGraphTestBase extends GraphTestBase {
         v2.addPropertyValue("prop1", "prop1", "val1", metadata, VISIBILITY_EMPTY, AUTHORIZATIONS_A_AND_B);
         graph.flush();
 
-        v1 = graph.getVertex("v1", AUTHORIZATIONS_EMPTY);
+        v1 = graph.getVertex("v1", FetchHint.ALL, AUTHORIZATIONS_EMPTY);
         assertEquals(0, v1.getProperty("prop1", "prop1").getMetadata().entrySet().size());
 
-        v2 = graph.getVertex("v2", AUTHORIZATIONS_EMPTY);
+        v2 = graph.getVertex("v2", FetchHint.ALL, AUTHORIZATIONS_EMPTY);
         metadata = v2.getProperty("prop1", "prop1").getMetadata();
         assertEquals(1, metadata.entrySet().size());
         assertEquals("metavalue1", metadata.getEntry("meta1", VISIBILITY_EMPTY).getValue());
 
         AccumuloGraph accumuloGraph = (AccumuloGraph) graph;
-        ScannerBase vertexScanner = accumuloGraph.createVertexScanner(FetchHint.ALL, AccumuloGraph.SINGLE_VERSION, null, null, new Range("V", "W"), AUTHORIZATIONS_EMPTY);
+        ScannerBase vertexScanner = accumuloGraph.createVertexScanner(FetchHint.DEFAULT, AccumuloGraph.SINGLE_VERSION, null, null, new Range("V", "W"), AUTHORIZATIONS_EMPTY);
         RowIterator rows = new RowIterator(vertexScanner.iterator());
         while (rows.hasNext()) {
             Iterator<Map.Entry<Key, Value>> row = rows.next();

--- a/cli/src/main/java/org/vertexium/cli/model/LazyEdgeMap.java
+++ b/cli/src/main/java/org/vertexium/cli/model/LazyEdgeMap.java
@@ -5,7 +5,7 @@ import org.vertexium.FetchHint;
 
 public class LazyEdgeMap extends ModelBase {
     public LazyEdge get(String edgeId) {
-        Edge e = getGraph().getEdge(edgeId, FetchHint.ALL, getTime(), getAuthorizations());
+        Edge e = getGraph().getEdge(edgeId, FetchHint.DEFAULT, getTime(), getAuthorizations());
         if (e == null) {
             return null;
         }

--- a/cli/src/main/java/org/vertexium/cli/model/LazyEdgeProperty.java
+++ b/cli/src/main/java/org/vertexium/cli/model/LazyEdgeProperty.java
@@ -20,7 +20,7 @@ public class LazyEdgeProperty extends LazyProperty {
 
     @Override
     protected Edge getE() {
-        return getGraph().getEdge(getEdgeId(), FetchHint.ALL, getTime(), getAuthorizations());
+        return getGraph().getEdge(getEdgeId(), FetchHint.DEFAULT, getTime(), getAuthorizations());
     }
 
     @Override

--- a/cli/src/main/java/org/vertexium/cli/model/LazyExtendedDataTable.java
+++ b/cli/src/main/java/org/vertexium/cli/model/LazyExtendedDataTable.java
@@ -41,9 +41,9 @@ public class LazyExtendedDataTable extends ModelBase {
     public Element getElement() {
         switch (elementType) {
             case VERTEX:
-                return getGraph().getVertex(getElementId(), FetchHint.ALL, getTime(), getAuthorizations());
+                return getGraph().getVertex(getElementId(), FetchHint.DEFAULT, getTime(), getAuthorizations());
             case EDGE:
-                return getGraph().getEdge(getElementId(), FetchHint.ALL, getTime(), getAuthorizations());
+                return getGraph().getEdge(getElementId(), FetchHint.DEFAULT, getTime(), getAuthorizations());
             default:
                 throw new VertexiumException("Unhandled element type: " + elementType);
         }

--- a/cli/src/main/java/org/vertexium/cli/model/LazyVertexMap.java
+++ b/cli/src/main/java/org/vertexium/cli/model/LazyVertexMap.java
@@ -10,14 +10,14 @@ public class LazyVertexMap extends ModelBase {
     public Object get(String vertexId) {
         if (vertexId.endsWith("*")) {
             String vertexIdPrefix = vertexId.substring(0, vertexId.length() - 1);
-            Iterable<Vertex> vertices = getGraph().getVerticesWithPrefix(vertexIdPrefix, FetchHint.ALL, getTime(), getAuthorizations());
+            Iterable<Vertex> vertices = getGraph().getVerticesWithPrefix(vertexIdPrefix, FetchHint.DEFAULT, getTime(), getAuthorizations());
             List<String> results = new ArrayList<>();
             for (Vertex v : vertices) {
                 results.add(v.getId());
             }
             return new LazyVertexList(results);
         } else {
-            Vertex v = getGraph().getVertex(vertexId, FetchHint.ALL, getTime(), getAuthorizations());
+            Vertex v = getGraph().getVertex(vertexId, FetchHint.DEFAULT, getTime(), getAuthorizations());
             if (v == null) {
                 return null;
             }

--- a/core/src/main/java/org/vertexium/Element.java
+++ b/core/src/main/java/org/vertexium/Element.java
@@ -3,6 +3,8 @@ package org.vertexium;
 import com.google.common.collect.ImmutableSet;
 import org.vertexium.mutation.ExistingElementMutation;
 
+import java.util.EnumSet;
+
 /**
  * An element on the graph. This can be either a vertex or edge.
  * <p/>
@@ -302,4 +304,9 @@ public interface Element extends VertexiumObject {
      * @return Iterable of all the rows.
      */
     Iterable<ExtendedDataRow> getExtendedData(String tableName);
+
+    /**
+     * Fetch hints used when fetching this element.
+     */
+    EnumSet<FetchHint> getFetchHints();
 }

--- a/core/src/main/java/org/vertexium/ElementBase.java
+++ b/core/src/main/java/org/vertexium/ElementBase.java
@@ -12,10 +12,7 @@ import org.vertexium.util.ConvertingIterable;
 import org.vertexium.util.FilterIterable;
 import org.vertexium.util.PropertyCollection;
 
-import java.util.ArrayList;
-import java.util.HashSet;
-import java.util.Iterator;
-import java.util.Set;
+import java.util.*;
 import java.util.concurrent.ConcurrentSkipListSet;
 
 public abstract class ElementBase implements Element {
@@ -25,6 +22,7 @@ public abstract class ElementBase implements Element {
     private Property edgeLabelProperty;
     private Visibility visibility;
     private final long timestamp;
+    private final EnumSet<FetchHint> fetchHints;
     private Set<Visibility> hiddenVisibilities = new HashSet<>();
 
     private final PropertyCollection properties;
@@ -43,12 +41,14 @@ public abstract class ElementBase implements Element {
             Iterable<Visibility> hiddenVisibilities,
             ImmutableSet<String> extendedDataTableNames,
             long timestamp,
+            EnumSet<FetchHint> fetchHints,
             Authorizations authorizations
     ) {
         this.graph = graph;
         this.id = id;
         this.visibility = visibility;
         this.timestamp = timestamp;
+        this.fetchHints = fetchHints;
         this.properties = new PropertyCollection();
         this.extendedDataTableNames = extendedDataTableNames;
         this.authorizations = authorizations;
@@ -171,7 +171,15 @@ public abstract class ElementBase implements Element {
 
     protected Property getIdProperty() {
         if (idProperty == null) {
-            idProperty = new MutablePropertyImpl(ElementMutation.DEFAULT_KEY, ID_PROPERTY_NAME, getId(), null, getTimestamp(), null, null);
+            idProperty = new MutablePropertyImpl(
+                    ElementMutation.DEFAULT_KEY,
+                    ID_PROPERTY_NAME, getId(),
+                    null,
+                    getTimestamp(),
+                    null,
+                    null,
+                    getFetchHints()
+            );
         }
         return idProperty;
     }
@@ -179,7 +187,16 @@ public abstract class ElementBase implements Element {
     protected Property getEdgeLabelProperty() {
         if (edgeLabelProperty == null && this instanceof Edge) {
             String edgeLabel = ((Edge) this).getLabel();
-            edgeLabelProperty = new MutablePropertyImpl(ElementMutation.DEFAULT_KEY, Edge.LABEL_PROPERTY_NAME, edgeLabel, null, getTimestamp(), null, null);
+            edgeLabelProperty = new MutablePropertyImpl(
+                    ElementMutation.DEFAULT_KEY,
+                    Edge.LABEL_PROPERTY_NAME,
+                    edgeLabel,
+                    null,
+                    getTimestamp(),
+                    null,
+                    null,
+                    getFetchHints()
+            );
         }
         return edgeLabelProperty;
     }
@@ -502,5 +519,10 @@ public abstract class ElementBase implements Element {
     @Override
     public ImmutableSet<String> getExtendedDataTableNames() {
         return extendedDataTableNames;
+    }
+
+    @Override
+    public EnumSet<FetchHint> getFetchHints() {
+        return fetchHints;
     }
 }

--- a/core/src/main/java/org/vertexium/ElementBuilder.java
+++ b/core/src/main/java/org/vertexium/ElementBuilder.java
@@ -100,7 +100,16 @@ public abstract class ElementBuilder<T extends Element> implements ElementMutati
         if (value == null) {
             throw new NullPointerException("property value cannot be null for property: " + name + ":" + key);
         }
-        this.properties.add(new MutablePropertyImpl(key, name, value, metadata, timestamp, null, visibility));
+        this.properties.add(new MutablePropertyImpl(
+                key,
+                name,
+                value,
+                metadata,
+                timestamp,
+                null,
+                visibility,
+                FetchHint.ALL_INCLUDING_HIDDEN
+        ));
         return this;
     }
 

--- a/core/src/main/java/org/vertexium/FetchHint.java
+++ b/core/src/main/java/org/vertexium/FetchHint.java
@@ -15,6 +15,7 @@ public enum FetchHint {
     EXTENDED_DATA_TABLE_NAMES;
 
     public static final EnumSet<FetchHint> NONE = EnumSet.noneOf(FetchHint.class);
+    public static final EnumSet<FetchHint> DEFAULT = EnumSet.of(PROPERTIES, IN_EDGE_REFS, OUT_EDGE_REFS, EXTENDED_DATA_TABLE_NAMES);
     public static final EnumSet<FetchHint> ALL = EnumSet.of(PROPERTIES, PROPERTY_METADATA, IN_EDGE_REFS, OUT_EDGE_REFS, EXTENDED_DATA_TABLE_NAMES);
     public static final EnumSet<FetchHint> ALL_INCLUDING_HIDDEN = EnumSet.allOf(FetchHint.class);
     public static final EnumSet<FetchHint> EDGE_REFS = EnumSet.of(IN_EDGE_REFS, OUT_EDGE_REFS);
@@ -58,6 +59,20 @@ public enum FetchHint {
             return EnumSet.noneOf(FetchHint.class);
         } else {
             return EnumSet.copyOf(results);
+        }
+    }
+
+    public static void checkFetchHints(EnumSet<FetchHint> fetchHints, FetchHint neededFetchHint) {
+        if (!fetchHints.contains(neededFetchHint)) {
+            throw new VertexiumMissingFetchHintException(fetchHints, EnumSet.of(neededFetchHint));
+        }
+    }
+
+    public static void checkFetchHints(EnumSet<FetchHint> fetchHints, EnumSet<FetchHint> neededFetchHints) {
+        for (FetchHint neededFetchHint : neededFetchHints) {
+            if (!fetchHints.contains(neededFetchHint)) {
+                throw new VertexiumMissingFetchHintException(fetchHints, neededFetchHints);
+            }
         }
     }
 }

--- a/core/src/main/java/org/vertexium/GraphBase.java
+++ b/core/src/main/java/org/vertexium/GraphBase.java
@@ -92,12 +92,12 @@ public abstract class GraphBase implements Graph {
 
     @Override
     public Vertex getVertex(String vertexId, Authorizations authorizations) throws VertexiumException {
-        return getVertex(vertexId, FetchHint.ALL, authorizations);
+        return getVertex(vertexId, FetchHint.DEFAULT, authorizations);
     }
 
     @Override
     public Iterable<Vertex> getVerticesWithPrefix(String vertexIdPrefix, Authorizations authorizations) {
-        return getVerticesWithPrefix(vertexIdPrefix, FetchHint.ALL, authorizations);
+        return getVerticesWithPrefix(vertexIdPrefix, FetchHint.DEFAULT, authorizations);
     }
 
     @Override
@@ -118,7 +118,7 @@ public abstract class GraphBase implements Graph {
 
     @Override
     public Iterable<Vertex> getVerticesInRange(Range idRange, Authorizations authorizations) {
-        return getVerticesInRange(idRange, FetchHint.ALL, authorizations);
+        return getVerticesInRange(idRange, FetchHint.DEFAULT, authorizations);
     }
 
     @Override
@@ -176,7 +176,7 @@ public abstract class GraphBase implements Graph {
 
     @Override
     public Iterable<Vertex> getVertices(final Iterable<String> ids, final Authorizations authorizations) {
-        return getVertices(ids, FetchHint.ALL, authorizations);
+        return getVertices(ids, FetchHint.DEFAULT, authorizations);
     }
 
     @Override
@@ -193,12 +193,12 @@ public abstract class GraphBase implements Graph {
 
     @Override
     public List<Vertex> getVerticesInOrder(Iterable<String> ids, Authorizations authorizations) {
-        return getVerticesInOrder(ids, FetchHint.ALL, authorizations);
+        return getVerticesInOrder(ids, FetchHint.DEFAULT, authorizations);
     }
 
     @Override
     public Iterable<Vertex> getVertices(Authorizations authorizations) throws VertexiumException {
-        return getVertices(FetchHint.ALL, authorizations);
+        return getVertices(FetchHint.DEFAULT, authorizations);
     }
 
     @Override
@@ -277,7 +277,7 @@ public abstract class GraphBase implements Graph {
 
     @Override
     public Edge getEdge(String edgeId, Authorizations authorizations) {
-        return getEdge(edgeId, FetchHint.ALL, authorizations);
+        return getEdge(edgeId, FetchHint.DEFAULT, authorizations);
     }
 
     @Override
@@ -454,12 +454,12 @@ public abstract class GraphBase implements Graph {
 
     @Override
     public Iterable<Edge> getEdges(final Iterable<String> ids, final Authorizations authorizations) {
-        return getEdges(ids, FetchHint.ALL, authorizations);
+        return getEdges(ids, FetchHint.DEFAULT, authorizations);
     }
 
     @Override
     public Iterable<Edge> getEdges(Authorizations authorizations) {
-        return getEdges(FetchHint.ALL, authorizations);
+        return getEdges(FetchHint.DEFAULT, authorizations);
     }
 
     @Override
@@ -472,7 +472,7 @@ public abstract class GraphBase implements Graph {
 
     @Override
     public Iterable<Edge> getEdgesInRange(Range idRange, Authorizations authorizations) {
-        return getEdgesInRange(idRange, FetchHint.ALL, authorizations);
+        return getEdgesInRange(idRange, FetchHint.DEFAULT, authorizations);
     }
 
     @Override

--- a/core/src/main/java/org/vertexium/VertexiumException.java
+++ b/core/src/main/java/org/vertexium/VertexiumException.java
@@ -1,6 +1,8 @@
 package org.vertexium;
 
 public class VertexiumException extends RuntimeException {
+    private static final long serialVersionUID = 6952596657973758922L;
+
     public VertexiumException(Exception e) {
         super(e);
     }

--- a/core/src/main/java/org/vertexium/VertexiumMissingFetchHintException.java
+++ b/core/src/main/java/org/vertexium/VertexiumMissingFetchHintException.java
@@ -1,0 +1,15 @@
+package org.vertexium;
+
+import java.util.EnumSet;
+
+public class VertexiumMissingFetchHintException extends VertexiumException {
+    private static final long serialVersionUID = 308097574790647596L;
+
+    public VertexiumMissingFetchHintException(EnumSet<FetchHint> fetchHints, EnumSet<FetchHint> neededFetchHints) {
+        super(createMessage(fetchHints, neededFetchHints));
+    }
+
+    private static String createMessage(EnumSet<FetchHint> fetchHints, EnumSet<FetchHint> neededFetchHints) {
+        return "Missing fetch hints. Found \"" + fetchHints + "\" needed \"" + neededFetchHints + "\"";
+    }
+}

--- a/core/src/main/java/org/vertexium/mutation/ExistingElementMutationImpl.java
+++ b/core/src/main/java/org/vertexium/mutation/ExistingElementMutationImpl.java
@@ -6,6 +6,7 @@ import org.vertexium.search.IndexHint;
 import org.vertexium.util.Preconditions;
 
 import java.util.ArrayList;
+import java.util.EnumSet;
 import java.util.List;
 
 public abstract class ExistingElementMutationImpl<T extends Element> implements ElementMutation<T>, ExistingElementMutation<T> {
@@ -45,7 +46,7 @@ public abstract class ExistingElementMutationImpl<T extends Element> implements 
     public ElementMutation<T> addPropertyValue(String key, String name, Object value, Metadata metadata, Long timestamp, Visibility visibility) {
         Preconditions.checkNotNull(name, "property name cannot be null for property: " + name + ":" + key);
         Preconditions.checkNotNull(value, "property value cannot be null for property: " + name + ":" + key);
-        properties.add(new MutablePropertyImpl(key, name, value, metadata, timestamp, null, visibility));
+        properties.add(new MutablePropertyImpl(key, name, value, metadata, timestamp, null, visibility, FetchHint.ALL_INCLUDING_HIDDEN));
         return this;
     }
 
@@ -70,6 +71,7 @@ public abstract class ExistingElementMutationImpl<T extends Element> implements 
 
     @Override
     public ElementMutation<T> deleteProperty(Property property) {
+        FetchHint.checkFetchHints(getElement().getFetchHints(), EnumSet.of(FetchHint.PROPERTIES, FetchHint.PROPERTY_METADATA));
         Preconditions.checkNotNull(property, "property cannot be null");
         propertyDeletes.add(new PropertyPropertyDeleteMutation(property));
         return this;
@@ -152,6 +154,7 @@ public abstract class ExistingElementMutationImpl<T extends Element> implements 
 
     @Override
     public ExistingElementMutation<T> alterPropertyVisibility(Property property, Visibility visibility) {
+        FetchHint.checkFetchHints(getElement().getFetchHints(), EnumSet.of(FetchHint.PROPERTIES, FetchHint.PROPERTY_METADATA));
         this.alterPropertyVisibilities.add(new AlterPropertyVisibility(property.getKey(), property.getName(), property.getVisibility(), visibility));
         return this;
     }
@@ -163,6 +166,7 @@ public abstract class ExistingElementMutationImpl<T extends Element> implements 
 
     @Override
     public ExistingElementMutation<T> alterPropertyVisibility(String key, String name, Visibility visibility) {
+        FetchHint.checkFetchHints(getElement().getFetchHints(), EnumSet.of(FetchHint.PROPERTIES, FetchHint.PROPERTY_METADATA));
         this.alterPropertyVisibilities.add(new AlterPropertyVisibility(key, name, null, visibility));
         return this;
     }

--- a/core/src/main/java/org/vertexium/property/MutablePropertyImpl.java
+++ b/core/src/main/java/org/vertexium/property/MutablePropertyImpl.java
@@ -1,27 +1,31 @@
 package org.vertexium.property;
 
-import org.vertexium.Authorizations;
-import org.vertexium.Metadata;
-import org.vertexium.Property;
-import org.vertexium.Visibility;
+import org.vertexium.*;
 import org.vertexium.util.IncreasingTime;
 
-import java.util.ArrayList;
-import java.util.Collection;
-import java.util.HashSet;
-import java.util.Set;
+import java.util.*;
 
 public class MutablePropertyImpl extends MutableProperty {
     private final String key;
     private final String name;
+    private final EnumSet<FetchHint> fetchHints;
     private Set<Visibility> hiddenVisibilities;
     private Object value;
     private Visibility visibility;
     private long timestamp;
     private final Metadata metadata;
 
-    public MutablePropertyImpl(String key, String name, Object value, Metadata metadata, Long timestamp, Set<Visibility> hiddenVisibilities, Visibility visibility) {
-        if (metadata == null) {
+    public MutablePropertyImpl(
+            String key,
+            String name,
+            Object value,
+            Metadata metadata,
+            Long timestamp,
+            Set<Visibility> hiddenVisibilities,
+            Visibility visibility,
+            EnumSet<FetchHint> fetchHints
+    ) {
+        if (metadata == null && fetchHints.contains(FetchHint.PROPERTY_METADATA)) {
             metadata = new Metadata();
         }
 
@@ -32,6 +36,7 @@ public class MutablePropertyImpl extends MutableProperty {
         this.timestamp = timestamp == null ? IncreasingTime.currentTimeMillis() : timestamp;
         this.visibility = visibility;
         this.hiddenVisibilities = hiddenVisibilities;
+        this.fetchHints = fetchHints;
     }
 
     public String getKey() {
@@ -56,6 +61,7 @@ public class MutablePropertyImpl extends MutableProperty {
     }
 
     public Metadata getMetadata() {
+        FetchHint.checkFetchHints(fetchHints, FetchHint.PROPERTY_METADATA);
         return metadata;
     }
 

--- a/core/src/main/java/org/vertexium/query/CompositeGraphQuery.java
+++ b/core/src/main/java/org/vertexium/query/CompositeGraphQuery.java
@@ -19,7 +19,7 @@ public class CompositeGraphQuery implements Query {
 
     @Override
     public QueryResultsIterable<Vertex> vertices() {
-        return vertices(FetchHint.ALL);
+        return vertices(FetchHint.DEFAULT);
     }
 
     @Override
@@ -44,7 +44,7 @@ public class CompositeGraphQuery implements Query {
 
     @Override
     public QueryResultsIterable<Edge> edges() {
-        return edges(FetchHint.ALL);
+        return edges(FetchHint.DEFAULT);
     }
 
     @Override
@@ -71,7 +71,7 @@ public class CompositeGraphQuery implements Query {
     @Deprecated
     public QueryResultsIterable<Edge> edges(final String label) {
         hasEdgeLabel(label);
-        return edges(FetchHint.ALL);
+        return edges(FetchHint.DEFAULT);
     }
 
     @Override
@@ -83,7 +83,7 @@ public class CompositeGraphQuery implements Query {
 
     @Override
     public QueryResultsIterable<Element> elements() {
-        return elements(FetchHint.ALL);
+        return elements(FetchHint.DEFAULT);
     }
 
     @Override
@@ -108,7 +108,7 @@ public class CompositeGraphQuery implements Query {
 
     @Override
     public QueryResultsIterable<ExtendedDataRow> extendedDataRows() {
-        return extendedDataRows(FetchHint.ALL);
+        return extendedDataRows(FetchHint.DEFAULT);
     }
 
     @Override
@@ -153,7 +153,7 @@ public class CompositeGraphQuery implements Query {
 
     @Override
     public QueryResultsIterable<? extends VertexiumObject> search() {
-        return search(VertexiumObjectType.ALL, FetchHint.ALL);
+        return search(VertexiumObjectType.ALL, FetchHint.DEFAULT);
     }
 
     @Override

--- a/core/src/main/java/org/vertexium/query/QueryBase.java
+++ b/core/src/main/java/org/vertexium/query/QueryBase.java
@@ -28,7 +28,7 @@ public abstract class QueryBase implements Query, SimilarToGraphQuery {
 
     @Override
     public QueryResultsIterable<Vertex> vertices() {
-        return vertices(FetchHint.ALL);
+        return vertices(FetchHint.DEFAULT);
     }
 
     @Override
@@ -39,7 +39,7 @@ public abstract class QueryBase implements Query, SimilarToGraphQuery {
 
     @Override
     public QueryResultsIterable<Edge> edges() {
-        return edges(FetchHint.ALL);
+        return edges(FetchHint.DEFAULT);
     }
 
     @Override
@@ -50,7 +50,7 @@ public abstract class QueryBase implements Query, SimilarToGraphQuery {
 
     @Override
     public QueryResultsIterable<ExtendedDataRow> extendedDataRows() {
-        return extendedDataRows(FetchHint.ALL);
+        return extendedDataRows(FetchHint.DEFAULT);
     }
 
     @Override
@@ -61,7 +61,7 @@ public abstract class QueryBase implements Query, SimilarToGraphQuery {
 
     @Override
     public QueryResultsIterable<? extends VertexiumObject> search() {
-        return search(VertexiumObjectType.ALL, FetchHint.ALL);
+        return search(VertexiumObjectType.ALL, FetchHint.DEFAULT);
     }
 
     @Override
@@ -188,7 +188,7 @@ public abstract class QueryBase implements Query, SimilarToGraphQuery {
 
     @Override
     public QueryResultsIterable<Element> elements() {
-        return elements(FetchHint.ALL);
+        return elements(FetchHint.DEFAULT);
     }
 
     @Override

--- a/core/src/test/java/org/vertexium/mutation/ExistingElementMutationImplTest.java
+++ b/core/src/test/java/org/vertexium/mutation/ExistingElementMutationImplTest.java
@@ -2,10 +2,7 @@ package org.vertexium.mutation;
 
 import org.junit.Before;
 import org.junit.Test;
-import org.vertexium.Authorizations;
-import org.vertexium.Element;
-import org.vertexium.Vertex;
-import org.vertexium.Visibility;
+import org.vertexium.*;
 import org.vertexium.property.MutablePropertyImpl;
 
 import static org.junit.Assert.assertFalse;
@@ -32,13 +29,31 @@ public class ExistingElementMutationImplTest {
 
     @Test
     public void testHasChangesDeleteProperty() {
-        mutation.deleteProperty(new MutablePropertyImpl("key1", "name1", "value", null, null, null, new Visibility("")));
+        mutation.deleteProperty(new MutablePropertyImpl(
+                "key1",
+                "name1",
+                "value",
+                null,
+                null,
+                null,
+                new Visibility(""),
+                FetchHint.ALL
+        ));
         assertTrue("should have changes", mutation.hasChanges());
     }
 
     @Test
     public void testHasChangesSoftDeleteProperty() {
-        mutation.softDeleteProperty(new MutablePropertyImpl("key1", "name1", "value", null, null, null, new Visibility("")));
+        mutation.softDeleteProperty(new MutablePropertyImpl(
+                "key1",
+                "name1",
+                "value",
+                null,
+                null,
+                null,
+                new Visibility(""),
+                FetchHint.ALL
+        ));
         assertTrue("should have changes", mutation.hasChanges());
     }
 

--- a/inmemory/src/main/java/org/vertexium/inmemory/InMemoryEdge.java
+++ b/inmemory/src/main/java/org/vertexium/inmemory/InMemoryEdge.java
@@ -15,11 +15,11 @@ public class InMemoryEdge extends InMemoryElement<InMemoryEdge> implements Edge 
             InMemoryGraph graph,
             String id,
             InMemoryTableEdge inMemoryTableElement,
-            boolean includeHidden,
+            EnumSet<FetchHint> fetchHints,
             Long endTime,
             Authorizations authorizations
     ) {
-        super(graph, id, inMemoryTableElement, includeHidden, endTime, authorizations);
+        super(graph, id, inMemoryTableElement, fetchHints, endTime, authorizations);
         edgeSetupMutation = inMemoryTableElement.findLastMutation(EdgeSetupMutation.class);
     }
 
@@ -47,7 +47,7 @@ public class InMemoryEdge extends InMemoryElement<InMemoryEdge> implements Edge 
 
     @Override
     public Vertex getVertex(Direction direction, Authorizations authorizations) {
-        return getVertex(direction, FetchHint.ALL, authorizations);
+        return getVertex(direction, FetchHint.DEFAULT, authorizations);
     }
 
     @Override
@@ -62,7 +62,7 @@ public class InMemoryEdge extends InMemoryElement<InMemoryEdge> implements Edge 
 
     @Override
     public Vertex getOtherVertex(String myVertexId, Authorizations authorizations) {
-        return getOtherVertex(myVertexId, FetchHint.ALL, authorizations);
+        return getOtherVertex(myVertexId, FetchHint.DEFAULT, authorizations);
     }
 
     @Override
@@ -72,7 +72,7 @@ public class InMemoryEdge extends InMemoryElement<InMemoryEdge> implements Edge 
 
     @Override
     public EdgeVertices getVertices(Authorizations authorizations) {
-        return getVertices(FetchHint.ALL, authorizations);
+        return getVertices(FetchHint.DEFAULT, authorizations);
     }
 
     @Override

--- a/inmemory/src/main/java/org/vertexium/inmemory/InMemoryTable.java
+++ b/inmemory/src/main/java/org/vertexium/inmemory/InMemoryTable.java
@@ -21,12 +21,12 @@ public abstract class InMemoryTable<TElement extends InMemoryElement> {
         this(new ConcurrentSkipListMap<String, InMemoryTableElement<TElement>>());
     }
 
-    public TElement get(InMemoryGraph graph, String id, Authorizations authorizations) {
+    public TElement get(InMemoryGraph graph, String id, EnumSet<FetchHint> fetchHints, Authorizations authorizations) {
         InMemoryTableElement<TElement> inMemoryTableElement = getTableElement(id);
         if (inMemoryTableElement == null) {
             return null;
         }
-        return inMemoryTableElement.createElement(graph, authorizations);
+        return inMemoryTableElement.createElement(graph, fetchHints, authorizations);
     }
 
     public InMemoryTableElement<TElement> getTableElement(String id) {
@@ -52,9 +52,12 @@ public abstract class InMemoryTable<TElement extends InMemoryElement> {
         rows.clear();
     }
 
-    public Iterable<TElement> getAll(final InMemoryGraph graph, final EnumSet<FetchHint> fetchHints, final Long endTime,
-                                     final Authorizations authorizations) {
-        final boolean includeHidden = fetchHints.contains(FetchHint.INCLUDE_HIDDEN);
+    public Iterable<TElement> getAll(
+            InMemoryGraph graph,
+            EnumSet<FetchHint> fetchHints,
+            Long endTime,
+            Authorizations authorizations
+    ) {
         return new LookAheadIterable<InMemoryTableElement<TElement>, TElement>() {
             @Override
             protected boolean isIncluded(InMemoryTableElement<TElement> src, TElement element) {
@@ -63,7 +66,7 @@ public abstract class InMemoryTable<TElement extends InMemoryElement> {
 
             @Override
             protected TElement convert(InMemoryTableElement<TElement> element) {
-                return element.createElement(graph, includeHidden, endTime, authorizations);
+                return element.createElement(graph, fetchHints, endTime, authorizations);
             }
 
             @Override

--- a/inmemory/src/main/java/org/vertexium/inmemory/InMemoryTableEdge.java
+++ b/inmemory/src/main/java/org/vertexium/inmemory/InMemoryTableEdge.java
@@ -1,6 +1,9 @@
 package org.vertexium.inmemory;
 
 import org.vertexium.Authorizations;
+import org.vertexium.FetchHint;
+
+import java.util.EnumSet;
 
 public class InMemoryTableEdge extends InMemoryTableElement<InMemoryEdge> {
     public InMemoryTableEdge(String id) {
@@ -8,7 +11,7 @@ public class InMemoryTableEdge extends InMemoryTableElement<InMemoryEdge> {
     }
 
     @Override
-    public InMemoryEdge createElementInternal(InMemoryGraph graph, boolean includeHidden, Long endTime, Authorizations authorizations) {
-        return new InMemoryEdge(graph, getId(), this, includeHidden, endTime, authorizations);
+    public InMemoryEdge createElementInternal(InMemoryGraph graph, EnumSet<FetchHint> fetchHints, Long endTime, Authorizations authorizations) {
+        return new InMemoryEdge(graph, getId(), this, fetchHints, endTime, authorizations);
     }
 }

--- a/inmemory/src/main/java/org/vertexium/inmemory/InMemoryTableVertex.java
+++ b/inmemory/src/main/java/org/vertexium/inmemory/InMemoryTableVertex.java
@@ -1,6 +1,9 @@
 package org.vertexium.inmemory;
 
 import org.vertexium.Authorizations;
+import org.vertexium.FetchHint;
+
+import java.util.EnumSet;
 
 public class InMemoryTableVertex extends InMemoryTableElement<InMemoryVertex> {
     public InMemoryTableVertex(String id) {
@@ -8,7 +11,7 @@ public class InMemoryTableVertex extends InMemoryTableElement<InMemoryVertex> {
     }
 
     @Override
-    public InMemoryVertex createElementInternal(InMemoryGraph graph, boolean includeHidden, Long endTime, Authorizations authorizations) {
-        return new InMemoryVertex(graph, getId(), this, includeHidden, endTime, authorizations);
+    public InMemoryVertex createElementInternal(InMemoryGraph graph, EnumSet<FetchHint> fetchHints, Long endTime, Authorizations authorizations) {
+        return new InMemoryVertex(graph, getId(), this, fetchHints, endTime, authorizations);
     }
 }

--- a/inmemory/src/main/java/org/vertexium/inmemory/InMemoryVertex.java
+++ b/inmemory/src/main/java/org/vertexium/inmemory/InMemoryVertex.java
@@ -17,7 +17,7 @@ public class InMemoryVertex extends InMemoryElement<InMemoryVertex> implements V
             InMemoryGraph graph,
             String id,
             InMemoryTableVertex inMemoryTableElement,
-            boolean includeHidden,
+            EnumSet<FetchHint> fetchHints,
             Long endTime,
             Authorizations authorizations
     ) {
@@ -25,7 +25,7 @@ public class InMemoryVertex extends InMemoryElement<InMemoryVertex> implements V
                 graph,
                 id,
                 inMemoryTableElement,
-                includeHidden,
+                fetchHints,
                 endTime,
                 authorizations
         );
@@ -33,7 +33,7 @@ public class InMemoryVertex extends InMemoryElement<InMemoryVertex> implements V
 
     @Override
     public Iterable<Edge> getEdges(Direction direction, Authorizations authorizations) {
-        return getEdges(direction, FetchHint.ALL, authorizations);
+        return getEdges(direction, FetchHint.DEFAULT, authorizations);
     }
 
     @Override
@@ -115,7 +115,7 @@ public class InMemoryVertex extends InMemoryElement<InMemoryVertex> implements V
 
     @Override
     public Iterable<Edge> getEdges(Direction direction, String label, Authorizations authorizations) {
-        return getEdges(direction, label, FetchHint.ALL, authorizations);
+        return getEdges(direction, label, FetchHint.DEFAULT, authorizations);
     }
 
     @Override
@@ -130,7 +130,7 @@ public class InMemoryVertex extends InMemoryElement<InMemoryVertex> implements V
 
     @Override
     public Iterable<Edge> getEdges(Direction direction, String[] labels, Authorizations authorizations) {
-        return getEdges(direction, labels, FetchHint.ALL, authorizations);
+        return getEdges(direction, labels, FetchHint.DEFAULT, authorizations);
     }
 
     @Override
@@ -158,7 +158,7 @@ public class InMemoryVertex extends InMemoryElement<InMemoryVertex> implements V
 
     @Override
     public Iterable<Edge> getEdges(Vertex otherVertex, Direction direction, Authorizations authorizations) {
-        return getEdges(otherVertex, direction, FetchHint.ALL, authorizations);
+        return getEdges(otherVertex, direction, FetchHint.DEFAULT, authorizations);
     }
 
     @Override
@@ -178,7 +178,7 @@ public class InMemoryVertex extends InMemoryElement<InMemoryVertex> implements V
 
     @Override
     public Iterable<Edge> getEdges(Vertex otherVertex, Direction direction, String label, Authorizations authorizations) {
-        return getEdges(otherVertex, direction, label, FetchHint.ALL, authorizations);
+        return getEdges(otherVertex, direction, label, FetchHint.DEFAULT, authorizations);
     }
 
     @Override
@@ -198,7 +198,7 @@ public class InMemoryVertex extends InMemoryElement<InMemoryVertex> implements V
 
     @Override
     public Iterable<Edge> getEdges(Vertex otherVertex, Direction direction, String[] labels, Authorizations authorizations) {
-        return getEdges(otherVertex, direction, labels, FetchHint.ALL, authorizations);
+        return getEdges(otherVertex, direction, labels, FetchHint.DEFAULT, authorizations);
     }
 
     @Override
@@ -233,7 +233,7 @@ public class InMemoryVertex extends InMemoryElement<InMemoryVertex> implements V
 
     @Override
     public Iterable<Vertex> getVertices(Direction direction, Authorizations authorizations) {
-        return getVertices(direction, FetchHint.ALL, authorizations);
+        return getVertices(direction, FetchHint.DEFAULT, authorizations);
     }
 
     @Override
@@ -243,7 +243,7 @@ public class InMemoryVertex extends InMemoryElement<InMemoryVertex> implements V
 
     @Override
     public Iterable<Vertex> getVertices(Direction direction, String label, Authorizations authorizations) {
-        return getVertices(direction, label, FetchHint.ALL, authorizations);
+        return getVertices(direction, label, FetchHint.DEFAULT, authorizations);
     }
 
     @Override
@@ -253,7 +253,7 @@ public class InMemoryVertex extends InMemoryElement<InMemoryVertex> implements V
 
     @Override
     public Iterable<Vertex> getVertices(Direction direction, String[] labels, Authorizations authorizations) {
-        return getVertices(direction, labels, FetchHint.ALL, authorizations);
+        return getVertices(direction, labels, FetchHint.DEFAULT, authorizations);
     }
 
     @Override
@@ -323,7 +323,7 @@ public class InMemoryVertex extends InMemoryElement<InMemoryVertex> implements V
 
     @Override
     public Iterable<EdgeVertexPair> getEdgeVertexPairs(Direction direction, Authorizations authorizations) {
-        return getEdgeVertexPairs(getEdgeInfos(direction, authorizations), FetchHint.ALL, null, authorizations);
+        return getEdgeVertexPairs(getEdgeInfos(direction, authorizations), FetchHint.DEFAULT, null, authorizations);
     }
 
     @Override
@@ -338,7 +338,7 @@ public class InMemoryVertex extends InMemoryElement<InMemoryVertex> implements V
 
     @Override
     public Iterable<EdgeVertexPair> getEdgeVertexPairs(Direction direction, String label, Authorizations authorizations) {
-        return getEdgeVertexPairs(getEdgeInfos(direction, label, authorizations), FetchHint.ALL, null, authorizations);
+        return getEdgeVertexPairs(getEdgeInfos(direction, label, authorizations), FetchHint.DEFAULT, null, authorizations);
     }
 
     @Override
@@ -348,7 +348,7 @@ public class InMemoryVertex extends InMemoryElement<InMemoryVertex> implements V
 
     @Override
     public Iterable<EdgeVertexPair> getEdgeVertexPairs(Direction direction, String[] labels, Authorizations authorizations) {
-        return getEdgeVertexPairs(getEdgeInfos(direction, labels, authorizations), FetchHint.ALL, null, authorizations);
+        return getEdgeVertexPairs(getEdgeInfos(direction, labels, authorizations), FetchHint.DEFAULT, null, authorizations);
     }
 
     @Override

--- a/sql/src/main/java/org/vertexium/sql/SqlGraph.java
+++ b/sql/src/main/java/org/vertexium/sql/SqlGraph.java
@@ -72,24 +72,26 @@ public class SqlGraph extends InMemoryGraph {
     }
 
     @Override
-    public Vertex getVertex(String vertexId, EnumSet<FetchHint> fetchHints, Long endTime,
-                            Authorizations authorizations) {
+    public Vertex getVertex(
+            String vertexId, EnumSet<FetchHint> fetchHints, Long endTime,
+            Authorizations authorizations
+    ) {
         validateAuthorizations(authorizations);
 
         InMemoryTableElement<InMemoryVertex> element = vertexMap.get(vertexId);
         if (element == null || !isIncludedInTimeSpan(element, fetchHints, endTime, authorizations)) {
             return null;
         } else {
-            return element.createElement(this, fetchHints.contains(FetchHint.INCLUDE_HIDDEN), endTime, authorizations);
+            return element.createElement(this, fetchHints, endTime, authorizations);
         }
     }
 
     @Override
-    public Iterable<Vertex> getVerticesWithPrefix(final String vertexIdPrefix, final EnumSet<FetchHint> fetchHints,
-                                                  final Long endTime, final Authorizations authorizations) {
+    public Iterable<Vertex> getVerticesWithPrefix(
+            final String vertexIdPrefix, final EnumSet<FetchHint> fetchHints,
+            final Long endTime, final Authorizations authorizations
+    ) {
         validateAuthorizations(authorizations);
-
-        final boolean includeHidden = fetchHints.contains(FetchHint.INCLUDE_HIDDEN);
 
         return new LookAheadIterable<InMemoryTableVertex, Vertex>() {
             @Override
@@ -99,13 +101,15 @@ public class SqlGraph extends InMemoryGraph {
 
             @Override
             protected Vertex convert(InMemoryTableVertex element) {
-                return element.createElement(SqlGraph.this, includeHidden, endTime, authorizations);
+                return element.createElement(SqlGraph.this, fetchHints, endTime, authorizations);
             }
 
             @Override
             protected Iterator<InMemoryTableVertex> createIterator() {
-                Iterator<InMemoryTableElement<InMemoryVertex>> elements = vertexMap.query("id like ?",
-                        vertexIdPrefix + "%");
+                Iterator<InMemoryTableElement<InMemoryVertex>> elements = vertexMap.query(
+                        "id like ?",
+                        vertexIdPrefix + "%"
+                );
 
                 return new ConvertingIterable<InMemoryTableElement<InMemoryVertex>, InMemoryTableVertex>(elements) {
                     @Override
@@ -123,30 +127,37 @@ public class SqlGraph extends InMemoryGraph {
         if (element == null || !isIncluded(element, fetchHints, authorizations)) {
             return null;
         } else {
-            return element.createElement(this, fetchHints.contains(FetchHint.INCLUDE_HIDDEN), endTime, authorizations);
+            return element.createElement(this, fetchHints, endTime, authorizations);
         }
     }
 
     @SuppressWarnings("unchecked")
     @Override
-    public Iterable<Vertex> getVertices(final Iterable<String> ids, final EnumSet<FetchHint> fetchHints,
-                                        final Long endTime, final Authorizations authorizations) {
+    public Iterable<Vertex> getVertices(
+            final Iterable<String> ids, final EnumSet<FetchHint> fetchHints,
+            final Long endTime, final Authorizations authorizations
+    ) {
         return (Iterable<Vertex>) getElements(ids, fetchHints, endTime, authorizations, vertexMap);
     }
 
     @SuppressWarnings("unchecked")
     @Override
-    public Iterable<Edge> getEdges(final Iterable<String> ids, final EnumSet<FetchHint> fetchHints, final Long endTime,
-                                   final Authorizations authorizations) {
+    public Iterable<Edge> getEdges(
+            Iterable<String> ids,
+            EnumSet<FetchHint> fetchHints,
+            Long endTime,
+            Authorizations authorizations
+    ) {
         return (Iterable<Edge>) getElements(ids, fetchHints, endTime, authorizations, edgeMap);
     }
 
-    private <T extends InMemoryElement> Iterable<?> getElements(final Iterable<String> ids,
-                                                                final EnumSet<FetchHint> fetchHints, final Long endTime,
-                                                                final Authorizations authorizations,
-                                                                final SqlMap<InMemoryTableElement<T>> sqlMap) {
-        final boolean includeHidden = fetchHints.contains(FetchHint.INCLUDE_HIDDEN);
-
+    private <T extends InMemoryElement> Iterable<?> getElements(
+            Iterable<String> ids,
+            EnumSet<FetchHint> fetchHints,
+            Long endTime,
+            Authorizations authorizations,
+            SqlMap<InMemoryTableElement<T>> sqlMap
+    ) {
         return new LookAheadIterable<InMemoryTableElement, T>() {
             @Override
             protected boolean isIncluded(InMemoryTableElement srcElement, T destElement) {
@@ -156,7 +167,7 @@ public class SqlGraph extends InMemoryGraph {
             @SuppressWarnings("unchecked")
             @Override
             protected T convert(InMemoryTableElement element) {
-                return (T) element.createElement(SqlGraph.this, includeHidden, endTime, authorizations);
+                return (T) element.createElement(SqlGraph.this, fetchHints, endTime, authorizations);
             }
 
             @SuppressWarnings("unused")
@@ -176,8 +187,10 @@ public class SqlGraph extends InMemoryGraph {
                 if (first) {
                     return Collections.emptyIterator();
                 } else {
-                    Iterator<InMemoryTableElement<T>> elements = sqlMap.query(idWhere.toString(),
-                            Iterables.toArray(ids, Object.class));
+                    Iterator<InMemoryTableElement<T>> elements = sqlMap.query(
+                            idWhere.toString(),
+                            Iterables.toArray(ids, Object.class)
+                    );
 
                     return new ConvertingIterable<InMemoryTableElement, InMemoryTableElement>(elements) {
                         @Override
@@ -191,10 +204,12 @@ public class SqlGraph extends InMemoryGraph {
     }
 
     @Override
-    public Iterable<Edge> getEdgesFromVertex(final String vertexId, final EnumSet<FetchHint> fetchHints,
-                                             final Long endTime, final Authorizations authorizations) {
-        final boolean includeHidden = fetchHints.contains(FetchHint.INCLUDE_HIDDEN);
-
+    public Iterable<Edge> getEdgesFromVertex(
+            String vertexId,
+            EnumSet<FetchHint> fetchHints,
+            Long endTime,
+            Authorizations authorizations
+    ) {
         return new LookAheadIterable<InMemoryTableEdge, Edge>() {
             @Override
             protected boolean isIncluded(InMemoryTableEdge element, Edge edge) {
@@ -203,7 +218,7 @@ public class SqlGraph extends InMemoryGraph {
 
             @Override
             protected Edge convert(InMemoryTableEdge element) {
-                return element.createElement(SqlGraph.this, includeHidden, endTime, authorizations);
+                return element.createElement(SqlGraph.this, fetchHints, endTime, authorizations);
             }
 
             @Override
@@ -236,9 +251,11 @@ public class SqlGraph extends InMemoryGraph {
     }
 
     @Override
-    protected StreamingPropertyValueRef saveStreamingPropertyValue(String elementId, String key, String name,
-                                                                   Visibility visibility, long timestamp,
-                                                                   StreamingPropertyValue value) {
+    protected StreamingPropertyValueRef saveStreamingPropertyValue(
+            String elementId, String key, String name,
+            Visibility visibility, long timestamp,
+            StreamingPropertyValue value
+    ) {
         return streamingPropertyTable.put(elementId, key, name, visibility, timestamp, value);
     }
 }

--- a/sql/src/main/java/org/vertexium/sql/SqlTableEdge.java
+++ b/sql/src/main/java/org/vertexium/sql/SqlTableEdge.java
@@ -8,6 +8,7 @@ import org.vertexium.inmemory.mutations.EdgeSetupMutation;
 import org.vertexium.inmemory.mutations.Mutation;
 import org.vertexium.sql.collections.Storable;
 
+import java.util.EnumSet;
 import java.util.List;
 import java.util.Map;
 import java.util.Set;
@@ -20,8 +21,8 @@ public class SqlTableEdge extends SqlTableElement<InMemoryEdge> {
     }
 
     @Override
-    public InMemoryEdge createElementInternal(InMemoryGraph graph, boolean includeHidden, Long endTime, Authorizations authorizations) {
-        return new InMemoryEdge(graph, getId(), asInMemoryTableElement(), includeHidden, endTime, authorizations);
+    public InMemoryEdge createElementInternal(InMemoryGraph graph, EnumSet<FetchHint> fetchHints, Long endTime, Authorizations authorizations) {
+        return new InMemoryEdge(graph, getId(), asInMemoryTableElement(), fetchHints, endTime, authorizations);
     }
 
     String inVertexId() {
@@ -99,8 +100,8 @@ public class SqlTableEdge extends SqlTableElement<InMemoryEdge> {
         }
 
         @Override
-        public Property getProperty(String key, String name, Visibility visibility, Authorizations authorizations) {
-            return sqlTableEdge.getProperty(key, name, visibility, authorizations);
+        public Property getProperty(String key, String name, Visibility visibility, EnumSet<FetchHint> fetchHints, Authorizations authorizations) {
+            return sqlTableEdge.getProperty(key, name, visibility, fetchHints, authorizations);
         }
 
         @Override
@@ -119,8 +120,8 @@ public class SqlTableEdge extends SqlTableElement<InMemoryEdge> {
         }
 
         @Override
-        public Iterable<Property> getProperties(boolean includeHidden, Long endTime, Authorizations authorizations) {
-            return sqlTableEdge.getProperties(includeHidden, endTime, authorizations);
+        public Iterable<Property> getProperties(EnumSet<FetchHint> fetchHints, Long endTime, Authorizations authorizations) {
+            return sqlTableEdge.getProperties(fetchHints, endTime, authorizations);
         }
 
         @Override
@@ -194,8 +195,8 @@ public class SqlTableEdge extends SqlTableElement<InMemoryEdge> {
         }
 
         @Override
-        public InMemoryEdge createElement(InMemoryGraph graph, Authorizations authorizations) {
-            return sqlTableEdge.createElement(graph, authorizations);
+        public InMemoryEdge createElement(InMemoryGraph graph, EnumSet<FetchHint> fetchHints, Authorizations authorizations) {
+            return sqlTableEdge.createElement(graph, fetchHints, authorizations);
         }
 
         @Override
@@ -204,8 +205,8 @@ public class SqlTableEdge extends SqlTableElement<InMemoryEdge> {
         }
 
         @Override
-        public InMemoryEdge createElementInternal(InMemoryGraph graph, boolean includeHidden, Long endTime, Authorizations authorizations) {
-            return sqlTableEdge.createElementInternal(graph, includeHidden, endTime, authorizations);
+        public InMemoryEdge createElementInternal(InMemoryGraph graph, EnumSet<FetchHint> fetchHints, Long endTime, Authorizations authorizations) {
+            return sqlTableEdge.createElementInternal(graph, fetchHints, endTime, authorizations);
         }
     }
 }

--- a/sql/src/main/java/org/vertexium/sql/SqlTableVertex.java
+++ b/sql/src/main/java/org/vertexium/sql/SqlTableVertex.java
@@ -7,6 +7,7 @@ import org.vertexium.inmemory.InMemoryVertex;
 import org.vertexium.inmemory.mutations.Mutation;
 import org.vertexium.sql.collections.Storable;
 
+import java.util.EnumSet;
 import java.util.List;
 import java.util.Map;
 import java.util.Set;
@@ -20,10 +21,12 @@ public class SqlTableVertex extends SqlTableElement<InMemoryVertex> {
 
     @Override
     public InMemoryVertex createElementInternal(
-            InMemoryGraph graph, boolean includeHidden, Long endTime,
+            InMemoryGraph graph,
+            EnumSet<FetchHint> fetchHints,
+            Long endTime,
             Authorizations authorizations
     ) {
-        return new InMemoryVertex(graph, getId(), asInMemoryTableElement(), includeHidden, endTime, authorizations);
+        return new InMemoryVertex(graph, getId(), asInMemoryTableElement(), fetchHints, endTime, authorizations);
     }
 
     @Override
@@ -91,8 +94,8 @@ public class SqlTableVertex extends SqlTableElement<InMemoryVertex> {
         }
 
         @Override
-        public Property getProperty(String key, String name, Visibility visibility, Authorizations authorizations) {
-            return sqlTableVertex.getProperty(key, name, visibility, authorizations);
+        public Property getProperty(String key, String name, Visibility visibility, EnumSet<FetchHint> fetchHints, Authorizations authorizations) {
+            return sqlTableVertex.getProperty(key, name, visibility, fetchHints, authorizations);
         }
 
         @Override
@@ -111,8 +114,8 @@ public class SqlTableVertex extends SqlTableElement<InMemoryVertex> {
         }
 
         @Override
-        public Iterable<Property> getProperties(boolean includeHidden, Long endTime, Authorizations authorizations) {
-            return sqlTableVertex.getProperties(includeHidden, endTime, authorizations);
+        public Iterable<Property> getProperties(EnumSet<FetchHint> fetchHints, Long endTime, Authorizations authorizations) {
+            return sqlTableVertex.getProperties(fetchHints, endTime, authorizations);
         }
 
         @Override
@@ -186,8 +189,8 @@ public class SqlTableVertex extends SqlTableElement<InMemoryVertex> {
         }
 
         @Override
-        public InMemoryVertex createElement(InMemoryGraph graph, Authorizations authorizations) {
-            return sqlTableVertex.createElement(graph, authorizations);
+        public InMemoryVertex createElement(InMemoryGraph graph, EnumSet<FetchHint> fetchHints, Authorizations authorizations) {
+            return sqlTableVertex.createElement(graph, fetchHints, authorizations);
         }
 
         @Override
@@ -196,8 +199,8 @@ public class SqlTableVertex extends SqlTableElement<InMemoryVertex> {
         }
 
         @Override
-        public InMemoryVertex createElementInternal(InMemoryGraph graph, boolean includeHidden, Long endTime, Authorizations authorizations) {
-            return sqlTableVertex.createElementInternal(graph, includeHidden, endTime, authorizations);
+        public InMemoryVertex createElementInternal(InMemoryGraph graph, EnumSet<FetchHint> fetchHints, Long endTime, Authorizations authorizations) {
+            return sqlTableVertex.createElementInternal(graph, fetchHints, endTime, authorizations);
         }
     }
 }

--- a/test/src/main/java/org/vertexium/test/GraphTestBase.java
+++ b/test/src/main/java/org/vertexium/test/GraphTestBase.java
@@ -21,6 +21,7 @@ import org.vertexium.query.*;
 import org.vertexium.search.DefaultSearchIndex;
 import org.vertexium.search.IndexHint;
 import org.vertexium.test.util.LargeStringInputStream;
+import org.vertexium.test.util.VertexiumAssert;
 import org.vertexium.type.*;
 import org.vertexium.util.*;
 
@@ -236,7 +237,7 @@ public abstract class GraphTestBase {
                 .save(AUTHORIZATIONS_A_AND_B);
         graph.flush();
 
-        Vertex v = graph.getVertex("v1", AUTHORIZATIONS_A);
+        Vertex v = graph.getVertex("v1", FetchHint.ALL, AUTHORIZATIONS_A);
         if (v instanceof HasTimestamp) {
             assertTrue("timestamp should be more than 0", v.getTimestamp() > 0);
         }
@@ -258,7 +259,7 @@ public abstract class GraphTestBase {
                 .save(AUTHORIZATIONS_A_AND_B);
         graph.flush();
 
-        v = graph.getVertex("v1", AUTHORIZATIONS_A);
+        v = graph.getVertex("v1", FetchHint.ALL, AUTHORIZATIONS_A);
         Assert.assertEquals(1, count(v.getProperties("prop1")));
         prop1 = v.getProperties("prop1").iterator().next();
         prop1Metadata = prop1.getMetadata();
@@ -271,7 +272,7 @@ public abstract class GraphTestBase {
         v.setProperty("prop1", "value2", prop1Metadata, VISIBILITY_A, AUTHORIZATIONS_A_AND_B);
         graph.flush();
 
-        v = graph.getVertex("v1", AUTHORIZATIONS_A);
+        v = graph.getVertex("v1", FetchHint.ALL, AUTHORIZATIONS_A);
         Assert.assertEquals(1, count(v.getProperties("prop1")));
         prop1 = v.getProperties("prop1").iterator().next();
         assertEquals("value2", prop1.getValue());
@@ -438,13 +439,13 @@ public abstract class GraphTestBase {
         graph.flush();
         clearGraphEvents();
 
-        v = graph.getVertex("v1", AUTHORIZATIONS_A);
+        v = graph.getVertex("v1", FetchHint.ALL, AUTHORIZATIONS_A);
         Property prop1_propid1a = v.getProperty("propid1a", "prop1");
         Property prop1_propid1b = v.getProperty("propid1b", "prop1");
         v.deleteProperties("prop1", AUTHORIZATIONS_A_AND_B);
         graph.flush();
         Assert.assertEquals(1, count(v.getProperties()));
-        v = graph.getVertex("v1", AUTHORIZATIONS_A);
+        v = graph.getVertex("v1", FetchHint.ALL, AUTHORIZATIONS_A);
         Assert.assertEquals(1, count(v.getProperties()));
 
         Assert.assertEquals(1, count(graph.query(AUTHORIZATIONS_A_AND_B).has("prop2", "value2a").vertices()));
@@ -482,7 +483,7 @@ public abstract class GraphTestBase {
         clearGraphEvents();
 
         // delete multiple properties
-        v1 = graph.getVertex("v1", AUTHORIZATIONS_A);
+        v1 = graph.getVertex("v1", FetchHint.ALL, AUTHORIZATIONS_A);
         Property prop1_propid1a = v1.getProperty("propid1a", "prop1");
         Property prop1_propid1b = v1.getProperty("propid1b", "prop1");
         v1.prepareMutation()
@@ -490,7 +491,7 @@ public abstract class GraphTestBase {
                 .save(AUTHORIZATIONS_A_AND_B);
         graph.flush();
         Assert.assertEquals(1, count(v1.getProperties()));
-        v1 = graph.getVertex("v1", AUTHORIZATIONS_A);
+        v1 = graph.getVertex("v1", FetchHint.ALL, AUTHORIZATIONS_A);
         Assert.assertEquals(1, count(v1.getProperties()));
 
         Assert.assertEquals(1, count(graph.query(AUTHORIZATIONS_A_AND_B).has("prop2", "value2a").vertices()));
@@ -516,7 +517,7 @@ public abstract class GraphTestBase {
         clearGraphEvents();
 
         // delete property from edge
-        Edge e1 = graph.getEdge("e1", AUTHORIZATIONS_A);
+        Edge e1 = graph.getEdge("e1", FetchHint.ALL, AUTHORIZATIONS_A);
         Property edgeProperty = e1.getProperty("key1", "prop1");
         e1.prepareMutation()
                 .deleteProperties("key1", "prop1")
@@ -618,15 +619,15 @@ public abstract class GraphTestBase {
         graph.flush();
 
         assertNull(graph.getEdge(e1.getId(), AUTHORIZATIONS_A));
-        assertNull(graph.getEdge(e1.getId(), FetchHint.ALL, AUTHORIZATIONS_A));
+        assertNull(graph.getEdge(e1.getId(), FetchHint.DEFAULT, AUTHORIZATIONS_A));
         assertNull(graph.getEdge(e1.getId(), FetchHint.ALL_INCLUDING_HIDDEN, AUTHORIZATIONS_A));
         assertNull(graph.getVertex(v1.getId(), AUTHORIZATIONS_A));
-        assertNull(graph.getVertex(v1.getId(), FetchHint.ALL, AUTHORIZATIONS_A));
+        assertNull(graph.getVertex(v1.getId(), FetchHint.DEFAULT, AUTHORIZATIONS_A));
         assertNull(graph.getVertex(v1.getId(), FetchHint.ALL_INCLUDING_HIDDEN, AUTHORIZATIONS_A));
 
-        assertNotNull(graph.getEdge(e1.getId(), FetchHint.ALL, beforeDeleteTime, AUTHORIZATIONS_A));
+        assertNotNull(graph.getEdge(e1.getId(), FetchHint.DEFAULT, beforeDeleteTime, AUTHORIZATIONS_A));
         assertNotNull(graph.getEdge(e1.getId(), FetchHint.ALL_INCLUDING_HIDDEN, beforeDeleteTime, AUTHORIZATIONS_A));
-        assertNotNull(graph.getVertex(v1.getId(), FetchHint.ALL, beforeDeleteTime, AUTHORIZATIONS_A));
+        assertNotNull(graph.getVertex(v1.getId(), FetchHint.DEFAULT, beforeDeleteTime, AUTHORIZATIONS_A));
         assertNotNull(graph.getVertex(v1.getId(), FetchHint.ALL_INCLUDING_HIDDEN, beforeDeleteTime, AUTHORIZATIONS_A));
     }
 
@@ -930,7 +931,7 @@ public abstract class GraphTestBase {
         assertEquals(1, count(properties));
         graph.flush();
 
-        v1 = graph.getVertex("v1", FetchHint.ALL, beforeMarkPropertyVisibleTimestamp, AUTHORIZATIONS_A_AND_B);
+        v1 = graph.getVertex("v1", FetchHint.DEFAULT, beforeMarkPropertyVisibleTimestamp, AUTHORIZATIONS_A_AND_B);
         assertNotNull("could not find v1 before timestamp " + beforeMarkPropertyVisibleTimestamp + " current time " + t, v1);
         properties = IterableUtils.toList(v1.getProperties());
         assertEquals(0, count(properties));
@@ -1204,7 +1205,7 @@ public abstract class GraphTestBase {
         Assert.assertEquals(1, count(graph.getVertices(AUTHORIZATIONS_A)));
         Assert.assertEquals(0, count(graph.getVertices(AUTHORIZATIONS_B)));
         Assert.assertEquals(0, count(graph.getEdges(AUTHORIZATIONS_A)));
-        assertNull("found v1 but shouldn't have", graph.getVertex("v1", FetchHint.ALL, AUTHORIZATIONS_A));
+        assertNull("found v1 but shouldn't have", graph.getVertex("v1", FetchHint.DEFAULT, AUTHORIZATIONS_A));
         Vertex v1Hidden = graph.getVertex("v1", FetchHint.ALL_INCLUDING_HIDDEN, AUTHORIZATIONS_A);
         assertNotNull("did not find v1 but should have", v1Hidden);
         assertTrue("v1 should be hidden", v1Hidden.isHidden(AUTHORIZATIONS_A));
@@ -1279,7 +1280,7 @@ public abstract class GraphTestBase {
         Assert.assertEquals(0, count(graph.findPaths(new FindPathOptions("v1", "v3", 2), AUTHORIZATIONS_A_AND_B)));
         Assert.assertEquals(0, count(graph.findPaths(new FindPathOptions("v1", "v3", 10), AUTHORIZATIONS_A_AND_B)));
         Assert.assertEquals(1, count(graph.findPaths(new FindPathOptions("v1", "v3", 10), AUTHORIZATIONS_A)));
-        assertNull("found e1 but shouldn't have", graph.getEdge("v1tov2", FetchHint.ALL, AUTHORIZATIONS_A_AND_B));
+        assertNull("found e1 but shouldn't have", graph.getEdge("v1tov2", FetchHint.DEFAULT, AUTHORIZATIONS_A_AND_B));
         Edge e1Hidden = graph.getEdge("v1tov2", FetchHint.ALL_INCLUDING_HIDDEN, AUTHORIZATIONS_A_AND_B);
         assertNotNull("did not find e1 but should have", e1Hidden);
         assertTrue("e1 should be hidden", e1Hidden.isHidden(AUTHORIZATIONS_A_AND_B));
@@ -1462,14 +1463,14 @@ public abstract class GraphTestBase {
         assertEquals(v2, addedEdgeVertices.getInVertex());
 
         graph.getVertex("v1", FetchHint.NONE, AUTHORIZATIONS_A);
-        graph.getVertex("v1", FetchHint.ALL, AUTHORIZATIONS_A);
+        graph.getVertex("v1", FetchHint.DEFAULT, AUTHORIZATIONS_A);
         graph.getVertex("v1", EnumSet.of(FetchHint.PROPERTIES), AUTHORIZATIONS_A);
         graph.getVertex("v1", FetchHint.EDGE_REFS, AUTHORIZATIONS_A);
         graph.getVertex("v1", EnumSet.of(FetchHint.IN_EDGE_REFS), AUTHORIZATIONS_A);
         graph.getVertex("v1", EnumSet.of(FetchHint.OUT_EDGE_REFS), AUTHORIZATIONS_A);
 
         graph.getEdge("e1", FetchHint.NONE, AUTHORIZATIONS_A);
-        graph.getEdge("e1", FetchHint.ALL, AUTHORIZATIONS_A);
+        graph.getEdge("e1", FetchHint.DEFAULT, AUTHORIZATIONS_A);
         graph.getEdge("e1", EnumSet.of(FetchHint.PROPERTIES), AUTHORIZATIONS_A);
 
         Edge e = graph.getEdge("e1", AUTHORIZATIONS_B);
@@ -3693,7 +3694,7 @@ public abstract class GraphTestBase {
         graph.createAuthorizations(AUTHORIZATIONS_ALL);
         graph.flush();
 
-        Vertex v1 = graph.getVertex("v1", AUTHORIZATIONS_ALL);
+        Vertex v1 = graph.getVertex("v1", FetchHint.ALL, AUTHORIZATIONS_ALL);
         ExistingElementMutation<Vertex> m = v1.prepareMutation();
         m.alterElementVisibility(VISIBILITY_B);
         for (Property property : v1.getProperties()) {
@@ -3703,7 +3704,7 @@ public abstract class GraphTestBase {
         m.save(AUTHORIZATIONS_ALL);
         graph.flush();
 
-        v1 = graph.getVertex("v1", AUTHORIZATIONS_B);
+        v1 = graph.getVertex("v1", FetchHint.ALL, AUTHORIZATIONS_B);
         assertEquals(VISIBILITY_B, v1.getVisibility());
         List<Property> properties = toList(v1.getProperties());
         assertEquals(1, properties.size());
@@ -3745,7 +3746,7 @@ public abstract class GraphTestBase {
                 .save(AUTHORIZATIONS_A_AND_B);
         graph.flush();
 
-        Vertex v1 = graph.getVertex("v1", AUTHORIZATIONS_A_AND_B);
+        Vertex v1 = graph.getVertex("v1", FetchHint.ALL, AUTHORIZATIONS_A_AND_B);
         v1.prepareMutation()
                 .alterPropertyVisibility("prop1", VISIBILITY_B)
                 .save(AUTHORIZATIONS_A_AND_B);
@@ -3768,7 +3769,7 @@ public abstract class GraphTestBase {
             assertEquals(1L, (long) propertyCountByValue.get("value1"));
         }
 
-        v1 = graph.getVertex("v1", AUTHORIZATIONS_A_AND_B);
+        v1 = graph.getVertex("v1", FetchHint.ALL, AUTHORIZATIONS_A_AND_B);
         Property v1Prop1 = v1.getProperty("prop1");
         assertNotNull(v1Prop1);
         Assert.assertEquals(1, toList(v1Prop1.getMetadata().entrySet()).size());
@@ -3776,7 +3777,7 @@ public abstract class GraphTestBase {
         assertNotNull(v1.getProperty("prop2"));
 
         // alter and set property in one mutation
-        v1 = graph.getVertex("v1", AUTHORIZATIONS_A_AND_B);
+        v1 = graph.getVertex("v1", FetchHint.ALL, AUTHORIZATIONS_A_AND_B);
         v1.prepareMutation()
                 .alterPropertyVisibility("prop1", VISIBILITY_A)
                 .setProperty("prop1", "value1New", VISIBILITY_A)
@@ -3788,7 +3789,7 @@ public abstract class GraphTestBase {
         assertEquals("value1New", v1.getPropertyValue("prop1"));
 
         // alter visibility to the same visibility
-        v1 = graph.getVertex("v1", AUTHORIZATIONS_A_AND_B);
+        v1 = graph.getVertex("v1", FetchHint.ALL, AUTHORIZATIONS_A_AND_B);
         v1.prepareMutation()
                 .alterPropertyVisibility("prop1", VISIBILITY_A)
                 .setProperty("prop1", "value1New2", VISIBILITY_A)
@@ -3810,14 +3811,14 @@ public abstract class GraphTestBase {
                 .save(AUTHORIZATIONS_A_AND_B);
         graph.flush();
 
-        Vertex v1 = graph.getVertex("v1", AUTHORIZATIONS_A_AND_B);
+        Vertex v1 = graph.getVertex("v1", FetchHint.ALL, AUTHORIZATIONS_A_AND_B);
         v1.prepareMutation()
                 .alterPropertyVisibility("prop1", VISIBILITY_B)
                 .setPropertyMetadata("prop1", "prop1_key1", "metadata1New", VISIBILITY_EMPTY)
                 .save(AUTHORIZATIONS_A_AND_B);
         graph.flush();
 
-        v1 = graph.getVertex("v1", AUTHORIZATIONS_A_AND_B);
+        v1 = graph.getVertex("v1", FetchHint.ALL, AUTHORIZATIONS_A_AND_B);
         assertNotNull(v1.getProperty("prop1"));
         assertEquals(VISIBILITY_B, v1.getProperty("prop1").getVisibility());
         assertEquals("metadata1New", v1.getProperty("prop1").getMetadata().getValue("prop1_key1"));
@@ -3838,7 +3839,7 @@ public abstract class GraphTestBase {
 
         long beforeAlterTimestamp = IncreasingTime.currentTimeMillis();
 
-        Vertex v1 = graph.getVertex("v1", AUTHORIZATIONS_A);
+        Vertex v1 = graph.getVertex("v1", FetchHint.ALL, AUTHORIZATIONS_A);
         v1.prepareMutation()
                 .alterPropertyVisibility(v1.getProperty("", "prop1", VISIBILITY_A), VISIBILITY_EMPTY)
                 .save(AUTHORIZATIONS_A_AND_B);
@@ -3850,7 +3851,7 @@ public abstract class GraphTestBase {
         assertEquals("value2", v1.getProperty("", "prop1", VISIBILITY_EMPTY).getValue());
         assertNull(v1.getProperty("", "prop1", VISIBILITY_A));
 
-        v1 = graph.getVertex("v1", FetchHint.ALL, beforeAlterTimestamp, AUTHORIZATIONS_A);
+        v1 = graph.getVertex("v1", FetchHint.DEFAULT, beforeAlterTimestamp, AUTHORIZATIONS_A);
         assertEquals(2, count(v1.getProperties()));
         assertNotNull(v1.getProperty("", "prop1", VISIBILITY_EMPTY));
         assertEquals("value1", v1.getProperty("", "prop1", VISIBILITY_EMPTY).getValue());
@@ -3934,14 +3935,14 @@ public abstract class GraphTestBase {
         graph.flush();
         Assert.assertEquals(2, count(graph.getVertex("v1", AUTHORIZATIONS_A).getProperties()));
 
-        graph.getVertex("v1", AUTHORIZATIONS_A)
+        graph.getVertex("v1", FetchHint.ALL, AUTHORIZATIONS_A)
                 .prepareMutation()
                 .alterPropertyVisibility("propSmall", VISIBILITY_B)
                 .save(AUTHORIZATIONS_A_AND_B);
         graph.flush();
         Assert.assertEquals(1, count(graph.getVertex("v1", AUTHORIZATIONS_A).getProperties()));
 
-        graph.getVertex("v1", AUTHORIZATIONS_A)
+        graph.getVertex("v1", FetchHint.ALL, AUTHORIZATIONS_A)
                 .prepareMutation()
                 .alterPropertyVisibility(largePropertyName, VISIBILITY_B)
                 .save(AUTHORIZATIONS_A_AND_B);
@@ -3962,24 +3963,24 @@ public abstract class GraphTestBase {
                 .save(AUTHORIZATIONS_A_AND_B);
         graph.flush();
 
-        Vertex v1 = graph.getVertex("v1", AUTHORIZATIONS_A);
+        Vertex v1 = graph.getVertex("v1", FetchHint.ALL, AUTHORIZATIONS_A);
         v1.prepareMutation()
                 .setPropertyMetadata("prop1", "prop1_key1", "valueNew", VISIBILITY_EMPTY)
                 .save(AUTHORIZATIONS_A_AND_B);
         graph.flush();
         assertEquals("valueNew", v1.getProperty("prop1").getMetadata().getEntry("prop1_key1", VISIBILITY_EMPTY).getValue());
 
-        v1 = graph.getVertex("v1", AUTHORIZATIONS_A);
+        v1 = graph.getVertex("v1", FetchHint.ALL, AUTHORIZATIONS_A);
         assertEquals("valueNew", v1.getProperty("prop1").getMetadata().getEntry("prop1_key1", VISIBILITY_EMPTY).getValue());
 
-        v1 = graph.getVertex("v1", AUTHORIZATIONS_A);
+        v1 = graph.getVertex("v1", FetchHint.ALL, AUTHORIZATIONS_A);
         v1.prepareMutation()
                 .setPropertyMetadata("prop2", "prop2_key1", "valueNew", VISIBILITY_EMPTY)
                 .save(AUTHORIZATIONS_A_AND_B);
         graph.flush();
         assertEquals("valueNew", v1.getProperty("prop2").getMetadata().getEntry("prop2_key1", VISIBILITY_EMPTY).getValue());
 
-        v1 = graph.getVertex("v1", AUTHORIZATIONS_A);
+        v1 = graph.getVertex("v1", FetchHint.ALL, AUTHORIZATIONS_A);
         assertEquals("valueNew", v1.getProperty("prop2").getMetadata().getEntry("prop2_key1", VISIBILITY_EMPTY).getValue());
     }
 
@@ -3993,7 +3994,7 @@ public abstract class GraphTestBase {
                 .save(AUTHORIZATIONS_A_AND_B);
         graph.flush();
 
-        Vertex v1 = graph.getVertex("v1", AUTHORIZATIONS_A_AND_B);
+        Vertex v1 = graph.getVertex("v1", FetchHint.ALL, AUTHORIZATIONS_A_AND_B);
         Property p1 = v1.getProperty("prop1", VISIBILITY_A);
         v1.prepareMutation()
                 .alterPropertyVisibility(p1, VISIBILITY_B)
@@ -4001,7 +4002,7 @@ public abstract class GraphTestBase {
                 .save(AUTHORIZATIONS_A_AND_B);
         graph.flush();
 
-        v1 = graph.getVertex("v1", AUTHORIZATIONS_A_AND_B);
+        v1 = graph.getVertex("v1", FetchHint.ALL, AUTHORIZATIONS_A_AND_B);
         assertEquals("valueNew", v1.getProperty("prop1", VISIBILITY_B).getMetadata().getEntry("prop1_key1", VISIBILITY_B).getValue());
     }
 
@@ -4013,14 +4014,14 @@ public abstract class GraphTestBase {
                 .save(AUTHORIZATIONS_A_AND_B);
         graph.flush();
 
-        ExistingElementMutation<Vertex> m = graph.getVertex("v1", AUTHORIZATIONS_A_AND_B).prepareMutation();
+        ExistingElementMutation<Vertex> m = graph.getVertex("v1", FetchHint.ALL, AUTHORIZATIONS_A_AND_B).prepareMutation();
         m.setPropertyMetadata(v1.getProperty("prop1", VISIBILITY_A), "metadata1", "metadata-value1aa", VISIBILITY_A);
         m.setPropertyMetadata(v1.getProperty("prop1", VISIBILITY_A), "metadata1", "metadata-value1ab", VISIBILITY_B);
         m.setPropertyMetadata(v1.getProperty("prop1", VISIBILITY_B), "metadata1", "metadata-value1bb", VISIBILITY_B);
         m.save(AUTHORIZATIONS_A_AND_B);
         graph.flush();
 
-        v1 = graph.getVertex("v1", AUTHORIZATIONS_A_AND_B);
+        v1 = graph.getVertex("v1", FetchHint.ALL, AUTHORIZATIONS_A_AND_B);
 
         Property prop1A = v1.getProperty("prop1", VISIBILITY_A);
         assertEquals(2, prop1A.getMetadata().entrySet().size());
@@ -4405,7 +4406,7 @@ public abstract class GraphTestBase {
                 .save(AUTHORIZATIONS_A);
         graph.flush();
 
-        Vertex v1 = graph.getVertex("v1", AUTHORIZATIONS_A);
+        Vertex v1 = graph.getVertex("v1", FetchHint.ALL, AUTHORIZATIONS_A);
         List<HistoricalPropertyValue> values = toList(v1.getHistoricalPropertyValues("", "age", VISIBILITY_A, AUTHORIZATIONS_A));
         assertEquals(2, values.size());
 
@@ -4483,9 +4484,9 @@ public abstract class GraphTestBase {
         assertEquals(1, count(graph.getEdges(AUTHORIZATIONS_A)));
 
         // verify old version
-        assertEquals(25, graph.getVertex("v1", FetchHint.ALL, time25.getTime(), AUTHORIZATIONS_A).getPropertyValue("", "age"));
-        assertNull("v3 should not exist at time25", graph.getVertex("v3", FetchHint.ALL, time25.getTime(), AUTHORIZATIONS_A));
-        assertEquals("e1 should not exist", 0, count(graph.getEdges(FetchHint.ALL, time25.getTime(), AUTHORIZATIONS_A)));
+        assertEquals(25, graph.getVertex("v1", FetchHint.DEFAULT, time25.getTime(), AUTHORIZATIONS_A).getPropertyValue("", "age"));
+        assertNull("v3 should not exist at time25", graph.getVertex("v3", FetchHint.DEFAULT, time25.getTime(), AUTHORIZATIONS_A));
+        assertEquals("e1 should not exist", 0, count(graph.getEdges(FetchHint.DEFAULT, time25.getTime(), AUTHORIZATIONS_A)));
     }
 
     @Test
@@ -5767,6 +5768,21 @@ public abstract class GraphTestBase {
     }
 
     @Test
+    public void testFetchHintsExceptions() {
+        Metadata prop1Metadata = new Metadata();
+        prop1Metadata.add("metadata1", "metadata1Value", VISIBILITY_A);
+
+        graph.prepareVertex("v1", VISIBILITY_A)
+                .setProperty("prop1", "value1", prop1Metadata, VISIBILITY_A)
+                .save(AUTHORIZATIONS_A_AND_B);
+        graph.flush();
+
+        Vertex v1 = graph.getVertex("v1", FetchHint.DEFAULT, AUTHORIZATIONS_A);
+        Property prop1 = v1.getProperty("prop1");
+        assertThrowsException(prop1::getMetadata);
+    }
+
+    @Test
     public void benchmark() {
         assumeTrue(benchmarkEnabled());
         Random random = new Random(1);
@@ -6087,14 +6103,14 @@ public abstract class GraphTestBase {
         graph.flush();
 
         // modify property value
-        Vertex v1 = graph.getVertex("v1", AUTHORIZATIONS_A_AND_B);
+        Vertex v1 = graph.getVertex("v1", FetchHint.ALL, AUTHORIZATIONS_A_AND_B);
         vertexAdded = v1.prepareMutation()
                 .alterPropertyVisibility("prop1_A", VISIBILITY_B)
                 .save(AUTHORIZATIONS_A_AND_B);
         graph.flush();
 
         // Restore
-        v1 = graph.getVertex("v1", AUTHORIZATIONS_A_AND_B);
+        v1 = graph.getVertex("v1", FetchHint.ALL, AUTHORIZATIONS_A_AND_B);
         vertexAdded = v1.prepareMutation()
                 .alterPropertyVisibility("prop1_A", VISIBILITY_A)
                 .save(AUTHORIZATIONS_A_AND_B);

--- a/test/src/main/java/org/vertexium/test/util/VertexiumAssert.java
+++ b/test/src/main/java/org/vertexium/test/util/VertexiumAssert.java
@@ -9,6 +9,7 @@ import org.vertexium.query.QueryResultsIterable;
 import java.util.*;
 import java.util.stream.Collectors;
 
+import static junit.framework.TestCase.fail;
 import static org.junit.Assert.assertEquals;
 import static org.vertexium.util.IterableUtils.count;
 import static org.vertexium.util.IterableUtils.toList;
@@ -101,5 +102,14 @@ public class VertexiumAssert {
                 .filter((sr) -> sr instanceof ExtendedDataRow)
                 .map((sr) -> ((ExtendedDataRow) sr).getId().getRowId())
                 .collect(Collectors.toList());
+    }
+
+    public static void assertThrowsException(Runnable fn) {
+        try {
+            fn.run();
+        } catch (Throwable ex) {
+            return;
+        }
+        fail("Should have thrown an exception");
     }
 }


### PR DESCRIPTION
Bringing property metadata back is expensive as the metadata grows and
most times you don't need this information. This changes the default to
not bring metadata back.