### PR TITLE
Query for id values rather than VertexiumObjects

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,6 @@
 # v2.6.0
 
+* Added: ability to query for vertex/edge/element ids rather than the elements themselves
 * Added: ability to return if there is any paths between two vertices
 * Added: ability to store extended data rows on an element
 * Added: Elasticsearch 2.x support

--- a/core/src/main/java/org/vertexium/query/CompositeGraphQuery.java
+++ b/core/src/main/java/org/vertexium/query/CompositeGraphQuery.java
@@ -43,6 +43,11 @@ public class CompositeGraphQuery implements Query {
     }
 
     @Override
+    public QueryResultsIterable<String> vertexIds() {
+        return new DefaultGraphQueryIdIterable<>(vertices(FetchHint.NONE));
+    }
+
+    @Override
     public QueryResultsIterable<Edge> edges() {
         return edges(FetchHint.ALL);
     }
@@ -65,6 +70,11 @@ public class CompositeGraphQuery implements Query {
                 return super.isIncluded(edge);
             }
         };
+    }
+
+    @Override
+    public QueryResultsIterable<String> edgeIds() {
+        return new DefaultGraphQueryIdIterable<>(edges(FetchHint.NONE));
     }
 
     @Override
@@ -107,6 +117,11 @@ public class CompositeGraphQuery implements Query {
     }
 
     @Override
+    public QueryResultsIterable<String> elementIds() {
+        return new DefaultGraphQueryIdIterable<>(elements(FetchHint.NONE));
+    }
+
+    @Override
     public QueryResultsIterable<ExtendedDataRow> extendedDataRows() {
         return extendedDataRows(FetchHint.ALL);
     }
@@ -129,6 +144,11 @@ public class CompositeGraphQuery implements Query {
                 return super.isIncluded(extendedDataRows);
             }
         };
+    }
+
+    @Override
+    public QueryResultsIterable<ExtendedDataRowId> extendedDataRowIds() {
+        return new DefaultGraphQueryIdIterable<>(extendedDataRows(FetchHint.NONE));
     }
 
     @Override

--- a/core/src/main/java/org/vertexium/query/DefaultGraphQueryIdIterable.java
+++ b/core/src/main/java/org/vertexium/query/DefaultGraphQueryIdIterable.java
@@ -1,0 +1,45 @@
+package org.vertexium.query;
+
+import org.vertexium.Element;
+import org.vertexium.ExtendedDataRow;
+import org.vertexium.VertexiumException;
+import org.vertexium.VertexiumObject;
+import org.vertexium.util.ConvertingIterable;
+
+import java.io.IOException;
+
+public class DefaultGraphQueryIdIterable<T> extends ConvertingIterable<VertexiumObject, T> implements QueryResultsIterable<T> {
+
+    private final QueryResultsIterable<? extends VertexiumObject> iterable;
+
+    public DefaultGraphQueryIdIterable(QueryResultsIterable<? extends VertexiumObject> iterable) {
+        super(iterable);
+        this.iterable = iterable;
+    }
+
+    @SuppressWarnings("unchecked")
+    @Override
+    protected T convert(VertexiumObject vertexiumObject) {
+        if (vertexiumObject instanceof Element) {
+            return (T) ((Element) vertexiumObject).getId();
+        } else if (vertexiumObject instanceof ExtendedDataRow) {
+            return (T) ((ExtendedDataRow) vertexiumObject).getId();
+        }
+        throw new VertexiumException("Unsupported class: " + vertexiumObject.getClass().getName());
+    }
+
+    @Override
+    public <TResult extends AggregationResult> TResult getAggregationResult(String name, Class<? extends TResult> resultType) {
+        return iterable.getAggregationResult(name, resultType);
+    }
+
+    @Override
+    public void close() throws IOException {
+        iterable.close();
+    }
+
+    @Override
+    public long getTotalHits() {
+        return iterable.getTotalHits();
+    }
+}

--- a/core/src/main/java/org/vertexium/query/DefaultGraphQueryIterable.java
+++ b/core/src/main/java/org/vertexium/query/DefaultGraphQueryIterable.java
@@ -11,7 +11,7 @@ import static org.vertexium.util.IterableUtils.count;
 import static org.vertexium.util.IterableUtils.toList;
 import static org.vertexium.util.Preconditions.checkNotNull;
 
