### PR TITLE
return paths one hop away when finding path with a max of 2 hops

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -5,3 +5,4 @@ jdk:
 branches:
   only:
     - master
+    - 2.5.x 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,4 +1,6 @@
 # v2.5.4
+
+* Fixed: Find Path max 2 hops not returning one hop paths
 * Added: configuration for number of Elasticsearch replicas
 * Changed: Delete events added to HistoricalPropertyValue reporting
 

--- a/accumulo/src/main/java/org/vertexium/accumulo/AccumuloFindPathStrategy.java
+++ b/accumulo/src/main/java/org/vertexium/accumulo/AccumuloFindPathStrategy.java
@@ -58,21 +58,28 @@ public class AccumuloFindPathStrategy {
     }
 
     private void findPathsSetIntersection(List<Path> foundPaths) {
+        String sourceVertexId = options.getSourceVertexId();
+        String destVertexId = options.getDestVertexId();
+        
         Set<String> vertexIds = new HashSet<>();
-        vertexIds.add(options.getSourceVertexId());
-        vertexIds.add(options.getDestVertexId());
+        vertexIds.add(sourceVertexId);
+        vertexIds.add(destVertexId);
         Map<String, Set<String>> connectedVertexIds = getConnectedVertexIds(vertexIds);
 
         progressCallback.progress(0.1, ProgressCallback.Step.SEARCHING_SOURCE_VERTEX_EDGES);
-        Set<String> sourceVertexConnectedVertexIds = connectedVertexIds.get(options.getSourceVertexId());
+        Set<String> sourceVertexConnectedVertexIds = connectedVertexIds.get(sourceVertexId);
         if (sourceVertexConnectedVertexIds == null) {
             return;
         }
 
         progressCallback.progress(0.3, ProgressCallback.Step.SEARCHING_DESTINATION_VERTEX_EDGES);
-        Set<String> destVertexConnectedVertexIds = connectedVertexIds.get(options.getDestVertexId());
+        Set<String> destVertexConnectedVertexIds = connectedVertexIds.get(destVertexId);
         if (destVertexConnectedVertexIds == null) {
             return;
+        }
+
+        if (sourceVertexConnectedVertexIds.contains(destVertexId)) {
+            foundPaths.add(new Path(sourceVertexId, destVertexId));
         }
 
         progressCallback.progress(0.6, ProgressCallback.Step.MERGING_EDGES);
@@ -81,7 +88,7 @@ public class AccumuloFindPathStrategy {
         progressCallback.progress(0.9, ProgressCallback.Step.ADDING_PATHS);
         foundPaths.addAll(
                 sourceVertexConnectedVertexIds.stream()
-                        .map(connectedVertexId -> new Path(options.getSourceVertexId(), connectedVertexId, options.getDestVertexId()))
+                        .map(connectedVertexId -> new Path(sourceVertexId, connectedVertexId, destVertexId))
                         .collect(Collectors.toList())
         );
     }

--- a/core/src/main/java/org/vertexium/GraphBase.java
+++ b/core/src/main/java/org/vertexium/GraphBase.java
@@ -584,6 +584,10 @@ public abstract class GraphBase implements Graph {
         progressCallback.progress(0.3, ProgressCallback.Step.SEARCHING_DESTINATION_VERTEX_EDGES);
         Set<String> destVertexConnectedVertexIds = filterFindPathEdgeInfo(options, destVertex.getEdgeInfos(Direction.BOTH, options.getLabels(), authorizations));
 
+        if (sourceVertexConnectedVertexIds.contains(destVertexId)) {
+            foundPaths.add(new Path(sourceVertexId, destVertexId));
+        }
+
         progressCallback.progress(0.6, ProgressCallback.Step.MERGING_EDGES);
         sourceVertexConnectedVertexIds.retainAll(destVertexConnectedVertexIds);
 

--- a/test/src/main/java/org/vertexium/test/GraphTestBase.java
+++ b/test/src/main/java/org/vertexium/test/GraphTestBase.java
@@ -2926,10 +2926,20 @@ public abstract class GraphTestBase {
         graph.addEdge(v4, v6, "knows", VISIBILITY_A, AUTHORIZATIONS_A); // v4 -> v6
         graph.flush();
 
-        List<Path> paths = toList(graph.findPaths(new FindPathOptions("v1", "v4", 2), AUTHORIZATIONS_A));
-        List<Path> pathsByLabels = toList(graph.findPaths(new FindPathOptions("v1", "v4", 2).setLabels("knows"), AUTHORIZATIONS_A));
+        List<Path> paths = toList(graph.findPaths(new FindPathOptions("v1", "v2", 2), AUTHORIZATIONS_A));
+        List<Path> pathsByLabels = toList(graph.findPaths(new FindPathOptions("v1", "v2", 2).setLabels("knows"), AUTHORIZATIONS_A));
         assertEquals(pathsByLabels, paths);
-        List<Path> pathsByBadLabel = toList(graph.findPaths(new FindPathOptions("v1", "v4", 2).setLabels("bad"), AUTHORIZATIONS_A));
+        List<Path> pathsByBadLabel = toList(graph.findPaths(new FindPathOptions("v1", "v2", 2).setLabels("bad"), AUTHORIZATIONS_A));
+        assertEquals(0, pathsByBadLabel.size());
+        assertPaths(
+                paths,
+                new Path("v1", "v2")
+        );
+
+        paths = toList(graph.findPaths(new FindPathOptions("v1", "v4", 2), AUTHORIZATIONS_A));
+        pathsByLabels = toList(graph.findPaths(new FindPathOptions("v1", "v4", 2).setLabels("knows"), AUTHORIZATIONS_A));
+        assertEquals(pathsByLabels, paths);
+        pathsByBadLabel = toList(graph.findPaths(new FindPathOptions("v1", "v4", 2).setLabels("bad"), AUTHORIZATIONS_A));
         assertEquals(0, pathsByBadLabel.size());
         assertPaths(
                 paths,


### PR DESCRIPTION
Backporting this fix to 2.5.4