### PR TITLE
Changed: Remove property metadata from default fetch hints

### DIFF
--- a/accumulo-iterators/src/main/java/org/vertexium/accumulo/iterator/EdgeIterator.java
+++ b/accumulo-iterators/src/main/java/org/vertexium/accumulo/iterator/EdgeIterator.java
@@ -6,7 +6,7 @@ import org.apache.accumulo.core.iterators.IteratorEnvironment;
 import org.apache.accumulo.core.iterators.SortedKeyValueIterator;
 import org.apache.hadoop.io.Text;
 import org.vertexium.accumulo.iterator.model.EdgeElementData;
-import org.vertexium.accumulo.iterator.model.FetchHint;
+import org.vertexium.accumulo.iterator.model.IteratorFetchHint;
 
 import java.util.EnumSet;
 
@@ -19,14 +19,14 @@ public class EdgeIterator extends ElementIterator<EdgeElementData> {
     public static final Text CF_IN_VERTEX = new Text(CF_IN_VERTEX_STRING);
 
     public EdgeIterator() {
-        this(FetchHint.ALL);
+        this(IteratorFetchHint.ALL);
     }
 
-    public EdgeIterator(EnumSet<FetchHint> fetchHints) {
+    public EdgeIterator(EnumSet<IteratorFetchHint> fetchHints) {
         super(null, fetchHints);
     }
 
-    public EdgeIterator(SortedKeyValueIterator<Key, Value> source, EnumSet<FetchHint> fetchHints) {
+    public EdgeIterator(SortedKeyValueIterator<Key, Value> source, EnumSet<IteratorFetchHint> fetchHints) {
         super(source, fetchHints);
     }
 

--- a/accumulo-iterators/src/main/java/org/vertexium/accumulo/iterator/ElementIterator.java
+++ b/accumulo-iterators/src/main/java/org/vertexium/accumulo/iterator/ElementIterator.java
@@ -42,11 +42,11 @@ public abstract class ElementIterator<T extends ElementData> extends RowEncoding
     public static final String METADATA_COLUMN_QUALIFIER_STRING = "";
     public static final Text METADATA_COLUMN_QUALIFIER = new Text(METADATA_COLUMN_QUALIFIER_STRING);
     private static final String SETTING_FETCH_HINTS = "fetchHints";
-    private EnumSet<FetchHint> fetchHints;
+    private EnumSet<IteratorFetchHint> fetchHints;
     private T elementData;
     private static final Map<Text, PropertyMetadataColumnQualifier> stringToPropertyMetadataColumnQualifierCache = new HashMap<>();
 
-    public ElementIterator(SortedKeyValueIterator<Key, Value> source, EnumSet<FetchHint> fetchHints) {
+    public ElementIterator(SortedKeyValueIterator<Key, Value> source, EnumSet<IteratorFetchHint> fetchHints) {
         this.sourceIter = source;
         this.fetchHints = fetchHints;
         this.elementData = createElementData();
@@ -141,7 +141,7 @@ public abstract class ElementIterator<T extends ElementData> extends RowEncoding
         }
 
         if (CF_HIDDEN.equals(columnFamily)) {
-            if (fetchHints.contains(FetchHint.INCLUDE_HIDDEN)) {
+            if (fetchHints.contains(IteratorFetchHint.INCLUDE_HIDDEN)) {
                 this.elementData.hiddenVisibilities.add(key.getColumnVisibility());
                 return true;
             } else {
@@ -228,17 +228,17 @@ public abstract class ElementIterator<T extends ElementData> extends RowEncoding
         if (options.get(SETTING_FETCH_HINTS) == null) {
             throw new IOException(SETTING_FETCH_HINTS + " is required");
         }
-        fetchHints = FetchHint.parse(options.get(SETTING_FETCH_HINTS));
+        fetchHints = IteratorFetchHint.parse(options.get(SETTING_FETCH_HINTS));
         elementData = createElementData();
     }
 
     protected abstract T createElementData();
 
-    public static void setFetchHints(IteratorSetting iteratorSettings, EnumSet<FetchHint> fetchHints) {
-        iteratorSettings.addOption(SETTING_FETCH_HINTS, FetchHint.toString(fetchHints));
+    public static void setFetchHints(IteratorSetting iteratorSettings, EnumSet<IteratorFetchHint> fetchHints) {
+        iteratorSettings.addOption(SETTING_FETCH_HINTS, IteratorFetchHint.toString(fetchHints));
     }
 
-    public EnumSet<FetchHint> getFetchHints() {
+    public EnumSet<IteratorFetchHint> getFetchHints() {
         return fetchHints;
     }
 

--- a/accumulo-iterators/src/main/java/org/vertexium/accumulo/iterator/VertexIterator.java
+++ b/accumulo-iterators/src/main/java/org/vertexium/accumulo/iterator/VertexIterator.java
@@ -6,7 +6,7 @@ import org.apache.accumulo.core.iterators.IteratorEnvironment;
 import org.apache.accumulo.core.iterators.SortedKeyValueIterator;
 import org.apache.hadoop.io.Text;
 import org.vertexium.accumulo.iterator.model.EdgeInfo;
-import org.vertexium.accumulo.iterator.model.FetchHint;
+import org.vertexium.accumulo.iterator.model.IteratorFetchHint;
 import org.vertexium.accumulo.iterator.model.SoftDeleteEdgeInfo;
 import org.vertexium.accumulo.iterator.model.VertexElementData;
 
@@ -30,14 +30,14 @@ public class VertexIterator extends ElementIterator<VertexElementData> {
     public static final Text CF_IN_EDGE_SOFT_DELETE = new Text(CF_IN_EDGE_SOFT_DELETE_STRING);
 
     public VertexIterator() {
-        this(FetchHint.ALL);
+        this(IteratorFetchHint.ALL);
     }
 
-    public VertexIterator(EnumSet<FetchHint> fetchHints) {
+    public VertexIterator(EnumSet<IteratorFetchHint> fetchHints) {
         super(null, fetchHints);
     }
 
-    public VertexIterator(SortedKeyValueIterator<Key, Value> source, EnumSet<FetchHint> fetchHints) {
+    public VertexIterator(SortedKeyValueIterator<Key, Value> source, EnumSet<IteratorFetchHint> fetchHints) {
         super(source, fetchHints);
     }
 
@@ -51,7 +51,7 @@ public class VertexIterator extends ElementIterator<VertexElementData> {
     }
 
     private void removeHiddenAndSoftDeletes() {
-        if (!getFetchHints().contains(FetchHint.INCLUDE_HIDDEN)) {
+        if (!getFetchHints().contains(IteratorFetchHint.INCLUDE_HIDDEN)) {
             for (Text edgeId : this.getElementData().hiddenEdges) {
                 this.getElementData().inEdges.remove(edgeId);
                 this.getElementData().outEdges.remove(edgeId);

--- a/accumulo-iterators/src/main/java/org/vertexium/accumulo/iterator/model/EdgeElementData.java
+++ b/accumulo-iterators/src/main/java/org/vertexium/accumulo/iterator/model/EdgeElementData.java
@@ -21,7 +21,7 @@ public class EdgeElementData extends ElementData {
     }
 
     @Override
-    protected void encode(DataOutputStream out, EnumSet<FetchHint> fetchHints) throws IOException {
+    protected void encode(DataOutputStream out, EnumSet<IteratorFetchHint> fetchHints) throws IOException {
         super.encode(out, fetchHints);
         DataOutputStreamUtils.encodeText(out, inVertexId);
         DataOutputStreamUtils.encodeText(out, outVertexId);

--- a/accumulo-iterators/src/main/java/org/vertexium/accumulo/iterator/model/ElementData.java
+++ b/accumulo-iterators/src/main/java/org/vertexium/accumulo/iterator/model/ElementData.java
@@ -45,14 +45,14 @@ public abstract class ElementData {
         extendedTableNames.clear();
     }
 
-    public final Value encode(EnumSet<FetchHint> fetchHints) throws IOException {
+    public final Value encode(EnumSet<IteratorFetchHint> fetchHints) throws IOException {
         ByteArrayOutputStream out = new ByteArrayOutputStream();
         DataOutputStream dout = new DataOutputStream(out);
         encode(dout, fetchHints);
         return new Value(out.toByteArray());
     }
 
-    protected void encode(DataOutputStream out, EnumSet<FetchHint> fetchHints) throws IOException {
+    protected void encode(DataOutputStream out, EnumSet<IteratorFetchHint> fetchHints) throws IOException {
         encodeHeader(out);
         DataOutputStreamUtils.encodeText(out, id);
         out.writeLong(timestamp);
@@ -69,7 +69,7 @@ public abstract class ElementData {
 
     protected abstract byte getTypeId();
 
-    private void encodeProperties(final DataOutputStream out, EnumSet<FetchHint> fetchHints) throws IOException {
+    private void encodeProperties(final DataOutputStream out, EnumSet<IteratorFetchHint> fetchHints) throws IOException {
         iterateProperties(new PropertyDataHandler() {
             @Override
             public void handle(
@@ -95,8 +95,8 @@ public abstract class ElementData {
         out.write(PROP_END);
     }
 
-    private void iterateProperties(PropertyDataHandler propertyDataHandler, EnumSet<FetchHint> fetchHints) throws IOException {
-        boolean includeHidden = fetchHints.contains(FetchHint.INCLUDE_HIDDEN);
+    private void iterateProperties(PropertyDataHandler propertyDataHandler, EnumSet<IteratorFetchHint> fetchHints) throws IOException {
+        boolean includeHidden = fetchHints.contains(IteratorFetchHint.INCLUDE_HIDDEN);
         for (Map.Entry<String, byte[]> propertyValueEntry : propertyValues.entrySet()) {
             String key = propertyValueEntry.getKey();
             PropertyColumnQualifier propertyColumnQualifier = propertyColumnQualifiers.get(key);
@@ -118,7 +118,7 @@ public abstract class ElementData {
         }
     }
 
-    public Iterable<Property> getProperties(EnumSet<FetchHint> fetchHints) {
+    public Iterable<Property> getProperties(EnumSet<IteratorFetchHint> fetchHints) {
         final List<Property> results = new ArrayList<>();
         try {
             iterateProperties(new PropertyDataHandler() {

--- a/accumulo-iterators/src/main/java/org/vertexium/accumulo/iterator/model/IteratorFetchHint.java
+++ b/accumulo-iterators/src/main/java/org/vertexium/accumulo/iterator/model/IteratorFetchHint.java
@@ -4,7 +4,7 @@ import java.util.ArrayList;
 import java.util.EnumSet;
 import java.util.List;
 
-public enum FetchHint {
+public enum IteratorFetchHint {
     PROPERTIES,
     PROPERTY_METADATA,
     IN_EDGE_REFS,
@@ -14,12 +14,12 @@ public enum FetchHint {
     OUT_EDGE_LABELS,
     EXTENDED_DATA_TABLE_NAMES;
 
-    public static final EnumSet<FetchHint> ALL = EnumSet.of(PROPERTIES, PROPERTY_METADATA, IN_EDGE_REFS, OUT_EDGE_REFS, EXTENDED_DATA_TABLE_NAMES);
+    public static final EnumSet<IteratorFetchHint> ALL = EnumSet.of(PROPERTIES, PROPERTY_METADATA, IN_EDGE_REFS, OUT_EDGE_REFS, EXTENDED_DATA_TABLE_NAMES);
 
-    public static String toString(EnumSet<FetchHint> fetchHints) {
+    public static String toString(EnumSet<IteratorFetchHint> fetchHints) {
         StringBuilder result = new StringBuilder();
         boolean first = true;
-        for (FetchHint fetchHint : fetchHints) {
+        for (IteratorFetchHint fetchHint : fetchHints) {
             if (!first) {
                 result.append(",");
             }
@@ -29,19 +29,19 @@ public enum FetchHint {
         return result.toString();
     }
 
-    public static EnumSet<FetchHint> parse(String fetchHintsString) {
+    public static EnumSet<IteratorFetchHint> parse(String fetchHintsString) {
         if (fetchHintsString == null) {
             throw new NullPointerException("fetchHintsString cannot be null");
         }
         String[] parts = fetchHintsString.split(",");
-        List<FetchHint> results = new ArrayList<>();
+        List<IteratorFetchHint> results = new ArrayList<>();
         for (String part : parts) {
             String name = part.toUpperCase();
             if (name.trim().length() == 0) {
                 continue;
             }
             try {
-                results.add(FetchHint.valueOf(name));
+                results.add(IteratorFetchHint.valueOf(name));
             } catch (IllegalArgumentException ex) {
                 throw new IllegalArgumentException("Could not find enum value: '" + name + "'", ex);
             }
@@ -49,9 +49,9 @@ public enum FetchHint {
         return create(results);
     }
 
-    public static EnumSet<FetchHint> create(List<FetchHint> results) {
+    public static EnumSet<IteratorFetchHint> create(List<IteratorFetchHint> results) {
         if (results.size() == 0) {
-            return EnumSet.noneOf(FetchHint.class);
+            return EnumSet.noneOf(IteratorFetchHint.class);
         } else {
             return EnumSet.copyOf(results);
         }

--- a/accumulo-iterators/src/main/java/org/vertexium/accumulo/iterator/model/VertexElementData.java
+++ b/accumulo-iterators/src/main/java/org/vertexium/accumulo/iterator/model/VertexElementData.java
@@ -25,10 +25,10 @@ public class VertexElementData extends ElementData {
     }
 
     @Override
-    protected void encode(DataOutputStream out, EnumSet<FetchHint> fetchHints) throws IOException {
+    protected void encode(DataOutputStream out, EnumSet<IteratorFetchHint> fetchHints) throws IOException {
         super.encode(out, fetchHints);
-        DataOutputStreamUtils.encodeEdges(out, outEdges, fetchHints.contains(FetchHint.OUT_EDGE_LABELS) && !fetchHints.contains(FetchHint.OUT_EDGE_REFS));
-        DataOutputStreamUtils.encodeEdges(out, inEdges, fetchHints.contains(FetchHint.IN_EDGE_LABELS) && !fetchHints.contains(FetchHint.IN_EDGE_REFS));
+        DataOutputStreamUtils.encodeEdges(out, outEdges, fetchHints.contains(IteratorFetchHint.OUT_EDGE_LABELS) && !fetchHints.contains(IteratorFetchHint.OUT_EDGE_REFS));
+        DataOutputStreamUtils.encodeEdges(out, inEdges, fetchHints.contains(IteratorFetchHint.IN_EDGE_LABELS) && !fetchHints.contains(IteratorFetchHint.IN_EDGE_REFS));
     }
 
     @Override

--- a/accumulo/src/main/java/org/vertexium/accumulo/AccumuloEdge.java
+++ b/accumulo/src/main/java/org/vertexium/accumulo/AccumuloEdge.java
@@ -47,6 +47,7 @@ public class AccumuloEdge extends AccumuloElement implements Edge {
             Iterable<Visibility> hiddenVisibilities,
             ImmutableSet<String> extendedDataTableNames,
             long timestamp,
+            EnumSet<FetchHint> fetchHints,
             Authorizations authorizations
     ) {
         super(
@@ -59,6 +60,7 @@ public class AccumuloEdge extends AccumuloElement implements Edge {
                 hiddenVisibilities,
                 extendedDataTableNames,
                 timestamp,
+                fetchHints,
                 authorizations
         );
         this.outVertexId = outVertexId;
@@ -67,7 +69,13 @@ public class AccumuloEdge extends AccumuloElement implements Edge {
         this.newEdgeLabel = newEdgeLabel;
     }
 
-    public static Edge createFromIteratorValue(AccumuloGraph graph, Key key, Value value, Authorizations authorizations) {
+    public static Edge createFromIteratorValue(
+            AccumuloGraph graph,
+            Key key,
+            Value value,
+            EnumSet<FetchHint> fetchHints,
+            Authorizations authorizations
+    ) {
         try {
             String edgeId;
             Visibility vertexVisibility;
@@ -92,7 +100,7 @@ public class AccumuloEdge extends AccumuloElement implements Edge {
                     return new Visibility(input.toString());
                 }
             });
-            properties = DataInputStreamUtils.decodeProperties(graph, in);
+            properties = DataInputStreamUtils.decodeProperties(graph, in, fetchHints);
             ImmutableSet<String> extendedDataTableNames = DataInputStreamUtils.decodeStringSet(in);
             String inVertexId = DataInputStreamUtils.decodeText(in).toString();
             String outVertexId = DataInputStreamUtils.decodeText(in).toString();
@@ -112,6 +120,7 @@ public class AccumuloEdge extends AccumuloElement implements Edge {
                     hiddenVisibilities,
                     extendedDataTableNames,
                     timestamp,
+                    fetchHints,
                     authorizations
             );
         } catch (IOException ex) {
@@ -142,7 +151,7 @@ public class AccumuloEdge extends AccumuloElement implements Edge {
 
     @Override
     public Vertex getVertex(Direction direction, Authorizations authorizations) {
-        return getVertex(direction, FetchHint.ALL, authorizations);
+        return getVertex(direction, FetchHint.DEFAULT, authorizations);
     }
 
     @Override
@@ -157,7 +166,7 @@ public class AccumuloEdge extends AccumuloElement implements Edge {
 
     @Override
     public Vertex getOtherVertex(String myVertexId, Authorizations authorizations) {
-        return getOtherVertex(myVertexId, FetchHint.ALL, authorizations);
+        return getOtherVertex(myVertexId, FetchHint.DEFAULT, authorizations);
     }
 
     @Override
@@ -167,7 +176,7 @@ public class AccumuloEdge extends AccumuloElement implements Edge {
 
     @Override
     public EdgeVertices getVertices(Authorizations authorizations) {
-        return getVertices(FetchHint.ALL, authorizations);
+        return getVertices(FetchHint.DEFAULT, authorizations);
     }
 
     @Override

--- a/accumulo/src/main/java/org/vertexium/accumulo/AccumuloElement.java
+++ b/accumulo/src/main/java/org/vertexium/accumulo/AccumuloElement.java
@@ -8,6 +8,7 @@ import org.vertexium.accumulo.iterator.ElementIterator;
 import org.vertexium.mutation.*;
 
 import java.io.Serializable;
+import java.util.EnumSet;
 
 public abstract class AccumuloElement extends ElementBase implements Serializable, HasTimestamp {
     private static final long serialVersionUID = 1L;
@@ -38,6 +39,7 @@ public abstract class AccumuloElement extends ElementBase implements Serializabl
             Iterable<Visibility> hiddenVisibilities,
             ImmutableSet<String> extendedDataTableNames,
             long timestamp,
+            EnumSet<FetchHint> fetchHints,
             Authorizations authorizations
     ) {
         super(
@@ -50,6 +52,7 @@ public abstract class AccumuloElement extends ElementBase implements Serializabl
                 hiddenVisibilities,
                 extendedDataTableNames,
                 timestamp,
+                fetchHints,
                 authorizations
         );
     }

--- a/accumulo/src/main/java/org/vertexium/accumulo/AccumuloGraph.java
+++ b/accumulo/src/main/java/org/vertexium/accumulo/AccumuloGraph.java
@@ -1,6 +1,8 @@
 package org.vertexium.accumulo;
 
-import com.google.common.collect.*;
+import com.google.common.collect.ArrayListMultimap;
+import com.google.common.collect.Lists;
+import com.google.common.collect.Maps;
 import com.google.common.primitives.Longs;
 import org.apache.accumulo.core.client.*;
 import org.apache.accumulo.core.client.Scanner;
@@ -20,8 +22,6 @@ import org.apache.accumulo.core.security.ColumnVisibility;
 import org.apache.accumulo.core.trace.DistributedTrace;
 import org.apache.accumulo.core.trace.Span;
 import org.apache.accumulo.core.trace.Trace;
-import org.apache.commons.collections.MultiMap;
-import org.apache.commons.lang3.tuple.Pair;
 import org.apache.curator.RetryPolicy;
 import org.apache.curator.framework.CuratorFramework;
 import org.apache.curator.framework.CuratorFrameworkFactory;
@@ -31,11 +31,10 @@ import org.apache.hadoop.fs.FileSystem;
 import org.apache.hadoop.io.Text;
 import org.apache.zookeeper.CreateMode;
 import org.vertexium.*;
-import org.vertexium.HistoricalPropertyValue;
 import org.vertexium.HistoricalPropertyValue.HistoricalPropertyValueBuilder;
-import org.vertexium.Range;
 import org.vertexium.accumulo.iterator.*;
 import org.vertexium.accumulo.iterator.model.EdgeInfo;
+import org.vertexium.accumulo.iterator.model.IteratorFetchHint;
 import org.vertexium.accumulo.iterator.model.PropertyColumnQualifier;
 import org.vertexium.accumulo.iterator.model.PropertyMetadataColumnQualifier;
 import org.vertexium.accumulo.iterator.util.ByteArrayWrapper;
@@ -357,6 +356,7 @@ public class AccumuloGraph extends GraphBaseWithSearchIndex implements Traceable
                         hiddenVisibilities,
                         getExtendedDataTableNames(),
                         timestampLong,
+                        FetchHint.ALL_INCLUDING_HIDDEN,
                         authorizations
                 );
             }
@@ -399,12 +399,8 @@ public class AccumuloGraph extends GraphBaseWithSearchIndex implements Traceable
         if (indexHint != IndexHint.DO_NOT_INDEX) {
             // Bulk delete properties
             List<PropertyDescriptor> propertyList = Lists.newArrayList();
-            propertyDeletes.forEach(p -> {
-                propertyList.add(PropertyDescriptor.fromPropertyDeleteMutation(p));
-            });
-            propertySoftDeletes.forEach(p -> {
-                propertyList.add(PropertyDescriptor.fromPropertySoftDeleteMutation(p));
-            });
+            propertyDeletes.forEach(p -> propertyList.add(PropertyDescriptor.fromPropertyDeleteMutation(p)));
+            propertySoftDeletes.forEach(p -> propertyList.add(PropertyDescriptor.fromPropertySoftDeleteMutation(p)));
 
             getSearchIndex().deleteProperties(
                     this,
@@ -429,6 +425,8 @@ public class AccumuloGraph extends GraphBaseWithSearchIndex implements Traceable
     }
 
     void deleteProperty(AccumuloElement element, Property property, Authorizations authorizations) {
+        FetchHint.checkFetchHints(element.getFetchHints(), EnumSet.of(FetchHint.PROPERTIES, FetchHint.PROPERTY_METADATA));
+
         Mutation m = new Mutation(element.getId());
         elementMutationBuilder.addPropertyDeleteToMutation(m, property);
         addMutations(element, m);
@@ -699,7 +697,13 @@ public class AccumuloGraph extends GraphBaseWithSearchIndex implements Traceable
                     // This has to occur before createEdge since it will mutate the properties
                     elementMutationBuilder.saveEdgeBuilder(AccumuloGraph.this, this, timestampLong);
 
-                    AccumuloEdge edge = AccumuloGraph.this.createEdge(AccumuloGraph.this, this, timestampLong, authorizations);
+                    AccumuloEdge edge = AccumuloGraph.this.createEdge(
+                            AccumuloGraph.this,
+                            this,
+                            timestampLong,
+                            FetchHint.ALL_INCLUDING_HIDDEN,
+                            authorizations
+                    );
                     return savePreparedEdge(this, edge, null, authorizations);
                 } finally {
                     trace.stop();
@@ -708,7 +712,13 @@ public class AccumuloGraph extends GraphBaseWithSearchIndex implements Traceable
 
             @Override
             protected AccumuloEdge createEdge(Authorizations authorizations) {
-                return AccumuloGraph.this.createEdge(AccumuloGraph.this, this, timestampLong, authorizations);
+                return AccumuloGraph.this.createEdge(
+                        AccumuloGraph.this,
+                        this,
+                        timestampLong,
+                        FetchHint.ALL_INCLUDING_HIDDEN,
+                        authorizations
+                );
             }
         };
     }
@@ -748,7 +758,13 @@ public class AccumuloGraph extends GraphBaseWithSearchIndex implements Traceable
                     // This has to occur before createEdge since it will mutate the properties
                     elementMutationBuilder.saveEdgeBuilder(AccumuloGraph.this, this, timestampLong);
 
-                    AccumuloEdge edge = createEdge(AccumuloGraph.this, this, timestampLong, authorizations);
+                    AccumuloEdge edge = createEdge(
+                            AccumuloGraph.this,
+                            this,
+                            timestampLong,
+                            FetchHint.ALL_INCLUDING_HIDDEN,
+                            authorizations
+                    );
                     return savePreparedEdge(this, edge, addEdgeToVertex, authorizations);
                 } finally {
                     trace.stop();
@@ -761,6 +777,7 @@ public class AccumuloGraph extends GraphBaseWithSearchIndex implements Traceable
             AccumuloGraph accumuloGraph,
             EdgeBuilderBase edgeBuilder,
             long timestamp,
+            EnumSet<FetchHint> fetchHints,
             Authorizations authorizations
     ) {
         Iterable<Visibility> hiddenVisibilities = null;
@@ -778,6 +795,7 @@ public class AccumuloGraph extends GraphBaseWithSearchIndex implements Traceable
                 hiddenVisibilities,
                 edgeBuilder.getExtendedDataTableNames(),
                 timestamp,
+                fetchHints,
                 authorizations
         );
     }
@@ -914,7 +932,7 @@ public class AccumuloGraph extends GraphBaseWithSearchIndex implements Traceable
                     }
                 }
 
-                for(Key entry : softDeleteObserved.values()) {
+                for (Key entry : softDeleteObserved.values()) {
                     String cq = entry.getColumnQualifier().toString();
                     PropertyColumnQualifier propertyColumnQualifier = KeyHelper.createPropertyColumnQualifier(cq, getNameSubstitutionStrategy());
                     String propertyKey = propertyColumnQualifier.getPropertyKey();
@@ -922,7 +940,7 @@ public class AccumuloGraph extends GraphBaseWithSearchIndex implements Traceable
                     String propIdent = propertyKey + ":" + propertyName;
 
                     List<String> active = activeVisibilities.get(propIdent);
-                    if(active == null || active.isEmpty()) {
+                    if (active == null || active.isEmpty()) {
                         long timestamp = entry.getTimestamp() + 1;
                         String columnVisibility = entry.getColumnVisibility().toString();
                         Visibility propertyVisibility = accumuloVisibilityToVisibility(columnVisibility);
@@ -1548,16 +1566,16 @@ public class AccumuloGraph extends GraphBaseWithSearchIndex implements Traceable
         }
     }
 
-    public static EnumSet<org.vertexium.accumulo.iterator.model.FetchHint> toIteratorFetchHints(EnumSet<FetchHint> fetchHints) {
-        List<org.vertexium.accumulo.iterator.model.FetchHint> results = new ArrayList<>();
+    public static EnumSet<IteratorFetchHint> toIteratorFetchHints(EnumSet<FetchHint> fetchHints) {
+        List<IteratorFetchHint> results = new ArrayList<>();
         for (FetchHint fetchHint : fetchHints) {
             results.add(toIteratorFetchHint(fetchHint));
         }
-        return org.vertexium.accumulo.iterator.model.FetchHint.create(results);
+        return IteratorFetchHint.create(results);
     }
 
-    private static org.vertexium.accumulo.iterator.model.FetchHint toIteratorFetchHint(FetchHint fetchHint) {
-        return org.vertexium.accumulo.iterator.model.FetchHint.valueOf(fetchHint.name());
+    private static IteratorFetchHint toIteratorFetchHint(FetchHint fetchHint) {
+        return IteratorFetchHint.valueOf(fetchHint.name());
     }
 
     protected ScannerBase createVertexScanner(
@@ -1641,7 +1659,7 @@ public class AccumuloGraph extends GraphBaseWithSearchIndex implements Traceable
 
     private void applyFetchHints(ScannerBase scanner, EnumSet<FetchHint> fetchHints, ElementType elementType) {
         scanner.clearColumns();
-        if (fetchHints.equals(FetchHint.ALL)) {
+        if (fetchHints.equals(FetchHint.DEFAULT)) {
             return;
         }
 
@@ -1656,6 +1674,7 @@ public class AccumuloGraph extends GraphBaseWithSearchIndex implements Traceable
 
         columnFamiliesToFetch.add(AccumuloElement.CF_HIDDEN);
         columnFamiliesToFetch.add(AccumuloElement.CF_SOFT_DELETE);
+        columnFamiliesToFetch.add(AccumuloElement.DELETE_ROW_COLUMN_FAMILY);
 
         if (elementType == ElementType.VERTEX) {
             columnFamiliesToFetch.add(AccumuloVertex.CF_SIGNAL);
@@ -2474,7 +2493,7 @@ public class AccumuloGraph extends GraphBaseWithSearchIndex implements Traceable
 
             @Override
             protected Vertex convert(Map.Entry<Key, Value> next) {
-                return createVertexFromVertexIteratorValue(next.getKey(), next.getValue(), authorizations);
+                return createVertexFromVertexIteratorValue(next.getKey(), next.getValue(), fetchHints, authorizations);
             }
 
             @Override
@@ -2502,12 +2521,12 @@ public class AccumuloGraph extends GraphBaseWithSearchIndex implements Traceable
         };
     }
 
-    private Vertex createVertexFromVertexIteratorValue(Key key, Value value, Authorizations authorizations) {
-        return AccumuloVertex.createFromIteratorValue(this, key, value, authorizations);
+    private Vertex createVertexFromVertexIteratorValue(Key key, Value value, EnumSet<FetchHint> fetchHints, Authorizations authorizations) {
+        return AccumuloVertex.createFromIteratorValue(this, key, value, fetchHints, authorizations);
     }
 
-    private Edge createEdgeFromEdgeIteratorValue(Key key, Value value, Authorizations authorizations) {
-        return AccumuloEdge.createFromIteratorValue(this, key, value, authorizations);
+    private Edge createEdgeFromEdgeIteratorValue(Key key, Value value, EnumSet<FetchHint> fetchHints, Authorizations authorizations) {
+        return AccumuloEdge.createFromIteratorValue(this, key, value, fetchHints, authorizations);
     }
 
     @Override
@@ -2537,7 +2556,7 @@ public class AccumuloGraph extends GraphBaseWithSearchIndex implements Traceable
 
             @Override
             protected Vertex convert(Map.Entry<Key, Value> row) {
-                return createVertexFromVertexIteratorValue(row.getKey(), row.getValue(), authorizations);
+                return createVertexFromVertexIteratorValue(row.getKey(), row.getValue(), fetchHints, authorizations);
             }
 
             @Override
@@ -2558,7 +2577,7 @@ public class AccumuloGraph extends GraphBaseWithSearchIndex implements Traceable
     }
 
     @Override
-    public CloseableIterable<Edge> getEdges(Iterable<String> ids, final EnumSet<FetchHint> fetchHints, final Long endTime, final Authorizations authorizations) {
+    public CloseableIterable<Edge> getEdges(Iterable<String> ids, EnumSet<FetchHint> fetchHints, Long endTime, Authorizations authorizations) {
         final List<org.apache.accumulo.core.data.Range> ranges = new ArrayList<>();
         int idCount = 0;
         for (String id : ids) {
@@ -2584,7 +2603,7 @@ public class AccumuloGraph extends GraphBaseWithSearchIndex implements Traceable
 
             @Override
             protected Edge convert(Map.Entry<Key, Value> row) {
-                return createEdgeFromEdgeIteratorValue(row.getKey(), row.getValue(), authorizations);
+                return createEdgeFromEdgeIteratorValue(row.getKey(), row.getValue(), fetchHints, authorizations);
             }
 
             @Override
@@ -2659,11 +2678,11 @@ public class AccumuloGraph extends GraphBaseWithSearchIndex implements Traceable
     }
 
     protected CloseableIterable<Edge> getEdgesInRange(
-            final Span trace,
-            final org.apache.accumulo.core.data.Range range,
-            final EnumSet<FetchHint> fetchHints,
-            final Long endTime,
-            final Authorizations authorizations
+            Span trace,
+            org.apache.accumulo.core.data.Range range,
+            EnumSet<FetchHint> fetchHints,
+            Long endTime,
+            Authorizations authorizations
     ) throws VertexiumException {
         traceDataFetchHints(trace, fetchHints);
 
@@ -2679,7 +2698,7 @@ public class AccumuloGraph extends GraphBaseWithSearchIndex implements Traceable
 
             @Override
             protected Edge convert(Map.Entry<Key, Value> next) {
-                return createEdgeFromEdgeIteratorValue(next.getKey(), next.getValue(), authorizations);
+                return createEdgeFromEdgeIteratorValue(next.getKey(), next.getValue(), fetchHints, authorizations);
             }
 
             @Override

--- a/accumulo/src/main/java/org/vertexium/accumulo/LazyMutableProperty.java
+++ b/accumulo/src/main/java/org/vertexium/accumulo/LazyMutableProperty.java
@@ -4,10 +4,7 @@ import org.vertexium.*;
 import org.vertexium.property.MutableProperty;
 import org.vertexium.property.StreamingPropertyValueRef;
 
-import java.util.ArrayList;
-import java.util.Collection;
-import java.util.HashSet;
-import java.util.Set;
+import java.util.*;
 
 public class LazyMutableProperty extends MutableProperty {
     private final AccumuloGraph graph;
@@ -15,6 +12,7 @@ public class LazyMutableProperty extends MutableProperty {
     private final String propertyKey;
     private final String propertyName;
     private long timestamp;
+    private final EnumSet<FetchHint> fetchHints;
     private Set<Visibility> hiddenVisibilities;
     private byte[] propertyValue;
     private LazyPropertyMetadata metadata;
@@ -31,7 +29,8 @@ public class LazyMutableProperty extends MutableProperty {
             LazyPropertyMetadata metadata,
             Set<Visibility> hiddenVisibilities,
             Visibility visibility,
-            long timestamp
+            long timestamp,
+            EnumSet<FetchHint> fetchHints
     ) {
         this.graph = graph;
         this.vertexiumSerializer = vertexiumSerializer;
@@ -42,6 +41,7 @@ public class LazyMutableProperty extends MutableProperty {
         this.visibility = visibility;
         this.hiddenVisibilities = hiddenVisibilities;
         this.timestamp = timestamp;
+        this.fetchHints = fetchHints;
     }
 
     @Override
@@ -121,6 +121,7 @@ public class LazyMutableProperty extends MutableProperty {
 
     @Override
     public Metadata getMetadata() {
+        FetchHint.checkFetchHints(fetchHints, FetchHint.PROPERTY_METADATA);
         if (cachedMetadata == null) {
             if (metadata == null) {
                 cachedMetadata = new Metadata();

--- a/accumulo/src/main/java/org/vertexium/accumulo/mapreduce/AccumuloElementInputFormatBase.java
+++ b/accumulo/src/main/java/org/vertexium/accumulo/mapreduce/AccumuloElementInputFormatBase.java
@@ -20,6 +20,7 @@ import org.vertexium.accumulo.AccumuloGraph;
 import org.vertexium.accumulo.LazyMutableProperty;
 import org.vertexium.accumulo.LazyPropertyMetadata;
 import org.vertexium.accumulo.iterator.model.ElementData;
+import org.vertexium.accumulo.iterator.model.IteratorFetchHint;
 import org.vertexium.util.MapUtils;
 
 import javax.annotation.Nullable;
@@ -104,7 +105,7 @@ public abstract class AccumuloElementInputFormatBase<TValue extends Element> ext
 
     protected abstract TValue createElementFromRow(AccumuloGraph graph, PeekingIterator<Map.Entry<Key, Value>> row, Authorizations authorizations);
 
-    protected static Iterable<Property> makePropertiesFromElementData(final AccumuloGraph graph, ElementData elementData, EnumSet<org.vertexium.accumulo.iterator.model.FetchHint> fetchHints) {
+    protected static Iterable<Property> makePropertiesFromElementData(final AccumuloGraph graph, ElementData elementData, EnumSet<IteratorFetchHint> fetchHints) {
         return Iterables.transform(elementData.getProperties(fetchHints), new Function<org.vertexium.accumulo.iterator.model.Property, Property>() {
             @Nullable
             @Override
@@ -136,7 +137,8 @@ public abstract class AccumuloElementInputFormatBase<TValue extends Element> ext
                 metadata,
                 hiddenVisibilities,
                 visibility,
-                property.timestamp
+                property.timestamp,
+                FetchHint.ALL_INCLUDING_HIDDEN
         );
     }
 }

--- a/accumulo/src/main/java/org/vertexium/accumulo/mapreduce/ElementMapper.java
+++ b/accumulo/src/main/java/org/vertexium/accumulo/mapreduce/ElementMapper.java
@@ -130,6 +130,7 @@ public abstract class ElementMapper<KEYIN, VALUEIN, KEYOUT, VALUEOUT> extends Ma
                         hiddenVisibilities,
                         getExtendedDataTableNames(),
                         timestampLong,
+                        FetchHint.ALL_INCLUDING_HIDDEN,
                         authorizations
                 );
             }
@@ -197,6 +198,7 @@ public abstract class ElementMapper<KEYIN, VALUEIN, KEYOUT, VALUEOUT> extends Ma
                         null,
                         getExtendedDataTableNames(),
                         timestampLong,
+                        FetchHint.ALL_INCLUDING_HIDDEN,
                         authorizations
                 );
                 return edge;
@@ -237,6 +239,7 @@ public abstract class ElementMapper<KEYIN, VALUEIN, KEYOUT, VALUEOUT> extends Ma
                         null,
                         getExtendedDataTableNames(),
                         timestampLong,
+                        FetchHint.ALL_INCLUDING_HIDDEN,
                         authorizations
                 );
                 return edge;

--- a/accumulo/src/main/java/org/vertexium/accumulo/util/DataInputStreamUtils.java
+++ b/accumulo/src/main/java/org/vertexium/accumulo/util/DataInputStreamUtils.java
@@ -5,6 +5,7 @@ import com.google.common.collect.ImmutableSet;
 import com.google.common.collect.Iterables;
 import com.google.common.collect.Sets;
 import org.apache.hadoop.io.Text;
+import org.vertexium.FetchHint;
 import org.vertexium.Property;
 import org.vertexium.Visibility;
 import org.vertexium.accumulo.AccumuloGraph;
@@ -18,10 +19,7 @@ import org.vertexium.id.NameSubstitutionStrategy;
 import javax.annotation.Nullable;
 import java.io.DataInputStream;
 import java.io.IOException;
-import java.util.ArrayList;
-import java.util.Arrays;
-import java.util.List;
-import java.util.Set;
+import java.util.*;
 
 public class DataInputStreamUtils {
     public static Text decodeText(DataInputStream in) throws IOException {
@@ -56,7 +54,11 @@ public class DataInputStreamUtils {
         return results.build();
     }
 
-    public static Iterable<Property> decodeProperties(AccumuloGraph graph, final DataInputStream in) throws IOException {
+    public static Iterable<Property> decodeProperties(
+            AccumuloGraph graph,
+            DataInputStream in,
+            EnumSet<FetchHint> fetchHints
+    ) throws IOException {
         List<Property> results = new ArrayList<>();
         while (true) {
             int propId = in.read();
@@ -96,7 +98,8 @@ public class DataInputStreamUtils {
                     metadata,
                     propertyHiddenVisibilities,
                     propertyVisibility,
-                    propertyTimestamp
+                    propertyTimestamp,
+                    fetchHints
             ));
         }
         return results;

--- a/accumulo/src/test/java/org/vertexium/accumulo/AccumuloGraphTestBase.java
+++ b/accumulo/src/test/java/org/vertexium/accumulo/AccumuloGraphTestBase.java
@@ -65,7 +65,7 @@ public abstract class AccumuloGraphTestBase extends GraphTestBase {
         assertEquals(0, IterableUtils.count(v1.getEdges(Direction.IN, AUTHORIZATIONS_A)));
         assertEquals(0, IterableUtils.count(v1.getEdges(Direction.OUT, AUTHORIZATIONS_A)));
 
-        v1 = graph.getVertex("v1", FetchHint.ALL, AUTHORIZATIONS_A);
+        v1 = graph.getVertex("v1", FetchHint.DEFAULT, AUTHORIZATIONS_A);
         assertNotNull(v1);
         assertEquals(1, IterableUtils.count(v1.getProperties()));
         assertEquals(1, IterableUtils.count(v1.getEdges(Direction.IN, AUTHORIZATIONS_A)));
@@ -101,7 +101,7 @@ public abstract class AccumuloGraphTestBase extends GraphTestBase {
         assertEquals("v1", e1.getVertexId(Direction.OUT));
         assertEquals("v2", e1.getVertexId(Direction.IN));
 
-        e1 = graph.getEdge("e1", FetchHint.ALL, AUTHORIZATIONS_A);
+        e1 = graph.getEdge("e1", FetchHint.DEFAULT, AUTHORIZATIONS_A);
         assertEquals(1, IterableUtils.count(e1.getProperties()));
         assertEquals("v1", e1.getVertexId(Direction.OUT));
         assertEquals("v2", e1.getVertexId(Direction.IN));
@@ -124,16 +124,16 @@ public abstract class AccumuloGraphTestBase extends GraphTestBase {
         v2.addPropertyValue("prop1", "prop1", "val1", metadata, VISIBILITY_EMPTY, AUTHORIZATIONS_A_AND_B);
         graph.flush();
 
-        v1 = graph.getVertex("v1", AUTHORIZATIONS_EMPTY);
+        v1 = graph.getVertex("v1", FetchHint.ALL, AUTHORIZATIONS_EMPTY);
         assertEquals(0, v1.getProperty("prop1", "prop1").getMetadata().entrySet().size());
 
-        v2 = graph.getVertex("v2", AUTHORIZATIONS_EMPTY);
+        v2 = graph.getVertex("v2", FetchHint.ALL, AUTHORIZATIONS_EMPTY);
         metadata = v2.getProperty("prop1", "prop1").getMetadata();
         assertEquals(1, metadata.entrySet().size());
         assertEquals("metavalue1", metadata.getEntry("meta1", VISIBILITY_EMPTY).getValue());
 
         AccumuloGraph accumuloGraph = (AccumuloGraph) graph;
-        ScannerBase vertexScanner = accumuloGraph.createVertexScanner(FetchHint.ALL, AccumuloGraph.SINGLE_VERSION, null, null, new Range("V", "W"), AUTHORIZATIONS_EMPTY);
+        ScannerBase vertexScanner = accumuloGraph.createVertexScanner(FetchHint.DEFAULT, AccumuloGraph.SINGLE_VERSION, null, null, new Range("V", "W"), AUTHORIZATIONS_EMPTY);
         RowIterator rows = new RowIterator(vertexScanner.iterator());
         while (rows.hasNext()) {
             Iterator<Map.Entry<Key, Value>> row = rows.next();

--- a/blueprints/src/main/java/org/vertexium/blueprints/VertexiumBlueprintsGraph.java
+++ b/blueprints/src/main/java/org/vertexium/blueprints/VertexiumBlueprintsGraph.java
@@ -5,10 +5,13 @@ import com.tinkerpop.blueprints.Features;
 import com.tinkerpop.blueprints.GraphQuery;
 import com.tinkerpop.blueprints.Vertex;
 import org.vertexium.Authorizations;
+import org.vertexium.FetchHint;
 import org.vertexium.Graph;
 import org.vertexium.Visibility;
 import org.vertexium.query.Compare;
 import org.vertexium.util.ConvertingIterable;
+
+import java.util.EnumSet;
 
 public abstract class VertexiumBlueprintsGraph implements com.tinkerpop.blueprints.Graph {
     private static final VertexiumBlueprintsGraphFeatures FEATURES = new VertexiumBlueprintsGraphFeatures();
@@ -40,7 +43,7 @@ public abstract class VertexiumBlueprintsGraph implements com.tinkerpop.blueprin
             throw new IllegalArgumentException("Id cannot be null");
         }
         Authorizations authorizations = getAuthorizationsProvider().getAuthorizations();
-        return VertexiumBlueprintsVertex.create(this, getGraph().getVertex(VertexiumBlueprintsConvert.idToString(id), authorizations), authorizations);
+        return VertexiumBlueprintsVertex.create(this, getGraph().getVertex(VertexiumBlueprintsConvert.idToString(id), getFetchHints(), authorizations), authorizations);
     }
 
     @Override
@@ -52,7 +55,7 @@ public abstract class VertexiumBlueprintsGraph implements com.tinkerpop.blueprin
     @Override
     public Iterable<Vertex> getVertices() {
         final Authorizations authorizations = getAuthorizationsProvider().getAuthorizations();
-        return new ConvertingIterable<org.vertexium.Vertex, Vertex>(getGraph().getVertices(authorizations)) {
+        return new ConvertingIterable<org.vertexium.Vertex, Vertex>(getGraph().getVertices(getFetchHints(), authorizations)) {
             @Override
             protected Vertex convert(org.vertexium.Vertex vertex) {
                 return VertexiumBlueprintsVertex.create(VertexiumBlueprintsGraph.this, vertex, authorizations);
@@ -63,7 +66,7 @@ public abstract class VertexiumBlueprintsGraph implements com.tinkerpop.blueprin
     @Override
     public Iterable<Vertex> getVertices(final String key, final Object value) {
         final Authorizations authorizations = getAuthorizationsProvider().getAuthorizations();
-        return new ConvertingIterable<org.vertexium.Vertex, Vertex>(getGraph().query(authorizations).has(key, Compare.EQUAL, value).vertices()) {
+        return new ConvertingIterable<org.vertexium.Vertex, Vertex>(getGraph().query(authorizations).has(key, Compare.EQUAL, value).vertices(getFetchHints())) {
             @Override
             protected Vertex convert(org.vertexium.Vertex vertex) {
                 return VertexiumBlueprintsVertex.create(VertexiumBlueprintsGraph.this, vertex, authorizations);
@@ -90,7 +93,11 @@ public abstract class VertexiumBlueprintsGraph implements com.tinkerpop.blueprin
             throw new IllegalArgumentException("Id cannot be null");
         }
         Authorizations authorizations = getAuthorizationsProvider().getAuthorizations();
-        return VertexiumBlueprintsEdge.create(this, getGraph().getEdge(VertexiumBlueprintsConvert.idToString(id), authorizations), authorizations);
+        return VertexiumBlueprintsEdge.create(this, getGraph().getEdge(VertexiumBlueprintsConvert.idToString(id), getFetchHints(), authorizations), authorizations);
+    }
+
+    protected EnumSet<FetchHint> getFetchHints() {
+        return FetchHint.ALL;
     }
 
     @Override
@@ -102,7 +109,7 @@ public abstract class VertexiumBlueprintsGraph implements com.tinkerpop.blueprin
     @Override
     public Iterable<Edge> getEdges() {
         final Authorizations authorizations = getAuthorizationsProvider().getAuthorizations();
-        return new ConvertingIterable<org.vertexium.Edge, Edge>(getGraph().getEdges(authorizations)) {
+        return new ConvertingIterable<org.vertexium.Edge, Edge>(getGraph().getEdges(getFetchHints(), authorizations)) {
             @Override
             protected Edge convert(org.vertexium.Edge edge) {
                 return VertexiumBlueprintsEdge.create(VertexiumBlueprintsGraph.this, edge, authorizations);
@@ -113,7 +120,7 @@ public abstract class VertexiumBlueprintsGraph implements com.tinkerpop.blueprin
     @Override
     public Iterable<Edge> getEdges(final String key, final Object value) {
         final Authorizations authorizations = getAuthorizationsProvider().getAuthorizations();
-        return new ConvertingIterable<org.vertexium.Edge, Edge>(getGraph().query(authorizations).has(key, Compare.EQUAL, value).edges()) {
+        return new ConvertingIterable<org.vertexium.Edge, Edge>(getGraph().query(authorizations).has(key, Compare.EQUAL, value).edges(getFetchHints())) {
             @Override
             protected Edge convert(org.vertexium.Edge edge) {
                 return VertexiumBlueprintsEdge.create(VertexiumBlueprintsGraph.this, edge, authorizations);

--- a/blueprints/src/main/java/org/vertexium/blueprints/VertexiumBlueprintsGraphQuery.java
+++ b/blueprints/src/main/java/org/vertexium/blueprints/VertexiumBlueprintsGraphQuery.java
@@ -80,18 +80,18 @@ public class VertexiumBlueprintsGraphQuery extends VertexiumBlueprintsQuery impl
     @Override
     public Iterable<Edge> edges() {
         if (!hasFilter) {
-            return VertexiumBlueprintsConvert.toBlueprintsEdges(graph, graph.getGraph().getEdges(authorizations), authorizations);
+            return VertexiumBlueprintsConvert.toBlueprintsEdges(graph, graph.getGraph().getEdges(graph.getFetchHints(), authorizations), authorizations);
         }
-        Iterable<org.vertexium.Edge> edges = q.edges();
+        Iterable<org.vertexium.Edge> edges = q.edges(graph.getFetchHints());
         return VertexiumBlueprintsConvert.toBlueprintsEdges(graph, edges, authorizations);
     }
 
     @Override
     public Iterable<Vertex> vertices() {
         if (!hasFilter) {
-            return VertexiumBlueprintsConvert.toBlueprintsVertices(graph, graph.getGraph().getVertices(authorizations), authorizations);
+            return VertexiumBlueprintsConvert.toBlueprintsVertices(graph, graph.getGraph().getVertices(graph.getFetchHints(), authorizations), authorizations);
         }
-        Iterable<org.vertexium.Vertex> vertices = q.vertices();
+        Iterable<org.vertexium.Vertex> vertices = q.vertices(graph.getFetchHints());
         return VertexiumBlueprintsConvert.toBlueprintsVertices(graph, vertices, authorizations);
     }
 }

--- a/cli/src/main/java/org/vertexium/cli/model/LazyEdgeMap.java
+++ b/cli/src/main/java/org/vertexium/cli/model/LazyEdgeMap.java
@@ -5,7 +5,7 @@ import org.vertexium.FetchHint;
 
 public class LazyEdgeMap extends ModelBase {
     public LazyEdge get(String edgeId) {
-        Edge e = getGraph().getEdge(edgeId, FetchHint.ALL, getTime(), getAuthorizations());
+        Edge e = getGraph().getEdge(edgeId, FetchHint.DEFAULT, getTime(), getAuthorizations());
         if (e == null) {
             return null;
         }

--- a/cli/src/main/java/org/vertexium/cli/model/LazyEdgeProperty.java
+++ b/cli/src/main/java/org/vertexium/cli/model/LazyEdgeProperty.java
@@ -20,7 +20,7 @@ public class LazyEdgeProperty extends LazyProperty {
 
     @Override
     protected Edge getE() {
-        return getGraph().getEdge(getEdgeId(), FetchHint.ALL, getTime(), getAuthorizations());
+        return getGraph().getEdge(getEdgeId(), FetchHint.DEFAULT, getTime(), getAuthorizations());
     }
 
     @Override

--- a/cli/src/main/java/org/vertexium/cli/model/LazyExtendedDataTable.java
+++ b/cli/src/main/java/org/vertexium/cli/model/LazyExtendedDataTable.java
@@ -41,9 +41,9 @@ public class LazyExtendedDataTable extends ModelBase {
     public Element getElement() {
         switch (elementType) {
             case VERTEX:
-                return getGraph().getVertex(getElementId(), FetchHint.ALL, getTime(), getAuthorizations());
+                return getGraph().getVertex(getElementId(), FetchHint.DEFAULT, getTime(), getAuthorizations());
             case EDGE:
-                return getGraph().getEdge(getElementId(), FetchHint.ALL, getTime(), getAuthorizations());
+                return getGraph().getEdge(getElementId(), FetchHint.DEFAULT, getTime(), getAuthorizations());
             default:
                 throw new VertexiumException("Unhandled element type: " + elementType);
         }

--- a/cli/src/main/java/org/vertexium/cli/model/LazyVertexMap.java
+++ b/cli/src/main/java/org/vertexium/cli/model/LazyVertexMap.java
@@ -10,14 +10,14 @@ public class LazyVertexMap extends ModelBase {
     public Object get(String vertexId) {
         if (vertexId.endsWith("*")) {
             String vertexIdPrefix = vertexId.substring(0, vertexId.length() - 1);
-            Iterable<Vertex> vertices = getGraph().getVerticesWithPrefix(vertexIdPrefix, FetchHint.ALL, getTime(), getAuthorizations());
+            Iterable<Vertex> vertices = getGraph().getVerticesWithPrefix(vertexIdPrefix, FetchHint.DEFAULT, getTime(), getAuthorizations());
             List<String> results = new ArrayList<>();
             for (Vertex v : vertices) {
                 results.add(v.getId());
             }
             return new LazyVertexList(results);
         } else {
-            Vertex v = getGraph().getVertex(vertexId, FetchHint.ALL, getTime(), getAuthorizations());
+            Vertex v = getGraph().getVertex(vertexId, FetchHint.DEFAULT, getTime(), getAuthorizations());
             if (v == null) {
                 return null;
             }

--- a/core/pom.xml
+++ b/core/pom.xml
@@ -36,6 +36,11 @@
             <artifactId>junit</artifactId>
             <scope>test</scope>
         </dependency>
+        <dependency>
+            <groupId>org.mockito</groupId>
+            <artifactId>mockito-core</artifactId>
+            <scope>test</scope>
+        </dependency>
     </dependencies>
 
     <build>

--- a/core/src/main/java/org/vertexium/Element.java
+++ b/core/src/main/java/org/vertexium/Element.java
@@ -3,6 +3,8 @@ package org.vertexium;
 import com.google.common.collect.ImmutableSet;
 import org.vertexium.mutation.ExistingElementMutation;
 
+import java.util.EnumSet;
+
 /**
  * An element on the graph. This can be either a vertex or edge.
  * <p/>
@@ -302,4 +304,9 @@ public interface Element extends VertexiumObject {
      * @return Iterable of all the rows.
      */
     Iterable<ExtendedDataRow> getExtendedData(String tableName);
+
+    /**
+     * Fetch hints used when fetching this element.
+     */
+    EnumSet<FetchHint> getFetchHints();
 }

--- a/core/src/main/java/org/vertexium/ElementBase.java
+++ b/core/src/main/java/org/vertexium/ElementBase.java
@@ -12,10 +12,7 @@ import org.vertexium.util.ConvertingIterable;
 import org.vertexium.util.FilterIterable;
 import org.vertexium.util.PropertyCollection;
 
-import java.util.ArrayList;
-import java.util.HashSet;
-import java.util.Iterator;
-import java.util.Set;
+import java.util.*;
 import java.util.concurrent.ConcurrentSkipListSet;
 
 public abstract class ElementBase implements Element {
@@ -25,6 +22,7 @@ public abstract class ElementBase implements Element {
     private Property edgeLabelProperty;
     private Visibility visibility;
     private final long timestamp;
+    private final EnumSet<FetchHint> fetchHints;
     private Set<Visibility> hiddenVisibilities = new HashSet<>();
 
     private final PropertyCollection properties;
@@ -43,12 +41,14 @@ public abstract class ElementBase implements Element {
             Iterable<Visibility> hiddenVisibilities,
             ImmutableSet<String> extendedDataTableNames,
             long timestamp,
+            EnumSet<FetchHint> fetchHints,
             Authorizations authorizations
     ) {
         this.graph = graph;
         this.id = id;
         this.visibility = visibility;
         this.timestamp = timestamp;
+        this.fetchHints = fetchHints;
         this.properties = new PropertyCollection();
         this.extendedDataTableNames = extendedDataTableNames;
         this.authorizations = authorizations;
@@ -171,7 +171,15 @@ public abstract class ElementBase implements Element {
 
     protected Property getIdProperty() {
         if (idProperty == null) {
-            idProperty = new MutablePropertyImpl(ElementMutation.DEFAULT_KEY, ID_PROPERTY_NAME, getId(), null, getTimestamp(), null, null);
+            idProperty = new MutablePropertyImpl(
+                    ElementMutation.DEFAULT_KEY,
+                    ID_PROPERTY_NAME, getId(),
+                    null,
+                    getTimestamp(),
+                    null,
+                    null,
+                    getFetchHints()
+            );
         }
         return idProperty;
     }
@@ -179,7 +187,16 @@ public abstract class ElementBase implements Element {
     protected Property getEdgeLabelProperty() {
         if (edgeLabelProperty == null && this instanceof Edge) {
             String edgeLabel = ((Edge) this).getLabel();
-            edgeLabelProperty = new MutablePropertyImpl(ElementMutation.DEFAULT_KEY, Edge.LABEL_PROPERTY_NAME, edgeLabel, null, getTimestamp(), null, null);
+            edgeLabelProperty = new MutablePropertyImpl(
+                    ElementMutation.DEFAULT_KEY,
+                    Edge.LABEL_PROPERTY_NAME,
+                    edgeLabel,
+                    null,
+                    getTimestamp(),
+                    null,
+                    null,
+                    getFetchHints()
+            );
         }
         return edgeLabelProperty;
     }
@@ -502,5 +519,10 @@ public abstract class ElementBase implements Element {
     @Override
     public ImmutableSet<String> getExtendedDataTableNames() {
         return extendedDataTableNames;
+    }
+
+    @Override
+    public EnumSet<FetchHint> getFetchHints() {
+        return fetchHints;
     }
 }

--- a/core/src/main/java/org/vertexium/ElementBuilder.java
+++ b/core/src/main/java/org/vertexium/ElementBuilder.java
@@ -100,7 +100,16 @@ public abstract class ElementBuilder<T extends Element> implements ElementMutati
         if (value == null) {
             throw new NullPointerException("property value cannot be null for property: " + name + ":" + key);
         }
-        this.properties.add(new MutablePropertyImpl(key, name, value, metadata, timestamp, null, visibility));
+        this.properties.add(new MutablePropertyImpl(
+                key,
+                name,
+                value,
+                metadata,
+                timestamp,
+                null,
+                visibility,
+                FetchHint.ALL_INCLUDING_HIDDEN
+        ));
         return this;
     }
 

--- a/core/src/main/java/org/vertexium/FetchHint.java
+++ b/core/src/main/java/org/vertexium/FetchHint.java
@@ -15,6 +15,7 @@ public enum FetchHint {
     EXTENDED_DATA_TABLE_NAMES;
 
     public static final EnumSet<FetchHint> NONE = EnumSet.noneOf(FetchHint.class);
+    public static final EnumSet<FetchHint> DEFAULT = EnumSet.of(PROPERTIES, IN_EDGE_REFS, OUT_EDGE_REFS, EXTENDED_DATA_TABLE_NAMES);
     public static final EnumSet<FetchHint> ALL = EnumSet.of(PROPERTIES, PROPERTY_METADATA, IN_EDGE_REFS, OUT_EDGE_REFS, EXTENDED_DATA_TABLE_NAMES);
     public static final EnumSet<FetchHint> ALL_INCLUDING_HIDDEN = EnumSet.allOf(FetchHint.class);
     public static final EnumSet<FetchHint> EDGE_REFS = EnumSet.of(IN_EDGE_REFS, OUT_EDGE_REFS);
@@ -58,6 +59,18 @@ public enum FetchHint {
             return EnumSet.noneOf(FetchHint.class);
         } else {
             return EnumSet.copyOf(results);
+        }
+    }
+
+    public static void checkFetchHints(EnumSet<FetchHint> fetchHints, FetchHint neededFetchHint) {
+        checkFetchHints(fetchHints, EnumSet.of(neededFetchHint));
+    }
+
+    public static void checkFetchHints(EnumSet<FetchHint> fetchHints, EnumSet<FetchHint> neededFetchHints) {
+        for (FetchHint neededFetchHint : neededFetchHints) {
+            if (!fetchHints.contains(neededFetchHint)) {
+                throw new VertexiumMissingFetchHintException(fetchHints, neededFetchHints);
+            }
         }
     }
 }

--- a/core/src/main/java/org/vertexium/GraphBase.java
+++ b/core/src/main/java/org/vertexium/GraphBase.java
@@ -92,12 +92,12 @@ public abstract class GraphBase implements Graph {
 
     @Override
     public Vertex getVertex(String vertexId, Authorizations authorizations) throws VertexiumException {
-        return getVertex(vertexId, FetchHint.ALL, authorizations);
+        return getVertex(vertexId, FetchHint.DEFAULT, authorizations);
     }
 
     @Override
     public Iterable<Vertex> getVerticesWithPrefix(String vertexIdPrefix, Authorizations authorizations) {
-        return getVerticesWithPrefix(vertexIdPrefix, FetchHint.ALL, authorizations);
+        return getVerticesWithPrefix(vertexIdPrefix, FetchHint.DEFAULT, authorizations);
     }
 
     @Override
@@ -118,7 +118,7 @@ public abstract class GraphBase implements Graph {
 
     @Override
     public Iterable<Vertex> getVerticesInRange(Range idRange, Authorizations authorizations) {
-        return getVerticesInRange(idRange, FetchHint.ALL, authorizations);
+        return getVerticesInRange(idRange, FetchHint.DEFAULT, authorizations);
     }
 
     @Override
@@ -176,7 +176,7 @@ public abstract class GraphBase implements Graph {
 
     @Override
     public Iterable<Vertex> getVertices(final Iterable<String> ids, final Authorizations authorizations) {
-        return getVertices(ids, FetchHint.ALL, authorizations);
+        return getVertices(ids, FetchHint.DEFAULT, authorizations);
     }
 
     @Override
@@ -193,12 +193,12 @@ public abstract class GraphBase implements Graph {
 
     @Override
     public List<Vertex> getVerticesInOrder(Iterable<String> ids, Authorizations authorizations) {
-        return getVerticesInOrder(ids, FetchHint.ALL, authorizations);
+        return getVerticesInOrder(ids, FetchHint.DEFAULT, authorizations);
     }
 
     @Override
     public Iterable<Vertex> getVertices(Authorizations authorizations) throws VertexiumException {
-        return getVertices(FetchHint.ALL, authorizations);
+        return getVertices(FetchHint.DEFAULT, authorizations);
     }
 
     @Override
@@ -277,7 +277,7 @@ public abstract class GraphBase implements Graph {
 
     @Override
     public Edge getEdge(String edgeId, Authorizations authorizations) {
-        return getEdge(edgeId, FetchHint.ALL, authorizations);
+        return getEdge(edgeId, FetchHint.DEFAULT, authorizations);
     }
 
     @Override
@@ -454,12 +454,12 @@ public abstract class GraphBase implements Graph {
 
     @Override
     public Iterable<Edge> getEdges(final Iterable<String> ids, final Authorizations authorizations) {
-        return getEdges(ids, FetchHint.ALL, authorizations);
+        return getEdges(ids, FetchHint.DEFAULT, authorizations);
     }
 
     @Override
     public Iterable<Edge> getEdges(Authorizations authorizations) {
-        return getEdges(FetchHint.ALL, authorizations);
+        return getEdges(FetchHint.DEFAULT, authorizations);
     }
 
     @Override
@@ -472,7 +472,7 @@ public abstract class GraphBase implements Graph {
 
     @Override
     public Iterable<Edge> getEdgesInRange(Range idRange, Authorizations authorizations) {
-        return getEdgesInRange(idRange, FetchHint.ALL, authorizations);
+        return getEdgesInRange(idRange, FetchHint.DEFAULT, authorizations);
     }
 
     @Override

--- a/core/src/main/java/org/vertexium/VertexiumException.java
+++ b/core/src/main/java/org/vertexium/VertexiumException.java
@@ -1,6 +1,8 @@
 package org.vertexium;
 
 public class VertexiumException extends RuntimeException {
+    private static final long serialVersionUID = 6952596657973758922L;
+
     public VertexiumException(Exception e) {
         super(e);
     }

--- a/core/src/main/java/org/vertexium/VertexiumMissingFetchHintException.java
+++ b/core/src/main/java/org/vertexium/VertexiumMissingFetchHintException.java
@@ -1,0 +1,15 @@
+package org.vertexium;
+
+import java.util.EnumSet;
+
+public class VertexiumMissingFetchHintException extends VertexiumException {
+    private static final long serialVersionUID = 308097574790647596L;
+
+    public VertexiumMissingFetchHintException(EnumSet<FetchHint> fetchHints, EnumSet<FetchHint> neededFetchHints) {
+        super(createMessage(fetchHints, neededFetchHints));
+    }
+
+    private static String createMessage(EnumSet<FetchHint> fetchHints, EnumSet<FetchHint> neededFetchHints) {
+        return "Missing fetch hints. Found \"" + fetchHints + "\" needed \"" + neededFetchHints + "\"";
+    }
+}

--- a/core/src/main/java/org/vertexium/mutation/ExistingElementMutationImpl.java
+++ b/core/src/main/java/org/vertexium/mutation/ExistingElementMutationImpl.java
@@ -6,6 +6,7 @@ import org.vertexium.search.IndexHint;
 import org.vertexium.util.Preconditions;
 
 import java.util.ArrayList;
+import java.util.EnumSet;
 import java.util.List;
 
 public abstract class ExistingElementMutationImpl<T extends Element> implements ElementMutation<T>, ExistingElementMutation<T> {
@@ -45,7 +46,7 @@ public abstract class ExistingElementMutationImpl<T extends Element> implements 
     public ElementMutation<T> addPropertyValue(String key, String name, Object value, Metadata metadata, Long timestamp, Visibility visibility) {
         Preconditions.checkNotNull(name, "property name cannot be null for property: " + name + ":" + key);
         Preconditions.checkNotNull(value, "property value cannot be null for property: " + name + ":" + key);
-        properties.add(new MutablePropertyImpl(key, name, value, metadata, timestamp, null, visibility));
+        properties.add(new MutablePropertyImpl(key, name, value, metadata, timestamp, null, visibility, FetchHint.ALL_INCLUDING_HIDDEN));
         return this;
     }
 
@@ -70,6 +71,7 @@ public abstract class ExistingElementMutationImpl<T extends Element> implements 
 
     @Override
     public ElementMutation<T> deleteProperty(Property property) {
+        FetchHint.checkFetchHints(getElement().getFetchHints(), EnumSet.of(FetchHint.PROPERTIES, FetchHint.PROPERTY_METADATA));
         Preconditions.checkNotNull(property, "property cannot be null");
         propertyDeletes.add(new PropertyPropertyDeleteMutation(property));
         return this;
@@ -152,6 +154,7 @@ public abstract class ExistingElementMutationImpl<T extends Element> implements 
 
     @Override
     public ExistingElementMutation<T> alterPropertyVisibility(Property property, Visibility visibility) {
+        FetchHint.checkFetchHints(getElement().getFetchHints(), EnumSet.of(FetchHint.PROPERTIES, FetchHint.PROPERTY_METADATA));
         this.alterPropertyVisibilities.add(new AlterPropertyVisibility(property.getKey(), property.getName(), property.getVisibility(), visibility));
         return this;
     }
@@ -163,6 +166,7 @@ public abstract class ExistingElementMutationImpl<T extends Element> implements 
 
     @Override
     public ExistingElementMutation<T> alterPropertyVisibility(String key, String name, Visibility visibility) {
+        FetchHint.checkFetchHints(getElement().getFetchHints(), EnumSet.of(FetchHint.PROPERTIES, FetchHint.PROPERTY_METADATA));
         this.alterPropertyVisibilities.add(new AlterPropertyVisibility(key, name, null, visibility));
         return this;
     }

--- a/core/src/main/java/org/vertexium/property/MutablePropertyImpl.java
+++ b/core/src/main/java/org/vertexium/property/MutablePropertyImpl.java
@@ -1,27 +1,31 @@
 package org.vertexium.property;
 
-import org.vertexium.Authorizations;
-import org.vertexium.Metadata;
-import org.vertexium.Property;
-import org.vertexium.Visibility;
+import org.vertexium.*;
 import org.vertexium.util.IncreasingTime;
 
-import java.util.ArrayList;
-import java.util.Collection;
-import java.util.HashSet;
-import java.util.Set;
+import java.util.*;
 
 public class MutablePropertyImpl extends MutableProperty {
     private final String key;
     private final String name;
+    private final EnumSet<FetchHint> fetchHints;
     private Set<Visibility> hiddenVisibilities;
     private Object value;
     private Visibility visibility;
     private long timestamp;
     private final Metadata metadata;
 
-    public MutablePropertyImpl(String key, String name, Object value, Metadata metadata, Long timestamp, Set<Visibility> hiddenVisibilities, Visibility visibility) {
-        if (metadata == null) {
+    public MutablePropertyImpl(
+            String key,
+            String name,
+            Object value,
+            Metadata metadata,
+            Long timestamp,
+            Set<Visibility> hiddenVisibilities,
+            Visibility visibility,
+            EnumSet<FetchHint> fetchHints
+    ) {
+        if (metadata == null && fetchHints.contains(FetchHint.PROPERTY_METADATA)) {
             metadata = new Metadata();
         }
 
@@ -32,6 +36,7 @@ public class MutablePropertyImpl extends MutableProperty {
         this.timestamp = timestamp == null ? IncreasingTime.currentTimeMillis() : timestamp;
         this.visibility = visibility;
         this.hiddenVisibilities = hiddenVisibilities;
+        this.fetchHints = fetchHints;
     }
 
     public String getKey() {
@@ -56,6 +61,7 @@ public class MutablePropertyImpl extends MutableProperty {
     }
 
     public Metadata getMetadata() {
+        FetchHint.checkFetchHints(fetchHints, FetchHint.PROPERTY_METADATA);
         return metadata;
     }
 

--- a/core/src/main/java/org/vertexium/query/CompositeGraphQuery.java
+++ b/core/src/main/java/org/vertexium/query/CompositeGraphQuery.java
@@ -19,7 +19,7 @@ public class CompositeGraphQuery implements Query {
 
     @Override
     public QueryResultsIterable<Vertex> vertices() {
-        return vertices(FetchHint.ALL);
+        return vertices(FetchHint.DEFAULT);
     }
 
     @Override
@@ -49,7 +49,7 @@ public class CompositeGraphQuery implements Query {
 
     @Override
     public QueryResultsIterable<Edge> edges() {
-        return edges(FetchHint.ALL);
+        return edges(FetchHint.DEFAULT);
     }
 
     @Override
@@ -81,7 +81,7 @@ public class CompositeGraphQuery implements Query {
     @Deprecated
     public QueryResultsIterable<Edge> edges(final String label) {
         hasEdgeLabel(label);
-        return edges(FetchHint.ALL);
+        return edges(FetchHint.DEFAULT);
     }
 
     @Override
@@ -93,7 +93,7 @@ public class CompositeGraphQuery implements Query {
 
     @Override
     public QueryResultsIterable<Element> elements() {
-        return elements(FetchHint.ALL);
+        return elements(FetchHint.DEFAULT);
     }
 
     @Override
@@ -123,7 +123,7 @@ public class CompositeGraphQuery implements Query {
 
     @Override
     public QueryResultsIterable<ExtendedDataRow> extendedDataRows() {
-        return extendedDataRows(FetchHint.ALL);
+        return extendedDataRows(FetchHint.DEFAULT);
     }
 
     @Override
@@ -173,7 +173,7 @@ public class CompositeGraphQuery implements Query {
 
     @Override
     public QueryResultsIterable<? extends VertexiumObject> search() {
-        return search(VertexiumObjectType.ALL, FetchHint.ALL);
+        return search(VertexiumObjectType.ALL, FetchHint.DEFAULT);
     }
 
     @Override

--- a/core/src/main/java/org/vertexium/query/QueryBase.java
+++ b/core/src/main/java/org/vertexium/query/QueryBase.java
@@ -28,7 +28,7 @@ public abstract class QueryBase implements Query, SimilarToGraphQuery {
 
     @Override
     public QueryResultsIterable<Vertex> vertices() {
-        return vertices(FetchHint.ALL);
+        return vertices(FetchHint.DEFAULT);
     }
 
     @Override
@@ -44,7 +44,7 @@ public abstract class QueryBase implements Query, SimilarToGraphQuery {
 
     @Override
     public QueryResultsIterable<Edge> edges() {
-        return edges(FetchHint.ALL);
+        return edges(FetchHint.DEFAULT);
     }
 
     @Override
@@ -60,7 +60,7 @@ public abstract class QueryBase implements Query, SimilarToGraphQuery {
 
     @Override
     public QueryResultsIterable<ExtendedDataRow> extendedDataRows() {
-        return extendedDataRows(FetchHint.ALL);
+        return extendedDataRows(FetchHint.DEFAULT);
     }
 
     @Override
@@ -71,7 +71,7 @@ public abstract class QueryBase implements Query, SimilarToGraphQuery {
 
     @Override
     public QueryResultsIterable<? extends VertexiumObject> search() {
-        return search(VertexiumObjectType.ALL, FetchHint.ALL);
+        return search(VertexiumObjectType.ALL, FetchHint.DEFAULT);
     }
 
     @Override
@@ -204,7 +204,7 @@ public abstract class QueryBase implements Query, SimilarToGraphQuery {
 
     @Override
     public QueryResultsIterable<Element> elements() {
-        return elements(FetchHint.ALL);
+        return elements(FetchHint.DEFAULT);
     }
 
     @Override

--- a/core/src/test/java/org/vertexium/mutation/ExistingElementMutationImplTest.java
+++ b/core/src/test/java/org/vertexium/mutation/ExistingElementMutationImplTest.java
@@ -2,21 +2,30 @@ package org.vertexium.mutation;
 
 import org.junit.Before;
 import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.mockito.Mock;
+import org.mockito.runners.MockitoJUnitRunner;
 import org.vertexium.Authorizations;
 import org.vertexium.Element;
-import org.vertexium.Vertex;
+import org.vertexium.FetchHint;
 import org.vertexium.Visibility;
 import org.vertexium.property.MutablePropertyImpl;
 
 import static org.junit.Assert.assertFalse;
 import static org.junit.Assert.assertTrue;
+import static org.mockito.Mockito.when;
 
+@RunWith(MockitoJUnitRunner.class)
 public class ExistingElementMutationImplTest {
     private TestExistingElementMutationImpl mutation;
 
+    @Mock
+    private Element element;
+
     @Before
     public void before() {
-        mutation = new TestExistingElementMutationImpl<>((Vertex) null);
+        when(element.getFetchHints()).thenReturn(FetchHint.ALL);
+        mutation = new TestExistingElementMutationImpl<>(element);
     }
 
     @Test
@@ -32,13 +41,31 @@ public class ExistingElementMutationImplTest {
 
     @Test
     public void testHasChangesDeleteProperty() {
-        mutation.deleteProperty(new MutablePropertyImpl("key1", "name1", "value", null, null, null, new Visibility("")));
+        mutation.deleteProperty(new MutablePropertyImpl(
+                "key1",
+                "name1",
+                "value",
+                null,
+                null,
+                null,
+                new Visibility(""),
+                FetchHint.ALL
+        ));
         assertTrue("should have changes", mutation.hasChanges());
     }
 
     @Test
     public void testHasChangesSoftDeleteProperty() {
-        mutation.softDeleteProperty(new MutablePropertyImpl("key1", "name1", "value", null, null, null, new Visibility("")));
+        mutation.softDeleteProperty(new MutablePropertyImpl(
+                "key1",
+                "name1",
+                "value",
+                null,
+                null,
+                null,
+                new Visibility(""),
+                FetchHint.ALL
+        ));
         assertTrue("should have changes", mutation.hasChanges());
     }
 

--- a/inmemory/src/main/java/org/vertexium/inmemory/InMemoryEdge.java
+++ b/inmemory/src/main/java/org/vertexium/inmemory/InMemoryEdge.java
@@ -15,11 +15,11 @@ public class InMemoryEdge extends InMemoryElement<InMemoryEdge> implements Edge 
             InMemoryGraph graph,
             String id,
             InMemoryTableEdge inMemoryTableElement,
-            boolean includeHidden,
+            EnumSet<FetchHint> fetchHints,
             Long endTime,
             Authorizations authorizations
     ) {
-        super(graph, id, inMemoryTableElement, includeHidden, endTime, authorizations);
+        super(graph, id, inMemoryTableElement, fetchHints, endTime, authorizations);
         edgeSetupMutation = inMemoryTableElement.findLastMutation(EdgeSetupMutation.class);
     }
 
@@ -47,7 +47,7 @@ public class InMemoryEdge extends InMemoryElement<InMemoryEdge> implements Edge 
 
     @Override
     public Vertex getVertex(Direction direction, Authorizations authorizations) {
-        return getVertex(direction, FetchHint.ALL, authorizations);
+        return getVertex(direction, FetchHint.DEFAULT, authorizations);
     }
 
     @Override
@@ -62,7 +62,7 @@ public class InMemoryEdge extends InMemoryElement<InMemoryEdge> implements Edge 
 
     @Override
     public Vertex getOtherVertex(String myVertexId, Authorizations authorizations) {
-        return getOtherVertex(myVertexId, FetchHint.ALL, authorizations);
+        return getOtherVertex(myVertexId, FetchHint.DEFAULT, authorizations);
     }
 
     @Override
@@ -72,7 +72,7 @@ public class InMemoryEdge extends InMemoryElement<InMemoryEdge> implements Edge 
 
     @Override
     public EdgeVertices getVertices(Authorizations authorizations) {
-        return getVertices(FetchHint.ALL, authorizations);
+        return getVertices(FetchHint.DEFAULT, authorizations);
     }
 
     @Override

--- a/inmemory/src/main/java/org/vertexium/inmemory/InMemoryGraph.java
+++ b/inmemory/src/main/java/org/vertexium/inmemory/InMemoryGraph.java
@@ -133,7 +133,7 @@ public class InMemoryGraph extends GraphBaseWithSearchIndex {
                 } else {
                     vertices.append(getElementId(), new ElementTimestampMutation(timestampLong));
                 }
-                InMemoryVertex vertex = InMemoryGraph.this.vertices.get(InMemoryGraph.this, getElementId(), authorizations);
+                InMemoryVertex vertex = InMemoryGraph.this.vertices.get(InMemoryGraph.this, getElementId(), FetchHint.ALL_INCLUDING_HIDDEN, authorizations);
                 if (isNew && hasEventListeners()) {
                     fireGraphEvent(new AddVertexEvent(InMemoryGraph.this, vertex));
                 }
@@ -257,7 +257,16 @@ public class InMemoryGraph extends GraphBaseWithSearchIndex {
         }
     }
 
-    public void markPropertyHidden(InMemoryElement element, InMemoryTableElement inMemoryTableElement, String key, String name, Visibility propertyVisibility, Long timestamp, Visibility visibility, Authorizations authorizations) {
+    public void markPropertyHidden(
+            InMemoryElement element,
+            InMemoryTableElement inMemoryTableElement,
+            String key,
+            String name,
+            Visibility propertyVisibility,
+            Long timestamp,
+            Visibility visibility,
+            Authorizations authorizations
+    ) {
         if (!element.canRead(authorizations)) {
             return;
         }
@@ -343,7 +352,7 @@ public class InMemoryGraph extends GraphBaseWithSearchIndex {
             edges.append(edgeBuilder.getElementId(), new AlterEdgeLabelMutation(incrementingTimestamp, edgeBuilder.getNewEdgeLabel()));
         }
 
-        InMemoryEdge edge = this.edges.get(InMemoryGraph.this, edgeBuilder.getElementId(), authorizations);
+        InMemoryEdge edge = this.edges.get(InMemoryGraph.this, edgeBuilder.getElementId(), FetchHint.ALL_INCLUDING_HIDDEN, authorizations);
         if (isNew && hasEventListeners()) {
             fireGraphEvent(new AddEdgeEvent(InMemoryGraph.this, edge));
         }
@@ -499,7 +508,7 @@ public class InMemoryGraph extends GraphBaseWithSearchIndex {
         if (sourceVertexId.equals(destVertexId)) {
             foundPaths.add(currentPath);
         } else if (hops > 0) {
-            Stream<Edge> edges = stream(getEdgesFromVertex(sourceVertexId, FetchHint.ALL, null, authorizations))
+            Stream<Edge> edges = stream(getEdgesFromVertex(sourceVertexId, FetchHint.DEFAULT, null, authorizations))
                     .filter(edge -> {
                         if (options.getExcludedLabels() != null) {
                             if (ArrayUtils.contains(options.getExcludedLabels(), edge.getLabel())) {
@@ -543,11 +552,11 @@ public class InMemoryGraph extends GraphBaseWithSearchIndex {
     }
 
     protected Iterable<Edge> getEdgesFromVertex(
-            final String vertexId, final EnumSet<FetchHint> fetchHints,
-            final Long endTime, final Authorizations authorizations
+            String vertexId,
+            EnumSet<FetchHint> fetchHints,
+            Long endTime,
+            Authorizations authorizations
     ) {
-        final boolean includeHidden = fetchHints.contains(FetchHint.INCLUDE_HIDDEN);
-
         return new LookAheadIterable<InMemoryTableEdge, Edge>() {
             @Override
             protected boolean isIncluded(InMemoryTableEdge inMemoryTableElement, Edge edge) {
@@ -567,7 +576,7 @@ public class InMemoryGraph extends GraphBaseWithSearchIndex {
 
             @Override
             protected Edge convert(InMemoryTableEdge inMemoryTableElement) {
-                return inMemoryTableElement.createElement(InMemoryGraph.this, includeHidden, endTime, authorizations);
+                return inMemoryTableElement.createElement(InMemoryGraph.this, fetchHints, endTime, authorizations);
             }
 
             @Override
@@ -663,7 +672,7 @@ public class InMemoryGraph extends GraphBaseWithSearchIndex {
             );
         }
         inMemoryTableElement.appendAddPropertyValueMutation(key, name, value, metadata, visibility, timestamp);
-        Property property = inMemoryTableElement.getProperty(key, name, visibility, authorizations);
+        Property property = inMemoryTableElement.getProperty(key, name, visibility, FetchHint.ALL_INCLUDING_HIDDEN, authorizations);
 
         if (hasEventListeners()) {
             fireGraphEvent(new AddPropertyEvent(this, element, property));
@@ -680,8 +689,12 @@ public class InMemoryGraph extends GraphBaseWithSearchIndex {
             Authorizations authorizations
     ) {
         for (AlterPropertyVisibility apv : alterPropertyVisibilities) {
-            Property property = inMemoryTableElement.getProperty(apv.getKey(), apv.getName(),
-                                                                 apv.getExistingVisibility(), authorizations
+            Property property = inMemoryTableElement.getProperty(
+                    apv.getKey(),
+                    apv.getName(),
+                    apv.getExistingVisibility(),
+                    FetchHint.ALL_INCLUDING_HIDDEN,
+                    authorizations
             );
             if (property == null) {
                 throw new VertexiumException("Could not find property " + apv.getKey() + ":" + apv.getName());
@@ -727,7 +740,12 @@ public class InMemoryGraph extends GraphBaseWithSearchIndex {
     ) {
         for (SetPropertyMetadata spm : setPropertyMetadatas) {
             Property property = inMemoryTableElement.getProperty(
-                    spm.getPropertyKey(), spm.getPropertyName(), spm.getPropertyVisibility(), authorizations);
+                    spm.getPropertyKey(),
+                    spm.getPropertyName(),
+                    spm.getPropertyVisibility(),
+                    FetchHint.ALL_INCLUDING_HIDDEN,
+                    authorizations
+            );
             if (property == null) {
                 throw new VertexiumException("Could not find property " + spm.getPropertyKey() + ":" + spm.getPropertyName());
             }
@@ -775,10 +793,12 @@ public class InMemoryGraph extends GraphBaseWithSearchIndex {
     protected void deleteProperty(
             InMemoryElement element,
             InMemoryTableElement inMemoryTableElement,
-            String key, String name, Visibility visibility,
+            String key,
+            String name,
+            Visibility visibility,
             Authorizations authorizations
     ) {
-        Property property = inMemoryTableElement.getProperty(key, name, visibility, authorizations);
+        Property property = inMemoryTableElement.getProperty(key, name, visibility, FetchHint.ALL_INCLUDING_HIDDEN, authorizations);
         inMemoryTableElement.deleteProperty(key, name, visibility, authorizations);
 
         getSearchIndex().deleteProperty(this, element, PropertyDescriptor.fromProperty(property), authorizations);

--- a/inmemory/src/main/java/org/vertexium/inmemory/InMemoryTable.java
+++ b/inmemory/src/main/java/org/vertexium/inmemory/InMemoryTable.java
@@ -21,12 +21,12 @@ public abstract class InMemoryTable<TElement extends InMemoryElement> {
         this(new ConcurrentSkipListMap<String, InMemoryTableElement<TElement>>());
     }
 
-    public TElement get(InMemoryGraph graph, String id, Authorizations authorizations) {
+    public TElement get(InMemoryGraph graph, String id, EnumSet<FetchHint> fetchHints, Authorizations authorizations) {
         InMemoryTableElement<TElement> inMemoryTableElement = getTableElement(id);
         if (inMemoryTableElement == null) {
             return null;
         }
-        return inMemoryTableElement.createElement(graph, authorizations);
+        return inMemoryTableElement.createElement(graph, fetchHints, authorizations);
     }
 
     public InMemoryTableElement<TElement> getTableElement(String id) {
@@ -52,9 +52,12 @@ public abstract class InMemoryTable<TElement extends InMemoryElement> {
         rows.clear();
     }
 
-    public Iterable<TElement> getAll(final InMemoryGraph graph, final EnumSet<FetchHint> fetchHints, final Long endTime,
-                                     final Authorizations authorizations) {
-        final boolean includeHidden = fetchHints.contains(FetchHint.INCLUDE_HIDDEN);
+    public Iterable<TElement> getAll(
+            InMemoryGraph graph,
+            EnumSet<FetchHint> fetchHints,
+            Long endTime,
+            Authorizations authorizations
+    ) {
         return new LookAheadIterable<InMemoryTableElement<TElement>, TElement>() {
             @Override
             protected boolean isIncluded(InMemoryTableElement<TElement> src, TElement element) {
@@ -63,7 +66,7 @@ public abstract class InMemoryTable<TElement extends InMemoryElement> {
 
             @Override
             protected TElement convert(InMemoryTableElement<TElement> element) {
-                return element.createElement(graph, includeHidden, endTime, authorizations);
+                return element.createElement(graph, fetchHints, endTime, authorizations);
             }
 
             @Override

--- a/inmemory/src/main/java/org/vertexium/inmemory/InMemoryTableEdge.java
+++ b/inmemory/src/main/java/org/vertexium/inmemory/InMemoryTableEdge.java
@@ -1,6 +1,9 @@
 package org.vertexium.inmemory;
 
 import org.vertexium.Authorizations;
+import org.vertexium.FetchHint;
+
+import java.util.EnumSet;
 
 public class InMemoryTableEdge extends InMemoryTableElement<InMemoryEdge> {
     public InMemoryTableEdge(String id) {
@@ -8,7 +11,7 @@ public class InMemoryTableEdge extends InMemoryTableElement<InMemoryEdge> {
     }
 
     @Override
-    public InMemoryEdge createElementInternal(InMemoryGraph graph, boolean includeHidden, Long endTime, Authorizations authorizations) {
-        return new InMemoryEdge(graph, getId(), this, includeHidden, endTime, authorizations);
+    public InMemoryEdge createElementInternal(InMemoryGraph graph, EnumSet<FetchHint> fetchHints, Long endTime, Authorizations authorizations) {
+        return new InMemoryEdge(graph, getId(), this, fetchHints, endTime, authorizations);
     }
 }

--- a/inmemory/src/main/java/org/vertexium/inmemory/InMemoryTableVertex.java
+++ b/inmemory/src/main/java/org/vertexium/inmemory/InMemoryTableVertex.java
@@ -1,6 +1,9 @@
 package org.vertexium.inmemory;
 
 import org.vertexium.Authorizations;
+import org.vertexium.FetchHint;
+
+import java.util.EnumSet;
 
 public class InMemoryTableVertex extends InMemoryTableElement<InMemoryVertex> {
     public InMemoryTableVertex(String id) {
@@ -8,7 +11,7 @@ public class InMemoryTableVertex extends InMemoryTableElement<InMemoryVertex> {
     }
 
     @Override
-    public InMemoryVertex createElementInternal(InMemoryGraph graph, boolean includeHidden, Long endTime, Authorizations authorizations) {
-        return new InMemoryVertex(graph, getId(), this, includeHidden, endTime, authorizations);
+    public InMemoryVertex createElementInternal(InMemoryGraph graph, EnumSet<FetchHint> fetchHints, Long endTime, Authorizations authorizations) {
+        return new InMemoryVertex(graph, getId(), this, fetchHints, endTime, authorizations);
     }
 }

--- a/inmemory/src/main/java/org/vertexium/inmemory/InMemoryVertex.java
+++ b/inmemory/src/main/java/org/vertexium/inmemory/InMemoryVertex.java
@@ -17,7 +17,7 @@ public class InMemoryVertex extends InMemoryElement<InMemoryVertex> implements V
             InMemoryGraph graph,
             String id,
             InMemoryTableVertex inMemoryTableElement,
-            boolean includeHidden,
+            EnumSet<FetchHint> fetchHints,
             Long endTime,
             Authorizations authorizations
     ) {
@@ -25,7 +25,7 @@ public class InMemoryVertex extends InMemoryElement<InMemoryVertex> implements V
                 graph,
                 id,
                 inMemoryTableElement,
-                includeHidden,
+                fetchHints,
                 endTime,
                 authorizations
         );
@@ -33,7 +33,7 @@ public class InMemoryVertex extends InMemoryElement<InMemoryVertex> implements V
 
     @Override
     public Iterable<Edge> getEdges(Direction direction, Authorizations authorizations) {
-        return getEdges(direction, FetchHint.ALL, authorizations);
+        return getEdges(direction, FetchHint.DEFAULT, authorizations);
     }
 
     @Override
@@ -115,7 +115,7 @@ public class InMemoryVertex extends InMemoryElement<InMemoryVertex> implements V
 
     @Override
     public Iterable<Edge> getEdges(Direction direction, String label, Authorizations authorizations) {
-        return getEdges(direction, label, FetchHint.ALL, authorizations);
+        return getEdges(direction, label, FetchHint.DEFAULT, authorizations);
     }
 
     @Override
@@ -130,7 +130,7 @@ public class InMemoryVertex extends InMemoryElement<InMemoryVertex> implements V
 
     @Override
     public Iterable<Edge> getEdges(Direction direction, String[] labels, Authorizations authorizations) {
-        return getEdges(direction, labels, FetchHint.ALL, authorizations);
+        return getEdges(direction, labels, FetchHint.DEFAULT, authorizations);
     }
 
     @Override
@@ -158,7 +158,7 @@ public class InMemoryVertex extends InMemoryElement<InMemoryVertex> implements V
 
     @Override
     public Iterable<Edge> getEdges(Vertex otherVertex, Direction direction, Authorizations authorizations) {
-        return getEdges(otherVertex, direction, FetchHint.ALL, authorizations);
+        return getEdges(otherVertex, direction, FetchHint.DEFAULT, authorizations);
     }
 
     @Override
@@ -178,7 +178,7 @@ public class InMemoryVertex extends InMemoryElement<InMemoryVertex> implements V
 
     @Override
     public Iterable<Edge> getEdges(Vertex otherVertex, Direction direction, String label, Authorizations authorizations) {
-        return getEdges(otherVertex, direction, label, FetchHint.ALL, authorizations);
+        return getEdges(otherVertex, direction, label, FetchHint.DEFAULT, authorizations);
     }
 
     @Override
@@ -198,7 +198,7 @@ public class InMemoryVertex extends InMemoryElement<InMemoryVertex> implements V
 
     @Override
     public Iterable<Edge> getEdges(Vertex otherVertex, Direction direction, String[] labels, Authorizations authorizations) {
-        return getEdges(otherVertex, direction, labels, FetchHint.ALL, authorizations);
+        return getEdges(otherVertex, direction, labels, FetchHint.DEFAULT, authorizations);
     }
 
     @Override
@@ -233,7 +233,7 @@ public class InMemoryVertex extends InMemoryElement<InMemoryVertex> implements V
 
     @Override
     public Iterable<Vertex> getVertices(Direction direction, Authorizations authorizations) {
-        return getVertices(direction, FetchHint.ALL, authorizations);
+        return getVertices(direction, FetchHint.DEFAULT, authorizations);
     }
 
     @Override
@@ -243,7 +243,7 @@ public class InMemoryVertex extends InMemoryElement<InMemoryVertex> implements V
 
     @Override
     public Iterable<Vertex> getVertices(Direction direction, String label, Authorizations authorizations) {
-        return getVertices(direction, label, FetchHint.ALL, authorizations);
+        return getVertices(direction, label, FetchHint.DEFAULT, authorizations);
     }
 
     @Override
@@ -253,7 +253,7 @@ public class InMemoryVertex extends InMemoryElement<InMemoryVertex> implements V
 
     @Override
     public Iterable<Vertex> getVertices(Direction direction, String[] labels, Authorizations authorizations) {
-        return getVertices(direction, labels, FetchHint.ALL, authorizations);
+        return getVertices(direction, labels, FetchHint.DEFAULT, authorizations);
     }
 
     @Override
@@ -323,7 +323,7 @@ public class InMemoryVertex extends InMemoryElement<InMemoryVertex> implements V
 
     @Override
     public Iterable<EdgeVertexPair> getEdgeVertexPairs(Direction direction, Authorizations authorizations) {
-        return getEdgeVertexPairs(getEdgeInfos(direction, authorizations), FetchHint.ALL, null, authorizations);
+        return getEdgeVertexPairs(getEdgeInfos(direction, authorizations), FetchHint.DEFAULT, null, authorizations);
     }
 
     @Override
@@ -338,7 +338,7 @@ public class InMemoryVertex extends InMemoryElement<InMemoryVertex> implements V
 
     @Override
     public Iterable<EdgeVertexPair> getEdgeVertexPairs(Direction direction, String label, Authorizations authorizations) {
-        return getEdgeVertexPairs(getEdgeInfos(direction, label, authorizations), FetchHint.ALL, null, authorizations);
+        return getEdgeVertexPairs(getEdgeInfos(direction, label, authorizations), FetchHint.DEFAULT, null, authorizations);
     }
 
     @Override
@@ -348,7 +348,7 @@ public class InMemoryVertex extends InMemoryElement<InMemoryVertex> implements V
 
     @Override
     public Iterable<EdgeVertexPair> getEdgeVertexPairs(Direction direction, String[] labels, Authorizations authorizations) {
-        return getEdgeVertexPairs(getEdgeInfos(direction, labels, authorizations), FetchHint.ALL, null, authorizations);
+        return getEdgeVertexPairs(getEdgeInfos(direction, labels, authorizations), FetchHint.DEFAULT, null, authorizations);
     }
 
     @Override

--- a/pom.xml
+++ b/pom.xml
@@ -112,6 +112,7 @@
         <h2.version>1.4.188</h2.version>
         <mysql.version>5.1.36</mysql.version>
         <xstream.version>1.4.8</xstream.version>
+        <mockito.version>1.9.5</mockito.version>
     </properties>
 
     <dependencyManagement>
@@ -146,6 +147,12 @@
                 <groupId>junit</groupId>
                 <artifactId>junit</artifactId>
                 <version>${junit.version}</version>
+                <scope>test</scope>
+            </dependency>
+            <dependency>
+                <groupId>org.mockito</groupId>
+                <artifactId>mockito-core</artifactId>
+                <version>${mockito.version}</version>
                 <scope>test</scope>
             </dependency>
             <dependency>

--- a/sql/src/main/java/org/vertexium/sql/SqlGraph.java
+++ b/sql/src/main/java/org/vertexium/sql/SqlGraph.java
@@ -72,24 +72,26 @@ public class SqlGraph extends InMemoryGraph {
     }
 
     @Override
-    public Vertex getVertex(String vertexId, EnumSet<FetchHint> fetchHints, Long endTime,
-                            Authorizations authorizations) {
+    public Vertex getVertex(
+            String vertexId, EnumSet<FetchHint> fetchHints, Long endTime,
+            Authorizations authorizations
+    ) {
         validateAuthorizations(authorizations);
 
         InMemoryTableElement<InMemoryVertex> element = vertexMap.get(vertexId);
         if (element == null || !isIncludedInTimeSpan(element, fetchHints, endTime, authorizations)) {
             return null;
         } else {
-            return element.createElement(this, fetchHints.contains(FetchHint.INCLUDE_HIDDEN), endTime, authorizations);
+            return element.createElement(this, fetchHints, endTime, authorizations);
         }
     }
 
     @Override
-    public Iterable<Vertex> getVerticesWithPrefix(final String vertexIdPrefix, final EnumSet<FetchHint> fetchHints,
-                                                  final Long endTime, final Authorizations authorizations) {
+    public Iterable<Vertex> getVerticesWithPrefix(
+            final String vertexIdPrefix, final EnumSet<FetchHint> fetchHints,
+            final Long endTime, final Authorizations authorizations
+    ) {
         validateAuthorizations(authorizations);
-
-        final boolean includeHidden = fetchHints.contains(FetchHint.INCLUDE_HIDDEN);
 
         return new LookAheadIterable<InMemoryTableVertex, Vertex>() {
             @Override
@@ -99,13 +101,15 @@ public class SqlGraph extends InMemoryGraph {
 
             @Override
             protected Vertex convert(InMemoryTableVertex element) {
-                return element.createElement(SqlGraph.this, includeHidden, endTime, authorizations);
+                return element.createElement(SqlGraph.this, fetchHints, endTime, authorizations);
             }
 
             @Override
             protected Iterator<InMemoryTableVertex> createIterator() {
-                Iterator<InMemoryTableElement<InMemoryVertex>> elements = vertexMap.query("id like ?",
-                        vertexIdPrefix + "%");
+                Iterator<InMemoryTableElement<InMemoryVertex>> elements = vertexMap.query(
+                        "id like ?",
+                        vertexIdPrefix + "%"
+                );
 
                 return new ConvertingIterable<InMemoryTableElement<InMemoryVertex>, InMemoryTableVertex>(elements) {
                     @Override
@@ -123,30 +127,37 @@ public class SqlGraph extends InMemoryGraph {
         if (element == null || !isIncluded(element, fetchHints, authorizations)) {
             return null;
         } else {
-            return element.createElement(this, fetchHints.contains(FetchHint.INCLUDE_HIDDEN), endTime, authorizations);
+            return element.createElement(this, fetchHints, endTime, authorizations);
         }
     }
 
     @SuppressWarnings("unchecked")
     @Override
-    public Iterable<Vertex> getVertices(final Iterable<String> ids, final EnumSet<FetchHint> fetchHints,
-                                        final Long endTime, final Authorizations authorizations) {
+    public Iterable<Vertex> getVertices(
+            final Iterable<String> ids, final EnumSet<FetchHint> fetchHints,
+            final Long endTime, final Authorizations authorizations
+    ) {
         return (Iterable<Vertex>) getElements(ids, fetchHints, endTime, authorizations, vertexMap);
     }
 
     @SuppressWarnings("unchecked")
     @Override
-    public Iterable<Edge> getEdges(final Iterable<String> ids, final EnumSet<FetchHint> fetchHints, final Long endTime,
-                                   final Authorizations authorizations) {
+    public Iterable<Edge> getEdges(
+            Iterable<String> ids,
+            EnumSet<FetchHint> fetchHints,
+            Long endTime,
+            Authorizations authorizations
+    ) {
         return (Iterable<Edge>) getElements(ids, fetchHints, endTime, authorizations, edgeMap);
     }
 
-    private <T extends InMemoryElement> Iterable<?> getElements(final Iterable<String> ids,
-                                                                final EnumSet<FetchHint> fetchHints, final Long endTime,
-                                                                final Authorizations authorizations,
-                                                                final SqlMap<InMemoryTableElement<T>> sqlMap) {
-        final boolean includeHidden = fetchHints.contains(FetchHint.INCLUDE_HIDDEN);
-
+    private <T extends InMemoryElement> Iterable<?> getElements(
+            Iterable<String> ids,
+            EnumSet<FetchHint> fetchHints,
+            Long endTime,
+            Authorizations authorizations,
+            SqlMap<InMemoryTableElement<T>> sqlMap
+    ) {
         return new LookAheadIterable<InMemoryTableElement, T>() {
             @Override
             protected boolean isIncluded(InMemoryTableElement srcElement, T destElement) {
@@ -156,7 +167,7 @@ public class SqlGraph extends InMemoryGraph {
             @SuppressWarnings("unchecked")
             @Override
             protected T convert(InMemoryTableElement element) {
-                return (T) element.createElement(SqlGraph.this, includeHidden, endTime, authorizations);
+                return (T) element.createElement(SqlGraph.this, fetchHints, endTime, authorizations);
             }
 
             @SuppressWarnings("unused")
@@ -176,8 +187,10 @@ public class SqlGraph extends InMemoryGraph {
                 if (first) {
                     return Collections.emptyIterator();
                 } else {
-                    Iterator<InMemoryTableElement<T>> elements = sqlMap.query(idWhere.toString(),
-                            Iterables.toArray(ids, Object.class));
+                    Iterator<InMemoryTableElement<T>> elements = sqlMap.query(
+                            idWhere.toString(),
+                            Iterables.toArray(ids, Object.class)
+                    );
 
                     return new ConvertingIterable<InMemoryTableElement, InMemoryTableElement>(elements) {
                         @Override
@@ -191,10 +204,12 @@ public class SqlGraph extends InMemoryGraph {
     }
 
     @Override
-    public Iterable<Edge> getEdgesFromVertex(final String vertexId, final EnumSet<FetchHint> fetchHints,
-                                             final Long endTime, final Authorizations authorizations) {
-        final boolean includeHidden = fetchHints.contains(FetchHint.INCLUDE_HIDDEN);
-
+    public Iterable<Edge> getEdgesFromVertex(
+            String vertexId,
+            EnumSet<FetchHint> fetchHints,
+            Long endTime,
+            Authorizations authorizations
+    ) {
         return new LookAheadIterable<InMemoryTableEdge, Edge>() {
             @Override
             protected boolean isIncluded(InMemoryTableEdge element, Edge edge) {
@@ -203,7 +218,7 @@ public class SqlGraph extends InMemoryGraph {
 
             @Override
             protected Edge convert(InMemoryTableEdge element) {
-                return element.createElement(SqlGraph.this, includeHidden, endTime, authorizations);
+                return element.createElement(SqlGraph.this, fetchHints, endTime, authorizations);
             }
 
             @Override
@@ -236,9 +251,11 @@ public class SqlGraph extends InMemoryGraph {
     }
 
     @Override
-    protected StreamingPropertyValueRef saveStreamingPropertyValue(String elementId, String key, String name,
-                                                                   Visibility visibility, long timestamp,
-                                                                   StreamingPropertyValue value) {
+    protected StreamingPropertyValueRef saveStreamingPropertyValue(
+            String elementId, String key, String name,
+            Visibility visibility, long timestamp,
+            StreamingPropertyValue value
+    ) {
         return streamingPropertyTable.put(elementId, key, name, visibility, timestamp, value);
     }
 }

--- a/sql/src/main/java/org/vertexium/sql/SqlTableEdge.java
+++ b/sql/src/main/java/org/vertexium/sql/SqlTableEdge.java
@@ -8,6 +8,7 @@ import org.vertexium.inmemory.mutations.EdgeSetupMutation;
 import org.vertexium.inmemory.mutations.Mutation;
 import org.vertexium.sql.collections.Storable;
 
+import java.util.EnumSet;
 import java.util.List;
 import java.util.Map;
 import java.util.Set;
@@ -20,8 +21,8 @@ public class SqlTableEdge extends SqlTableElement<InMemoryEdge> {
     }
 
     @Override
-    public InMemoryEdge createElementInternal(InMemoryGraph graph, boolean includeHidden, Long endTime, Authorizations authorizations) {
-        return new InMemoryEdge(graph, getId(), asInMemoryTableElement(), includeHidden, endTime, authorizations);
+    public InMemoryEdge createElementInternal(InMemoryGraph graph, EnumSet<FetchHint> fetchHints, Long endTime, Authorizations authorizations) {
+        return new InMemoryEdge(graph, getId(), asInMemoryTableElement(), fetchHints, endTime, authorizations);
     }
 
     String inVertexId() {
@@ -99,8 +100,8 @@ public class SqlTableEdge extends SqlTableElement<InMemoryEdge> {
         }
 
         @Override
-        public Property getProperty(String key, String name, Visibility visibility, Authorizations authorizations) {
-            return sqlTableEdge.getProperty(key, name, visibility, authorizations);
+        public Property getProperty(String key, String name, Visibility visibility, EnumSet<FetchHint> fetchHints, Authorizations authorizations) {
+            return sqlTableEdge.getProperty(key, name, visibility, fetchHints, authorizations);
         }
 
         @Override
@@ -119,8 +120,8 @@ public class SqlTableEdge extends SqlTableElement<InMemoryEdge> {
         }
 
         @Override
-        public Iterable<Property> getProperties(boolean includeHidden, Long endTime, Authorizations authorizations) {
-            return sqlTableEdge.getProperties(includeHidden, endTime, authorizations);
+        public Iterable<Property> getProperties(EnumSet<FetchHint> fetchHints, Long endTime, Authorizations authorizations) {
+            return sqlTableEdge.getProperties(fetchHints, endTime, authorizations);
         }
 
         @Override
@@ -194,8 +195,8 @@ public class SqlTableEdge extends SqlTableElement<InMemoryEdge> {
         }
 
         @Override
-        public InMemoryEdge createElement(InMemoryGraph graph, Authorizations authorizations) {
-            return sqlTableEdge.createElement(graph, authorizations);
+        public InMemoryEdge createElement(InMemoryGraph graph, EnumSet<FetchHint> fetchHints, Authorizations authorizations) {
+            return sqlTableEdge.createElement(graph, fetchHints, authorizations);
         }
 
         @Override
@@ -204,8 +205,8 @@ public class SqlTableEdge extends SqlTableElement<InMemoryEdge> {
         }
 
         @Override
-        public InMemoryEdge createElementInternal(InMemoryGraph graph, boolean includeHidden, Long endTime, Authorizations authorizations) {
-            return sqlTableEdge.createElementInternal(graph, includeHidden, endTime, authorizations);
+        public InMemoryEdge createElementInternal(InMemoryGraph graph, EnumSet<FetchHint> fetchHints, Long endTime, Authorizations authorizations) {
+            return sqlTableEdge.createElementInternal(graph, fetchHints, endTime, authorizations);
         }
     }
 }

--- a/sql/src/main/java/org/vertexium/sql/SqlTableVertex.java
+++ b/sql/src/main/java/org/vertexium/sql/SqlTableVertex.java
@@ -7,6 +7,7 @@ import org.vertexium.inmemory.InMemoryVertex;
 import org.vertexium.inmemory.mutations.Mutation;
 import org.vertexium.sql.collections.Storable;
 
+import java.util.EnumSet;
 import java.util.List;
 import java.util.Map;
 import java.util.Set;
@@ -20,10 +21,12 @@ public class SqlTableVertex extends SqlTableElement<InMemoryVertex> {
 
     @Override
     public InMemoryVertex createElementInternal(
-            InMemoryGraph graph, boolean includeHidden, Long endTime,
+            InMemoryGraph graph,
+            EnumSet<FetchHint> fetchHints,
+            Long endTime,
             Authorizations authorizations
     ) {
-        return new InMemoryVertex(graph, getId(), asInMemoryTableElement(), includeHidden, endTime, authorizations);
+        return new InMemoryVertex(graph, getId(), asInMemoryTableElement(), fetchHints, endTime, authorizations);
     }
 
     @Override
@@ -91,8 +94,8 @@ public class SqlTableVertex extends SqlTableElement<InMemoryVertex> {
         }
 
         @Override
-        public Property getProperty(String key, String name, Visibility visibility, Authorizations authorizations) {
-            return sqlTableVertex.getProperty(key, name, visibility, authorizations);
+        public Property getProperty(String key, String name, Visibility visibility, EnumSet<FetchHint> fetchHints, Authorizations authorizations) {
+            return sqlTableVertex.getProperty(key, name, visibility, fetchHints, authorizations);
         }
 
         @Override
@@ -111,8 +114,8 @@ public class SqlTableVertex extends SqlTableElement<InMemoryVertex> {
         }
 
         @Override
-        public Iterable<Property> getProperties(boolean includeHidden, Long endTime, Authorizations authorizations) {
-            return sqlTableVertex.getProperties(includeHidden, endTime, authorizations);
+        public Iterable<Property> getProperties(EnumSet<FetchHint> fetchHints, Long endTime, Authorizations authorizations) {
+            return sqlTableVertex.getProperties(fetchHints, endTime, authorizations);
         }
 
         @Override
@@ -186,8 +189,8 @@ public class SqlTableVertex extends SqlTableElement<InMemoryVertex> {
         }
 
         @Override
-        public InMemoryVertex createElement(InMemoryGraph graph, Authorizations authorizations) {
-            return sqlTableVertex.createElement(graph, authorizations);
+        public InMemoryVertex createElement(InMemoryGraph graph, EnumSet<FetchHint> fetchHints, Authorizations authorizations) {
+            return sqlTableVertex.createElement(graph, fetchHints, authorizations);
         }
 
         @Override
@@ -196,8 +199,8 @@ public class SqlTableVertex extends SqlTableElement<InMemoryVertex> {
         }
 
         @Override
-        public InMemoryVertex createElementInternal(InMemoryGraph graph, boolean includeHidden, Long endTime, Authorizations authorizations) {
-            return sqlTableVertex.createElementInternal(graph, includeHidden, endTime, authorizations);
+        public InMemoryVertex createElementInternal(InMemoryGraph graph, EnumSet<FetchHint> fetchHints, Long endTime, Authorizations authorizations) {
+            return sqlTableVertex.createElementInternal(graph, fetchHints, endTime, authorizations);
         }
     }
 }

--- a/test/src/main/java/org/vertexium/test/GraphTestBase.java
+++ b/test/src/main/java/org/vertexium/test/GraphTestBase.java
@@ -21,6 +21,7 @@ import org.vertexium.query.*;
 import org.vertexium.search.DefaultSearchIndex;
 import org.vertexium.search.IndexHint;
 import org.vertexium.test.util.LargeStringInputStream;
+import org.vertexium.test.util.VertexiumAssert;
 import org.vertexium.type.*;
 import org.vertexium.util.*;
 
@@ -246,7 +247,7 @@ public abstract class GraphTestBase {
                 .save(AUTHORIZATIONS_A_AND_B);
         graph.flush();
 
-        Vertex v = graph.getVertex("v1", AUTHORIZATIONS_A);
+        Vertex v = graph.getVertex("v1", FetchHint.ALL, AUTHORIZATIONS_A);
         if (v instanceof HasTimestamp) {
             assertTrue("timestamp should be more than 0", v.getTimestamp() > 0);
         }
@@ -268,7 +269,7 @@ public abstract class GraphTestBase {
                 .save(AUTHORIZATIONS_A_AND_B);
         graph.flush();
 
-        v = graph.getVertex("v1", AUTHORIZATIONS_A);
+        v = graph.getVertex("v1", FetchHint.ALL, AUTHORIZATIONS_A);
         Assert.assertEquals(1, count(v.getProperties("prop1")));
         prop1 = v.getProperties("prop1").iterator().next();
         prop1Metadata = prop1.getMetadata();
@@ -281,7 +282,7 @@ public abstract class GraphTestBase {
         v.setProperty("prop1", "value2", prop1Metadata, VISIBILITY_A, AUTHORIZATIONS_A_AND_B);
         graph.flush();
 
-        v = graph.getVertex("v1", AUTHORIZATIONS_A);
+        v = graph.getVertex("v1", FetchHint.ALL, AUTHORIZATIONS_A);
         Assert.assertEquals(1, count(v.getProperties("prop1")));
         prop1 = v.getProperties("prop1").iterator().next();
         assertEquals("value2", prop1.getValue());
@@ -448,13 +449,13 @@ public abstract class GraphTestBase {
         graph.flush();
         clearGraphEvents();
 
-        v = graph.getVertex("v1", AUTHORIZATIONS_A);
+        v = graph.getVertex("v1", FetchHint.ALL, AUTHORIZATIONS_A);
         Property prop1_propid1a = v.getProperty("propid1a", "prop1");
         Property prop1_propid1b = v.getProperty("propid1b", "prop1");
         v.deleteProperties("prop1", AUTHORIZATIONS_A_AND_B);
         graph.flush();
         Assert.assertEquals(1, count(v.getProperties()));
-        v = graph.getVertex("v1", AUTHORIZATIONS_A);
+        v = graph.getVertex("v1", FetchHint.ALL, AUTHORIZATIONS_A);
         Assert.assertEquals(1, count(v.getProperties()));
 
         Assert.assertEquals(1, count(graph.query(AUTHORIZATIONS_A_AND_B).has("prop2", "value2a").vertices()));
@@ -492,7 +493,7 @@ public abstract class GraphTestBase {
         clearGraphEvents();
 
         // delete multiple properties
-        v1 = graph.getVertex("v1", AUTHORIZATIONS_A);
+        v1 = graph.getVertex("v1", FetchHint.ALL, AUTHORIZATIONS_A);
         Property prop1_propid1a = v1.getProperty("propid1a", "prop1");
         Property prop1_propid1b = v1.getProperty("propid1b", "prop1");
         v1.prepareMutation()
@@ -500,7 +501,7 @@ public abstract class GraphTestBase {
                 .save(AUTHORIZATIONS_A_AND_B);
         graph.flush();
         Assert.assertEquals(1, count(v1.getProperties()));
-        v1 = graph.getVertex("v1", AUTHORIZATIONS_A);
+        v1 = graph.getVertex("v1", FetchHint.ALL, AUTHORIZATIONS_A);
         Assert.assertEquals(1, count(v1.getProperties()));
 
         Assert.assertEquals(1, count(graph.query(AUTHORIZATIONS_A_AND_B).has("prop2", "value2a").vertices()));
@@ -526,7 +527,7 @@ public abstract class GraphTestBase {
         clearGraphEvents();
 
         // delete property from edge
-        Edge e1 = graph.getEdge("e1", AUTHORIZATIONS_A);
+        Edge e1 = graph.getEdge("e1", FetchHint.ALL, AUTHORIZATIONS_A);
         Property edgeProperty = e1.getProperty("key1", "prop1");
         e1.prepareMutation()
                 .deleteProperties("key1", "prop1")
@@ -628,15 +629,15 @@ public abstract class GraphTestBase {
         graph.flush();
 
         assertNull(graph.getEdge(e1.getId(), AUTHORIZATIONS_A));
-        assertNull(graph.getEdge(e1.getId(), FetchHint.ALL, AUTHORIZATIONS_A));
+        assertNull(graph.getEdge(e1.getId(), FetchHint.DEFAULT, AUTHORIZATIONS_A));
         assertNull(graph.getEdge(e1.getId(), FetchHint.ALL_INCLUDING_HIDDEN, AUTHORIZATIONS_A));
         assertNull(graph.getVertex(v1.getId(), AUTHORIZATIONS_A));
-        assertNull(graph.getVertex(v1.getId(), FetchHint.ALL, AUTHORIZATIONS_A));
+        assertNull(graph.getVertex(v1.getId(), FetchHint.DEFAULT, AUTHORIZATIONS_A));
         assertNull(graph.getVertex(v1.getId(), FetchHint.ALL_INCLUDING_HIDDEN, AUTHORIZATIONS_A));
 
-        assertNotNull(graph.getEdge(e1.getId(), FetchHint.ALL, beforeDeleteTime, AUTHORIZATIONS_A));
+        assertNotNull(graph.getEdge(e1.getId(), FetchHint.DEFAULT, beforeDeleteTime, AUTHORIZATIONS_A));
         assertNotNull(graph.getEdge(e1.getId(), FetchHint.ALL_INCLUDING_HIDDEN, beforeDeleteTime, AUTHORIZATIONS_A));
-        assertNotNull(graph.getVertex(v1.getId(), FetchHint.ALL, beforeDeleteTime, AUTHORIZATIONS_A));
+        assertNotNull(graph.getVertex(v1.getId(), FetchHint.DEFAULT, beforeDeleteTime, AUTHORIZATIONS_A));
         assertNotNull(graph.getVertex(v1.getId(), FetchHint.ALL_INCLUDING_HIDDEN, beforeDeleteTime, AUTHORIZATIONS_A));
     }
 
@@ -940,7 +941,7 @@ public abstract class GraphTestBase {
         assertEquals(1, count(properties));
         graph.flush();
 
-        v1 = graph.getVertex("v1", FetchHint.ALL, beforeMarkPropertyVisibleTimestamp, AUTHORIZATIONS_A_AND_B);
+        v1 = graph.getVertex("v1", FetchHint.DEFAULT, beforeMarkPropertyVisibleTimestamp, AUTHORIZATIONS_A_AND_B);
         assertNotNull("could not find v1 before timestamp " + beforeMarkPropertyVisibleTimestamp + " current time " + t, v1);
         properties = IterableUtils.toList(v1.getProperties());
         assertEquals(0, count(properties));
@@ -1214,7 +1215,7 @@ public abstract class GraphTestBase {
         Assert.assertEquals(1, count(graph.getVertices(AUTHORIZATIONS_A)));
         Assert.assertEquals(0, count(graph.getVertices(AUTHORIZATIONS_B)));
         Assert.assertEquals(0, count(graph.getEdges(AUTHORIZATIONS_A)));
-        assertNull("found v1 but shouldn't have", graph.getVertex("v1", FetchHint.ALL, AUTHORIZATIONS_A));
+        assertNull("found v1 but shouldn't have", graph.getVertex("v1", FetchHint.DEFAULT, AUTHORIZATIONS_A));
         Vertex v1Hidden = graph.getVertex("v1", FetchHint.ALL_INCLUDING_HIDDEN, AUTHORIZATIONS_A);
         assertNotNull("did not find v1 but should have", v1Hidden);
         assertTrue("v1 should be hidden", v1Hidden.isHidden(AUTHORIZATIONS_A));
@@ -1289,7 +1290,7 @@ public abstract class GraphTestBase {
         Assert.assertEquals(0, count(graph.findPaths(new FindPathOptions("v1", "v3", 2), AUTHORIZATIONS_A_AND_B)));
         Assert.assertEquals(0, count(graph.findPaths(new FindPathOptions("v1", "v3", 10), AUTHORIZATIONS_A_AND_B)));
         Assert.assertEquals(1, count(graph.findPaths(new FindPathOptions("v1", "v3", 10), AUTHORIZATIONS_A)));
-        assertNull("found e1 but shouldn't have", graph.getEdge("v1tov2", FetchHint.ALL, AUTHORIZATIONS_A_AND_B));
+        assertNull("found e1 but shouldn't have", graph.getEdge("v1tov2", FetchHint.DEFAULT, AUTHORIZATIONS_A_AND_B));
         Edge e1Hidden = graph.getEdge("v1tov2", FetchHint.ALL_INCLUDING_HIDDEN, AUTHORIZATIONS_A_AND_B);
         assertNotNull("did not find e1 but should have", e1Hidden);
         assertTrue("e1 should be hidden", e1Hidden.isHidden(AUTHORIZATIONS_A_AND_B));
@@ -1472,14 +1473,14 @@ public abstract class GraphTestBase {
         assertEquals(v2, addedEdgeVertices.getInVertex());
 
         graph.getVertex("v1", FetchHint.NONE, AUTHORIZATIONS_A);
-        graph.getVertex("v1", FetchHint.ALL, AUTHORIZATIONS_A);
+        graph.getVertex("v1", FetchHint.DEFAULT, AUTHORIZATIONS_A);
         graph.getVertex("v1", EnumSet.of(FetchHint.PROPERTIES), AUTHORIZATIONS_A);
         graph.getVertex("v1", FetchHint.EDGE_REFS, AUTHORIZATIONS_A);
         graph.getVertex("v1", EnumSet.of(FetchHint.IN_EDGE_REFS), AUTHORIZATIONS_A);
         graph.getVertex("v1", EnumSet.of(FetchHint.OUT_EDGE_REFS), AUTHORIZATIONS_A);
 
         graph.getEdge("e1", FetchHint.NONE, AUTHORIZATIONS_A);
-        graph.getEdge("e1", FetchHint.ALL, AUTHORIZATIONS_A);
+        graph.getEdge("e1", FetchHint.DEFAULT, AUTHORIZATIONS_A);
         graph.getEdge("e1", EnumSet.of(FetchHint.PROPERTIES), AUTHORIZATIONS_A);
 
         Edge e = graph.getEdge("e1", AUTHORIZATIONS_B);
@@ -3827,7 +3828,7 @@ public abstract class GraphTestBase {
         graph.createAuthorizations(AUTHORIZATIONS_ALL);
         graph.flush();
 
-        Vertex v1 = graph.getVertex("v1", AUTHORIZATIONS_ALL);
+        Vertex v1 = graph.getVertex("v1", FetchHint.ALL, AUTHORIZATIONS_ALL);
         ExistingElementMutation<Vertex> m = v1.prepareMutation();
         m.alterElementVisibility(VISIBILITY_B);
         for (Property property : v1.getProperties()) {
@@ -3837,7 +3838,7 @@ public abstract class GraphTestBase {
         m.save(AUTHORIZATIONS_ALL);
         graph.flush();
 
-        v1 = graph.getVertex("v1", AUTHORIZATIONS_B);
+        v1 = graph.getVertex("v1", FetchHint.ALL, AUTHORIZATIONS_B);
         assertEquals(VISIBILITY_B, v1.getVisibility());
         List<Property> properties = toList(v1.getProperties());
         assertEquals(1, properties.size());
@@ -3879,7 +3880,7 @@ public abstract class GraphTestBase {
                 .save(AUTHORIZATIONS_A_AND_B);
         graph.flush();
 
-        Vertex v1 = graph.getVertex("v1", AUTHORIZATIONS_A_AND_B);
+        Vertex v1 = graph.getVertex("v1", FetchHint.ALL, AUTHORIZATIONS_A_AND_B);
         v1.prepareMutation()
                 .alterPropertyVisibility("prop1", VISIBILITY_B)
                 .save(AUTHORIZATIONS_A_AND_B);
@@ -3902,7 +3903,7 @@ public abstract class GraphTestBase {
             assertEquals(1L, (long) propertyCountByValue.get("value1"));
         }
 
-        v1 = graph.getVertex("v1", AUTHORIZATIONS_A_AND_B);
+        v1 = graph.getVertex("v1", FetchHint.ALL, AUTHORIZATIONS_A_AND_B);
         Property v1Prop1 = v1.getProperty("prop1");
         assertNotNull(v1Prop1);
         Assert.assertEquals(1, toList(v1Prop1.getMetadata().entrySet()).size());
@@ -3910,7 +3911,7 @@ public abstract class GraphTestBase {
         assertNotNull(v1.getProperty("prop2"));
 
         // alter and set property in one mutation
-        v1 = graph.getVertex("v1", AUTHORIZATIONS_A_AND_B);
+        v1 = graph.getVertex("v1", FetchHint.ALL, AUTHORIZATIONS_A_AND_B);
         v1.prepareMutation()
                 .alterPropertyVisibility("prop1", VISIBILITY_A)
                 .setProperty("prop1", "value1New", VISIBILITY_A)
@@ -3922,7 +3923,7 @@ public abstract class GraphTestBase {
         assertEquals("value1New", v1.getPropertyValue("prop1"));
 
         // alter visibility to the same visibility
-        v1 = graph.getVertex("v1", AUTHORIZATIONS_A_AND_B);
+        v1 = graph.getVertex("v1", FetchHint.ALL, AUTHORIZATIONS_A_AND_B);
         v1.prepareMutation()
                 .alterPropertyVisibility("prop1", VISIBILITY_A)
                 .setProperty("prop1", "value1New2", VISIBILITY_A)
@@ -3944,14 +3945,14 @@ public abstract class GraphTestBase {
                 .save(AUTHORIZATIONS_A_AND_B);
         graph.flush();
 
-        Vertex v1 = graph.getVertex("v1", AUTHORIZATIONS_A_AND_B);
+        Vertex v1 = graph.getVertex("v1", FetchHint.ALL, AUTHORIZATIONS_A_AND_B);
         v1.prepareMutation()
                 .alterPropertyVisibility("prop1", VISIBILITY_B)
                 .setPropertyMetadata("prop1", "prop1_key1", "metadata1New", VISIBILITY_EMPTY)
                 .save(AUTHORIZATIONS_A_AND_B);
         graph.flush();
 
-        v1 = graph.getVertex("v1", AUTHORIZATIONS_A_AND_B);
+        v1 = graph.getVertex("v1", FetchHint.ALL, AUTHORIZATIONS_A_AND_B);
         assertNotNull(v1.getProperty("prop1"));
         assertEquals(VISIBILITY_B, v1.getProperty("prop1").getVisibility());
         assertEquals("metadata1New", v1.getProperty("prop1").getMetadata().getValue("prop1_key1"));
@@ -3972,7 +3973,7 @@ public abstract class GraphTestBase {
 
         long beforeAlterTimestamp = IncreasingTime.currentTimeMillis();
 
-        Vertex v1 = graph.getVertex("v1", AUTHORIZATIONS_A);
+        Vertex v1 = graph.getVertex("v1", FetchHint.ALL, AUTHORIZATIONS_A);
         v1.prepareMutation()
                 .alterPropertyVisibility(v1.getProperty("", "prop1", VISIBILITY_A), VISIBILITY_EMPTY)
                 .save(AUTHORIZATIONS_A_AND_B);
@@ -3984,7 +3985,7 @@ public abstract class GraphTestBase {
         assertEquals("value2", v1.getProperty("", "prop1", VISIBILITY_EMPTY).getValue());
         assertNull(v1.getProperty("", "prop1", VISIBILITY_A));
 
-        v1 = graph.getVertex("v1", FetchHint.ALL, beforeAlterTimestamp, AUTHORIZATIONS_A);
+        v1 = graph.getVertex("v1", FetchHint.DEFAULT, beforeAlterTimestamp, AUTHORIZATIONS_A);
         assertEquals(2, count(v1.getProperties()));
         assertNotNull(v1.getProperty("", "prop1", VISIBILITY_EMPTY));
         assertEquals("value1", v1.getProperty("", "prop1", VISIBILITY_EMPTY).getValue());
@@ -4068,14 +4069,14 @@ public abstract class GraphTestBase {
         graph.flush();
         Assert.assertEquals(2, count(graph.getVertex("v1", AUTHORIZATIONS_A).getProperties()));
 
-        graph.getVertex("v1", AUTHORIZATIONS_A)
+        graph.getVertex("v1", FetchHint.ALL, AUTHORIZATIONS_A)
                 .prepareMutation()
                 .alterPropertyVisibility("propSmall", VISIBILITY_B)
                 .save(AUTHORIZATIONS_A_AND_B);
         graph.flush();
         Assert.assertEquals(1, count(graph.getVertex("v1", AUTHORIZATIONS_A).getProperties()));
 
-        graph.getVertex("v1", AUTHORIZATIONS_A)
+        graph.getVertex("v1", FetchHint.ALL, AUTHORIZATIONS_A)
                 .prepareMutation()
                 .alterPropertyVisibility(largePropertyName, VISIBILITY_B)
                 .save(AUTHORIZATIONS_A_AND_B);
@@ -4096,24 +4097,24 @@ public abstract class GraphTestBase {
                 .save(AUTHORIZATIONS_A_AND_B);
         graph.flush();
 
-        Vertex v1 = graph.getVertex("v1", AUTHORIZATIONS_A);
+        Vertex v1 = graph.getVertex("v1", FetchHint.ALL, AUTHORIZATIONS_A);
         v1.prepareMutation()
                 .setPropertyMetadata("prop1", "prop1_key1", "valueNew", VISIBILITY_EMPTY)
                 .save(AUTHORIZATIONS_A_AND_B);
         graph.flush();
         assertEquals("valueNew", v1.getProperty("prop1").getMetadata().getEntry("prop1_key1", VISIBILITY_EMPTY).getValue());
 
-        v1 = graph.getVertex("v1", AUTHORIZATIONS_A);
+        v1 = graph.getVertex("v1", FetchHint.ALL, AUTHORIZATIONS_A);
         assertEquals("valueNew", v1.getProperty("prop1").getMetadata().getEntry("prop1_key1", VISIBILITY_EMPTY).getValue());
 
-        v1 = graph.getVertex("v1", AUTHORIZATIONS_A);
+        v1 = graph.getVertex("v1", FetchHint.ALL, AUTHORIZATIONS_A);
         v1.prepareMutation()
                 .setPropertyMetadata("prop2", "prop2_key1", "valueNew", VISIBILITY_EMPTY)
                 .save(AUTHORIZATIONS_A_AND_B);
         graph.flush();
         assertEquals("valueNew", v1.getProperty("prop2").getMetadata().getEntry("prop2_key1", VISIBILITY_EMPTY).getValue());
 
-        v1 = graph.getVertex("v1", AUTHORIZATIONS_A);
+        v1 = graph.getVertex("v1", FetchHint.ALL, AUTHORIZATIONS_A);
         assertEquals("valueNew", v1.getProperty("prop2").getMetadata().getEntry("prop2_key1", VISIBILITY_EMPTY).getValue());
     }
 
@@ -4127,7 +4128,7 @@ public abstract class GraphTestBase {
                 .save(AUTHORIZATIONS_A_AND_B);
         graph.flush();
 
-        Vertex v1 = graph.getVertex("v1", AUTHORIZATIONS_A_AND_B);
+        Vertex v1 = graph.getVertex("v1", FetchHint.ALL, AUTHORIZATIONS_A_AND_B);
         Property p1 = v1.getProperty("prop1", VISIBILITY_A);
         v1.prepareMutation()
                 .alterPropertyVisibility(p1, VISIBILITY_B)
@@ -4135,7 +4136,7 @@ public abstract class GraphTestBase {
                 .save(AUTHORIZATIONS_A_AND_B);
         graph.flush();
 
-        v1 = graph.getVertex("v1", AUTHORIZATIONS_A_AND_B);
+        v1 = graph.getVertex("v1", FetchHint.ALL, AUTHORIZATIONS_A_AND_B);
         assertEquals("valueNew", v1.getProperty("prop1", VISIBILITY_B).getMetadata().getEntry("prop1_key1", VISIBILITY_B).getValue());
     }
 
@@ -4147,14 +4148,14 @@ public abstract class GraphTestBase {
                 .save(AUTHORIZATIONS_A_AND_B);
         graph.flush();
 
-        ExistingElementMutation<Vertex> m = graph.getVertex("v1", AUTHORIZATIONS_A_AND_B).prepareMutation();
+        ExistingElementMutation<Vertex> m = graph.getVertex("v1", FetchHint.ALL, AUTHORIZATIONS_A_AND_B).prepareMutation();
         m.setPropertyMetadata(v1.getProperty("prop1", VISIBILITY_A), "metadata1", "metadata-value1aa", VISIBILITY_A);
         m.setPropertyMetadata(v1.getProperty("prop1", VISIBILITY_A), "metadata1", "metadata-value1ab", VISIBILITY_B);
         m.setPropertyMetadata(v1.getProperty("prop1", VISIBILITY_B), "metadata1", "metadata-value1bb", VISIBILITY_B);
         m.save(AUTHORIZATIONS_A_AND_B);
         graph.flush();
 
-        v1 = graph.getVertex("v1", AUTHORIZATIONS_A_AND_B);
+        v1 = graph.getVertex("v1", FetchHint.ALL, AUTHORIZATIONS_A_AND_B);
 
         Property prop1A = v1.getProperty("prop1", VISIBILITY_A);
         assertEquals(2, prop1A.getMetadata().entrySet().size());
@@ -4546,7 +4547,7 @@ public abstract class GraphTestBase {
                 .save(AUTHORIZATIONS_A);
         graph.flush();
 
-        Vertex v1 = graph.getVertex("v1", AUTHORIZATIONS_A);
+        Vertex v1 = graph.getVertex("v1", FetchHint.ALL, AUTHORIZATIONS_A);
         List<HistoricalPropertyValue> values = toList(v1.getHistoricalPropertyValues("", "age", VISIBILITY_A, AUTHORIZATIONS_A));
         assertEquals(2, values.size());
 
@@ -4624,9 +4625,9 @@ public abstract class GraphTestBase {
         assertEquals(1, count(graph.getEdges(AUTHORIZATIONS_A)));
 
         // verify old version
-        assertEquals(25, graph.getVertex("v1", FetchHint.ALL, time25.getTime(), AUTHORIZATIONS_A).getPropertyValue("", "age"));
-        assertNull("v3 should not exist at time25", graph.getVertex("v3", FetchHint.ALL, time25.getTime(), AUTHORIZATIONS_A));
-        assertEquals("e1 should not exist", 0, count(graph.getEdges(FetchHint.ALL, time25.getTime(), AUTHORIZATIONS_A)));
+        assertEquals(25, graph.getVertex("v1", FetchHint.DEFAULT, time25.getTime(), AUTHORIZATIONS_A).getPropertyValue("", "age"));
+        assertNull("v3 should not exist at time25", graph.getVertex("v3", FetchHint.DEFAULT, time25.getTime(), AUTHORIZATIONS_A));
+        assertEquals("e1 should not exist", 0, count(graph.getEdges(FetchHint.DEFAULT, time25.getTime(), AUTHORIZATIONS_A)));
     }
 
     @Test
@@ -5908,6 +5909,21 @@ public abstract class GraphTestBase {
     }
 
     @Test
+    public void testFetchHintsExceptions() {
+        Metadata prop1Metadata = new Metadata();
+        prop1Metadata.add("metadata1", "metadata1Value", VISIBILITY_A);
+
+        graph.prepareVertex("v1", VISIBILITY_A)
+                .setProperty("prop1", "value1", prop1Metadata, VISIBILITY_A)
+                .save(AUTHORIZATIONS_A_AND_B);
+        graph.flush();
+
+        Vertex v1 = graph.getVertex("v1", FetchHint.DEFAULT, AUTHORIZATIONS_A);
+        Property prop1 = v1.getProperty("prop1");
+        assertThrowsException(prop1::getMetadata);
+    }
+
+    @Test
     public void benchmark() {
         assumeTrue(benchmarkEnabled());
         Random random = new Random(1);
@@ -6222,14 +6238,14 @@ public abstract class GraphTestBase {
         graph.flush();
 
         // modify property value
-        Vertex v1 = graph.getVertex("v1", AUTHORIZATIONS_A_AND_B);
+        Vertex v1 = graph.getVertex("v1", FetchHint.ALL, AUTHORIZATIONS_A_AND_B);
         vertexAdded = v1.prepareMutation()
                 .alterPropertyVisibility("prop1_A", VISIBILITY_B)
                 .save(AUTHORIZATIONS_A_AND_B);
         graph.flush();
 
         // Restore
-        v1 = graph.getVertex("v1", AUTHORIZATIONS_A_AND_B);
+        v1 = graph.getVertex("v1", FetchHint.ALL, AUTHORIZATIONS_A_AND_B);
         vertexAdded = v1.prepareMutation()
                 .alterPropertyVisibility("prop1_A", VISIBILITY_A)
                 .save(AUTHORIZATIONS_A_AND_B);

--- a/test/src/main/java/org/vertexium/test/util/VertexiumAssert.java
+++ b/test/src/main/java/org/vertexium/test/util/VertexiumAssert.java
@@ -10,6 +10,7 @@ import org.vertexium.query.QueryResultsIterable;
 import java.util.*;
 import java.util.stream.Collectors;
 
+import static junit.framework.TestCase.fail;
 import static org.junit.Assert.assertEquals;
 import static org.vertexium.util.IterableUtils.count;
 import static org.vertexium.util.IterableUtils.toList;
@@ -114,5 +115,14 @@ public class VertexiumAssert {
                 .filter((sr) -> sr instanceof ExtendedDataRow)
                 .map((sr) -> ((ExtendedDataRow) sr).getId().getRowId())
                 .collect(Collectors.toList());
+    }
+
+    public static void assertThrowsException(Runnable fn) {
+        try {
+            fn.run();
+        } catch (Throwable ex) {
+            return;
+        }
+        fail("Should have thrown an exception");
     }
 }

--- a/tools/src/main/java/org/vertexium/tools/GraphBackup.java
+++ b/tools/src/main/java/org/vertexium/tools/GraphBackup.java
@@ -5,11 +5,11 @@ import org.apache.commons.codec.binary.Base64;
 import org.json.JSONArray;
 import org.json.JSONObject;
 import org.vertexium.*;
-import org.vertexium.*;
 import org.vertexium.property.StreamingPropertyValue;
 import org.vertexium.util.JavaSerializableUtils;
 
 import java.io.*;
+import java.util.EnumSet;
 
 public class GraphBackup extends GraphToolBase {
     public static final String BASE64_PREFIX = "base64/java:";
@@ -41,7 +41,8 @@ public class GraphBackup extends GraphToolBase {
     }
 
     public void save(Graph graph, OutputStream out, Authorizations authorizations) throws IOException {
-        save(graph.getVertices(authorizations), graph.getEdges(authorizations), out);
+        EnumSet<FetchHint> fetchHints = FetchHint.ALL;
+        save(graph.getVertices(fetchHints, authorizations), graph.getEdges(fetchHints, authorizations), out);
     }
 
     public void save(Iterable<Vertex> vertices, Iterable<Edge> edges, OutputStream out) throws IOException {


### PR DESCRIPTION
Bringing property metadata back is expensive as the metadata grows and
most times you don't need this information. This changes the default to
not bring metadata back.