-public class DefaultGraphQueryIterable<T extends VertexiumObject> implements
+public class DefaultGraphQueryIterable<T> implements
         Iterable<T>,
         QueryResultsIterable<T> {
     private final QueryParameters parameters;
@@ -95,17 +95,18 @@ public class DefaultGraphQueryIterable<T extends VertexiumObject> implements
 
                 while (it.hasNext()) {
                     T elem = it.next();
+                    VertexiumObject vertexiumElem = elem instanceof VertexiumObject ? (VertexiumObject) elem : null;
 
                     boolean match = true;
-                    if (evaluateHasContainers) {
+                    if (evaluateHasContainers && vertexiumElem != null) {
                         for (QueryBase.HasContainer has : parameters.getHasContainers()) {
-                            if (!has.isMatch(elem)) {
+                            if (!has.isMatch(vertexiumElem)) {
                                 match = false;
                                 break;
                             }
                         }
-                        if (elem instanceof Edge && parameters.getEdgeLabels().size() > 0) {
-                            Edge edge = (Edge) elem;
+                        if (vertexiumElem instanceof Edge && parameters.getEdgeLabels().size() > 0) {
+                            Edge edge = (Edge) vertexiumElem;
                             if (!parameters.getEdgeLabels().contains(edge.getLabel())) {
                                 match = false;
                             }
@@ -115,9 +116,10 @@ public class DefaultGraphQueryIterable<T extends VertexiumObject> implements
                         continue;
                     }
                     if (evaluateQueryString
+                            && vertexiumElem != null
                             && parameters instanceof QueryStringQueryParameters
                             && ((QueryStringQueryParameters) parameters).getQueryString() != null
-                            && !evaluateQueryString(elem, ((QueryStringQueryParameters) parameters).getQueryString())
+                            && !evaluateQueryString(vertexiumElem, ((QueryStringQueryParameters) parameters).getQueryString())
                             ) {
                         continue;
                     }

--- a/core/src/main/java/org/vertexium/query/Query.java
+++ b/core/src/main/java/org/vertexium/query/Query.java
@@ -10,13 +10,19 @@ public interface Query {
 
     QueryResultsIterable<Vertex> vertices(EnumSet<FetchHint> fetchHints);
 
+    QueryResultsIterable<String> vertexIds();
+
     QueryResultsIterable<Edge> edges();
 
     QueryResultsIterable<Edge> edges(EnumSet<FetchHint> fetchHints);
 
+    QueryResultsIterable<String> edgeIds();
+
     QueryResultsIterable<ExtendedDataRow> extendedDataRows();
 
     QueryResultsIterable<ExtendedDataRow> extendedDataRows(EnumSet<FetchHint> fetchHints);
+
+    QueryResultsIterable<ExtendedDataRowId> extendedDataRowIds();
 
     @Deprecated
     QueryResultsIterable<Edge> edges(String label);
@@ -27,6 +33,8 @@ public interface Query {
     QueryResultsIterable<Element> elements();
 
     QueryResultsIterable<Element> elements(EnumSet<FetchHint> fetchHints);
+
+    QueryResultsIterable<String> elementIds();
 
     QueryResultsIterable<? extends VertexiumObject> search(EnumSet<VertexiumObjectType> objectTypes, EnumSet<FetchHint> fetchHints);
 

--- a/core/src/main/java/org/vertexium/query/QueryBase.java
+++ b/core/src/main/java/org/vertexium/query/QueryBase.java
@@ -38,6 +38,11 @@ public abstract class QueryBase implements Query, SimilarToGraphQuery {
     }
 
     @Override
+    public QueryResultsIterable<String> vertexIds() {
+        return new DefaultGraphQueryIdIterable<>(vertices(FetchHint.NONE));
+    }
+
+    @Override
     public QueryResultsIterable<Edge> edges() {
         return edges(FetchHint.ALL);
     }
@@ -46,6 +51,11 @@ public abstract class QueryBase implements Query, SimilarToGraphQuery {
     public QueryResultsIterable<Edge> edges(final EnumSet<FetchHint> fetchHints) {
         //noinspection unchecked
         return (QueryResultsIterable<Edge>) search(EnumSet.of(VertexiumObjectType.EDGE), fetchHints);
+    }
+
+    @Override
+    public QueryResultsIterable<String> edgeIds() {
+        return new DefaultGraphQueryIdIterable<>(edges(FetchHint.NONE));
     }
 
     @Override
@@ -135,6 +145,12 @@ public abstract class QueryBase implements Query, SimilarToGraphQuery {
     }
 
     @Override
+    public QueryResultsIterable<ExtendedDataRowId> extendedDataRowIds() {
+        QueryResultsIterable<? extends VertexiumObject> vertexiumObjects = search(EnumSet.of(VertexiumObjectType.EXTENDED_DATA), FetchHint.NONE);
+        return new DefaultGraphQueryIdIterable<>(vertexiumObjects);
+    }
+
+    @Override
     public Query hasEdgeLabel(String... edgeLabels) {
         for (String edgeLabel : edgeLabels) {
             getParameters().addEdgeLabel(edgeLabel);
@@ -195,6 +211,11 @@ public abstract class QueryBase implements Query, SimilarToGraphQuery {
     public QueryResultsIterable<Element> elements(EnumSet<FetchHint> fetchHints) {
         //noinspection unchecked
         return (QueryResultsIterable<Element>) search(VertexiumObjectType.ELEMENTS, fetchHints);
+    }
+
+    @Override
+    public QueryResultsIterable<String> elementIds() {
+        return new DefaultGraphQueryIdIterable<>(elements(FetchHint.NONE));
     }
 
     @Override

--- a/core/src/main/java/org/vertexium/query/QueryResultsIterable.java
+++ b/core/src/main/java/org/vertexium/query/QueryResultsIterable.java
@@ -1,9 +1,8 @@
 package org.vertexium.query;
 
-import org.vertexium.VertexiumObject;
 import org.vertexium.util.CloseableIterable;
 
-public interface QueryResultsIterable<T extends VertexiumObject> extends
+public interface QueryResultsIterable<T> extends
         IterableWithTotalHits<T>,
         CloseableIterable<T>,
         Iterable<T> {

--- a/core/src/main/java/org/vertexium/query/SortContainersComparator.java
+++ b/core/src/main/java/org/vertexium/query/SortContainersComparator.java
@@ -1,7 +1,6 @@
 package org.vertexium.query;
 
 import org.vertexium.Element;
-import org.vertexium.VertexiumObject;
 import org.vertexium.VertexiumException;
 
 import java.util.Comparator;
@@ -9,7 +8,7 @@ import java.util.List;
 
 import static org.vertexium.util.IterableUtils.toList;
 
-public class SortContainersComparator<T extends VertexiumObject> implements Comparator<T> {
+public class SortContainersComparator<T> implements Comparator<T> {
     private final List<QueryBase.SortContainer> sortContainers;
 
     public SortContainersComparator(List<QueryBase.SortContainer> sortContainers) {
@@ -28,7 +27,7 @@ public class SortContainersComparator<T extends VertexiumObject> implements Comp
     }
 
     private int compare(QueryBase.SortContainer sortContainer, T vertexiumObject1, T vertexiumObject2) {
-        if(vertexiumObject1 instanceof Element && vertexiumObject2 instanceof Element) {
+        if (vertexiumObject1 instanceof Element && vertexiumObject2 instanceof Element) {
             Element elem1 = (Element) vertexiumObject1;
             Element elem2 = (Element) vertexiumObject2;
             List<Object> elem1PropertyValues = toList(elem1.getPropertyValues(sortContainer.propertyName));
@@ -48,8 +47,8 @@ public class SortContainersComparator<T extends VertexiumObject> implements Comp
                 }
             }
             return 0;
-        }else{
-            throw new VertexiumException("unexpected searchable item combination: "+vertexiumObject1.getClass().getName()+", "+vertexiumObject2.getClass().getName());
+        } else {
+            throw new VertexiumException("unexpected searchable item combination: " + vertexiumObject1.getClass().getName() + ", " + vertexiumObject2.getClass().getName());
         }
     }
 

--- a/elasticsearch-singledocument/src/main/java/org/vertexium/elasticsearch/ElasticSearchGraphQueryIterable.java
+++ b/elasticsearch-singledocument/src/main/java/org/vertexium/elasticsearch/ElasticSearchGraphQueryIterable.java
@@ -18,7 +18,6 @@ import org.elasticsearch.search.aggregations.metrics.percentiles.InternalPercent
 import org.elasticsearch.search.aggregations.metrics.percentiles.Percentiles;
 import org.elasticsearch.search.aggregations.metrics.stats.extended.ExtendedStats;
 import org.elasticsearch.search.aggregations.metrics.stats.extended.InternalExtendedStats;
-import org.vertexium.VertexiumObject;
 import org.vertexium.VertexiumException;
 import org.vertexium.elasticsearch.utils.ElasticsearchDocIdUtils;
 import org.vertexium.query.*;
@@ -26,13 +25,10 @@ import org.vertexium.type.GeoPoint;
 import org.vertexium.type.GeoRect;
 import org.vertexium.util.StreamUtils;
 
-import java.util.ArrayList;
-import java.util.HashMap;
-import java.util.List;
-import java.util.Map;
+import java.util.*;
 
 @SuppressWarnings("deprecation")
-public class ElasticSearchGraphQueryIterable<T extends VertexiumObject> extends DefaultGraphQueryIterable<T> implements
+public class ElasticSearchGraphQueryIterable<T> extends DefaultGraphQueryIterable<T> implements
         IterableWithTotalHits<T>,
         IterableWithSearchTime<T>,
         IterableWithScores<T>,
@@ -58,8 +54,6 @@ public class ElasticSearchGraphQueryIterable<T extends VertexiumObject> extends 
             SearchHits hits
     ) {
         super(parameters, iterable, evaluateQueryString, evaluateHasContainers, evaluateSortContainers);
-        ElasticSearchSingleDocumentSearchQueryBase query1 = query;
-        SearchResponse searchResponse1 = searchResponse;
         this.totalHits = totalHits;
         this.searchTimeInNanoSeconds = searchTimeInNanoSeconds;
         if (hits != null) {
@@ -67,7 +61,12 @@ public class ElasticSearchGraphQueryIterable<T extends VertexiumObject> extends 
                 scores.put(ElasticsearchDocIdUtils.fromSearchHit(hit), (double) hit.getScore());
             }
         }
-        this.aggregationResults = getAggregationResults(query1, searchResponse1);
+        this.aggregationResults = getAggregationResults(query, searchResponse);
+    }
+
+    @Override
+    protected Iterator<T> iterator(boolean iterateAll) {
+        return super.iterator(true); // Override to always pass true since Elasticsearch has done the skip for us
     }
 
     @Override

--- a/elasticsearch-singledocument/src/main/java/org/vertexium/elasticsearch/ElasticsearchGraphQueryIdIterable.java
+++ b/elasticsearch-singledocument/src/main/java/org/vertexium/elasticsearch/ElasticsearchGraphQueryIdIterable.java
@@ -1,0 +1,63 @@
+package org.vertexium.elasticsearch;
+
+import org.elasticsearch.search.SearchHit;
+import org.vertexium.elasticsearch.utils.ElasticsearchExtendedDataIdUtils;
+import org.vertexium.elasticsearch.utils.PagingIterable;
+import org.vertexium.query.AggregationResult;
+import org.vertexium.query.QueryResultsIterable;
+import org.vertexium.util.CloseableUtils;
+import org.vertexium.util.ConvertingIterable;
+import org.vertexium.util.VertexiumLogger;
+import org.vertexium.util.VertexiumLoggerFactory;
+
+import java.io.IOException;
+
+public class ElasticsearchGraphQueryIdIterable<T> extends ConvertingIterable<SearchHit, T> implements QueryResultsIterable<T> {
+    private static final VertexiumLogger LOGGER = VertexiumLoggerFactory.getLogger(ElasticsearchGraphQueryIdIterable.class);
+
+    private final PagingIterable<SearchHit> iterable;
+
+    public ElasticsearchGraphQueryIdIterable(PagingIterable<SearchHit> iterable) {
+        super(iterable);
+        this.iterable = iterable;
+    }
+
+    @Override
+    public void close() throws IOException {
+        CloseableUtils.closeQuietly(iterable);
+    }
+
+    @Override
+    public long getTotalHits() {
+        return iterable.getTotalHits();
+    }
+
+    @SuppressWarnings("unchecked")
+    @Override
+    protected T convert(SearchHit hit) {
+        ElasticsearchDocumentType dt = ElasticsearchDocumentType.fromSearchHit(hit);
+        T convertedId = null;
+        if (dt != null) {
+            String id = hit.getId();
+            switch (dt) {
+                case VERTEX:
+                case EDGE:
+                    convertedId = (T) id;
+                    break;
+                case VERTEX_EXTENDED_DATA:
+                case EDGE_EXTENDED_DATA:
+                    convertedId = (T) ElasticsearchExtendedDataIdUtils.fromSearchHit(hit);
+                    break;
+                default:
+                    LOGGER.warn("Unhandled document type: %s", dt);
+                    break;
+            }
+        }
+        return convertedId;
+    }
+
+    @Override
+    public <TResult extends AggregationResult> TResult getAggregationResult(String name, Class<? extends TResult> resultType) {
+        return iterable.getAggregationResult(name, resultType);
+    }
+}

--- a/elasticsearch-singledocument/src/main/java/org/vertexium/elasticsearch/EmptyElasticSearchGraphQueryIterable.java
+++ b/elasticsearch-singledocument/src/main/java/org/vertexium/elasticsearch/EmptyElasticSearchGraphQueryIterable.java
@@ -1,11 +1,10 @@
 package org.vertexium.elasticsearch;
 
-import org.vertexium.VertexiumObject;
 import org.vertexium.query.QueryParameters;
 
 import java.util.ArrayList;
 
-public class EmptyElasticSearchGraphQueryIterable<T extends VertexiumObject> extends ElasticSearchGraphQueryIterable<T> {
+public class EmptyElasticSearchGraphQueryIterable<T> extends ElasticSearchGraphQueryIterable<T> {
     public EmptyElasticSearchGraphQueryIterable(ElasticSearchSingleDocumentSearchQueryBase query, QueryParameters parameters) {
         super(query, null, parameters, new ArrayList<T>(), false, false, false, 0, 0, null);
     }

--- a/elasticsearch-singledocument/src/main/java/org/vertexium/elasticsearch/utils/PagingIterable.java
+++ b/elasticsearch-singledocument/src/main/java/org/vertexium/elasticsearch/utils/PagingIterable.java
@@ -1,6 +1,5 @@
 package org.vertexium.elasticsearch.utils;
 
-import org.vertexium.VertexiumObject;
 import org.vertexium.VertexiumException;
 import org.vertexium.elasticsearch.ElasticSearchGraphQueryIterable;
 import org.vertexium.query.*;
@@ -10,7 +9,7 @@ import java.util.Iterator;
 import java.util.Map;
 import java.util.NoSuchElementException;
 
-public abstract class PagingIterable<T extends VertexiumObject> implements
+public abstract class PagingIterable<T> implements
         Iterable<T>,
         IterableWithTotalHits<T>,
         IterableWithScores<T>,
@@ -81,22 +80,17 @@ public abstract class PagingIterable<T extends VertexiumObject> implements
 
     @Override
     public Iterator<T> iterator() {
-        MyIterator<T> it = new MyIterator<>(isFirstCallToIterator ? firstIterable : null, skip, limit, pageSize, new GetPageIterableFunction<T>() {
-            @Override
-            public ElasticSearchGraphQueryIterable<T> getPageIterable(int skip, int limit, boolean includeAggregations) {
-                return PagingIterable.this.getPageIterable(skip, limit, includeAggregations);
-            }
-        });
+        MyIterator<T> it = new MyIterator<>(isFirstCallToIterator ? firstIterable : null, skip, limit, pageSize, PagingIterable.this::getPageIterable);
         isFirstCallToIterator = false;
         return it;
     }
 
-    private interface GetPageIterableFunction<T extends VertexiumObject> {
-        ElasticSearchGraphQueryIterable<T> getPageIterable(int skip, int limit, boolean includeAggregations);
+    private interface GetPageIterableFunction<T> {
+        Iterable<T> getPageIterable(int skip, int limit, boolean includeAggregations);
     }
 
-    private static class MyIterator<T extends VertexiumObject> implements Iterator<T> {
-        private ElasticSearchGraphQueryIterable<T> firstIterable;
+    private static class MyIterator<T> implements Iterator<T> {
+        private Iterable<T> firstIterable;
         private final int pageSize;
         private final GetPageIterableFunction<T> getPageIterableFunction;
         private int nextSkip;
@@ -104,7 +98,7 @@ public abstract class PagingIterable<T extends VertexiumObject> implements
         private int currentIteratorCount;
         private Iterator<T> currentIterator;
 
-        public MyIterator(ElasticSearchGraphQueryIterable<T> firstIterable, long skip, Long limit, int pageSize, GetPageIterableFunction<T> getPageIterableFunction) {
+        public MyIterator(Iterable<T> firstIterable, long skip, Long limit, int pageSize, GetPageIterableFunction<T> getPageIterableFunction) {
             this.firstIterable = firstIterable;
             this.pageSize = pageSize;
             this.getPageIterableFunction = getPageIterableFunction;

--- a/elasticsearch2/src/main/java/org/vertexium/elasticsearch2/ElasticsearchGraphQueryIdIterable.java
+++ b/elasticsearch2/src/main/java/org/vertexium/elasticsearch2/ElasticsearchGraphQueryIdIterable.java
@@ -1,0 +1,66 @@
+package org.vertexium.elasticsearch2;
+
+import org.elasticsearch.search.SearchHit;
+import org.vertexium.elasticsearch2.utils.ElasticsearchExtendedDataIdUtils;
+import org.vertexium.elasticsearch2.utils.PagingIterable;
+import org.vertexium.query.AggregationResult;
+import org.vertexium.query.QueryResultsIterable;
+import org.vertexium.util.CloseableUtils;
+import org.vertexium.util.ConvertingIterable;
+import org.vertexium.util.VertexiumLogger;
+import org.vertexium.util.VertexiumLoggerFactory;
+
+import java.io.IOException;
+
+public class ElasticsearchGraphQueryIdIterable<T>
+        extends ConvertingIterable<SearchHit, T>
+        implements QueryResultsIterable<T> {
+
+    private static final VertexiumLogger LOGGER = VertexiumLoggerFactory.getLogger(ElasticsearchGraphQueryIdIterable.class);
+
+    private final PagingIterable<SearchHit> iterable;
+
+    public ElasticsearchGraphQueryIdIterable(PagingIterable<SearchHit> iterable) {
+        super(iterable);
+        this.iterable = iterable;
+    }
+
+    @Override
+    public void close() throws IOException {
+        CloseableUtils.closeQuietly(iterable);
+    }
+
+    @Override
+    public long getTotalHits() {
+        return iterable.getTotalHits();
+    }
+
+    @SuppressWarnings("unchecked")
+    @Override
+    protected T convert(SearchHit hit) {
+        ElasticsearchDocumentType dt = ElasticsearchDocumentType.fromSearchHit(hit);
+        T convertedId = null;
+        if (dt != null) {
+            String id = hit.getId();
+            switch (dt) {
+                case VERTEX:
+                case EDGE:
+                    convertedId = (T)id;
+                break;
+                case VERTEX_EXTENDED_DATA:
+                case EDGE_EXTENDED_DATA:
+                    convertedId = (T)ElasticsearchExtendedDataIdUtils.fromSearchHit(hit);
+                break;
+                default:
+                    LOGGER.warn("Unhandled document type: %s", dt);
+                    break;
+            }
+        }
+        return convertedId;
+    }
+
+    @Override
+    public <TResult extends AggregationResult> TResult getAggregationResult(String name, Class<? extends TResult> resultType) {
+        return iterable.getAggregationResult(name, resultType);
+    }
+}

--- a/elasticsearch2/src/main/java/org/vertexium/elasticsearch2/ElasticsearchGraphQueryIterable.java
+++ b/elasticsearch2/src/main/java/org/vertexium/elasticsearch2/ElasticsearchGraphQueryIterable.java
@@ -17,20 +17,16 @@ import org.elasticsearch.search.aggregations.metrics.percentiles.Percentiles;
 import org.elasticsearch.search.aggregations.metrics.stats.extended.ExtendedStats;
 import org.elasticsearch.search.aggregations.metrics.stats.extended.InternalExtendedStats;
 import org.vertexium.VertexiumException;
-import org.vertexium.VertexiumObject;
 import org.vertexium.elasticsearch2.utils.ElasticsearchDocIdUtils;
 import org.vertexium.query.*;
 import org.vertexium.type.GeoPoint;
 import org.vertexium.type.GeoRect;
 import org.vertexium.util.StreamUtils;
 
-import java.util.ArrayList;
-import java.util.HashMap;
-import java.util.List;
-import java.util.Map;
+import java.util.*;
 
 @SuppressWarnings("deprecation")
-public class ElasticsearchGraphQueryIterable<T extends VertexiumObject> extends DefaultGraphQueryIterable<T> implements
+public class ElasticsearchGraphQueryIterable<T> extends DefaultGraphQueryIterable<T> implements
         IterableWithTotalHits<T>,
         IterableWithSearchTime<T>,
         IterableWithScores<T>,
@@ -56,8 +52,6 @@ public class ElasticsearchGraphQueryIterable<T extends VertexiumObject> extends 
             SearchHits hits
     ) {
         super(parameters, iterable, evaluateQueryString, evaluateHasContainers, evaluateSortContainers);
-        ElasticsearchSearchQueryBase query1 = query;
-        SearchResponse searchResponse1 = searchResponse;
         this.totalHits = totalHits;
         this.searchTimeInNanoSeconds = searchTimeInNanoSeconds;
         if (hits != null) {
@@ -65,7 +59,12 @@ public class ElasticsearchGraphQueryIterable<T extends VertexiumObject> extends 
                 scores.put(ElasticsearchDocIdUtils.fromSearchHit(hit), (double) hit.getScore());
             }
         }
-        this.aggregationResults = getAggregationResults(query1, searchResponse1);
+        this.aggregationResults = getAggregationResults(query, searchResponse);
+    }
+
+    @Override
+    protected Iterator<T> iterator(boolean iterateAll) {
+        return super.iterator(true); // Override to always pass true since Elasticsearch has done the skip for us
     }
 
     @Override

--- a/elasticsearch2/src/main/java/org/vertexium/elasticsearch2/EmptyElasticsearchGraphQueryIterable.java
+++ b/elasticsearch2/src/main/java/org/vertexium/elasticsearch2/EmptyElasticsearchGraphQueryIterable.java
@@ -1,11 +1,10 @@
 package org.vertexium.elasticsearch2;
 
-import org.vertexium.VertexiumObject;
 import org.vertexium.query.QueryParameters;
 
 import java.util.ArrayList;
 
-public class EmptyElasticsearchGraphQueryIterable<T extends VertexiumObject> extends ElasticsearchGraphQueryIterable<T> {
+public class EmptyElasticsearchGraphQueryIterable<T> extends ElasticsearchGraphQueryIterable<T> {
     public EmptyElasticsearchGraphQueryIterable(ElasticsearchSearchQueryBase query, QueryParameters parameters) {
         super(query, null, parameters, new ArrayList<T>(), false, false, false, 0, 0, null);
     }

--- a/test/src/main/java/org/vertexium/test/util/VertexiumAssert.java
+++ b/test/src/main/java/org/vertexium/test/util/VertexiumAssert.java
@@ -4,6 +4,7 @@ import com.google.common.base.Joiner;
 import com.google.common.collect.Lists;
 import org.vertexium.*;
 import org.vertexium.event.GraphEvent;
+import org.vertexium.query.IterableWithTotalHits;
 import org.vertexium.query.QueryResultsIterable;
 
 import java.util.*;
@@ -16,6 +17,18 @@ import static org.vertexium.util.StreamUtils.stream;
 
 public class VertexiumAssert {
     protected final static List<GraphEvent> graphEvents = new ArrayList<>();
+
+    public static void assertIdsAnyOrder(Iterable<String> ids, String... expectedIds) {
+        List<String> sortedIds = stream(ids).sorted().collect(Collectors.toList());
+        Arrays.sort(expectedIds);
+
+        String idsString = idsToString(sortedIds.toArray(new String[sortedIds.size()]));
+        String expectedIdsString = idsToString(expectedIds);
+        assertEquals("ids length mismatch found:[" + idsString + "] expected:[" + expectedIdsString + "]", expectedIds.length, sortedIds.size());
+        for (int i = 0; i < expectedIds.length; i++) {
+            assertEquals("at offset: " + i + " found:[" + idsString + "] expected:[" + expectedIdsString + "]", expectedIds[i], sortedIds.get(i));
+        }
+    }
 
     public static void assertVertexIdsAnyOrder(Iterable<Vertex> vertices, String... expectedIds) {
         List<Vertex> sortedVertices = stream(vertices)
@@ -77,7 +90,7 @@ public class VertexiumAssert {
     public static void assertResultsCount(
             int expectedCount,
             int expectedTotalHits,
-            QueryResultsIterable<? extends VertexiumObject> results
+            IterableWithTotalHits<?> results
     ) {
         assertEquals(expectedTotalHits, results.getTotalHits());
         assertEquals(expectedCount, count(results));


### PR DESCRIPTION
Added the methods:
- Query#vertexIds
- Query#edgeIds
- Query#elementIds
- Query#extendedDataRowIds

This will provide better performance when using elasticsearch as the code will not need to additionally query the data store.

