### PR TITLE
Changed: The default behavior of calling methods without fetch hints …

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,7 @@
 * Added: ability to return if there is any paths between two vertices
 * Added: ability to store extended data rows on an element
 * Added: Elasticsearch 2.x support
+* Changed: The default behavior of calling methods without fetch hints will use the default fetch hints specified in the graph configuration
 * Fixed: Issue #135. Passing FetchHint.NONE when retrieving vertices from Accumulo using Elasticsearch will now properly return the vertices rather than an empty Iterable
 * Deprecated: EdgeCountScoringStrategy
 

--- a/accumulo/src/main/java/org/vertexium/accumulo/AccumuloEdge.java
+++ b/accumulo/src/main/java/org/vertexium/accumulo/AccumuloEdge.java
@@ -151,7 +151,7 @@ public class AccumuloEdge extends AccumuloElement implements Edge {
 
     @Override
     public Vertex getVertex(Direction direction, Authorizations authorizations) {
-        return getVertex(direction, FetchHint.DEFAULT, authorizations);
+        return getVertex(direction, getGraph().getDefaultFetchHints(), authorizations);
     }
 
     @Override
@@ -166,7 +166,7 @@ public class AccumuloEdge extends AccumuloElement implements Edge {
 
     @Override
     public Vertex getOtherVertex(String myVertexId, Authorizations authorizations) {
-        return getOtherVertex(myVertexId, FetchHint.DEFAULT, authorizations);
+        return getOtherVertex(myVertexId, getGraph().getDefaultFetchHints(), authorizations);
     }
 
     @Override
@@ -176,7 +176,7 @@ public class AccumuloEdge extends AccumuloElement implements Edge {
 
     @Override
     public EdgeVertices getVertices(Authorizations authorizations) {
-        return getVertices(FetchHint.DEFAULT, authorizations);
+        return getVertices(getGraph().getDefaultFetchHints(), authorizations);
     }
 
     @Override

--- a/accumulo/src/main/java/org/vertexium/accumulo/AccumuloGraph.java
+++ b/accumulo/src/main/java/org/vertexium/accumulo/AccumuloGraph.java
@@ -1659,9 +1659,6 @@ public class AccumuloGraph extends GraphBaseWithSearchIndex implements Traceable
 
     private void applyFetchHints(ScannerBase scanner, EnumSet<FetchHint> fetchHints, ElementType elementType) {
         scanner.clearColumns();
-        if (fetchHints.equals(FetchHint.DEFAULT)) {
-            return;
-        }
 
         Iterable<Text> columnFamiliesToFetch = getColumnFamiliesToFetch(elementType, fetchHints);
         for (Text columnFamilyToFetch : columnFamiliesToFetch) {

--- a/accumulo/src/main/java/org/vertexium/accumulo/AccumuloVertex.java
+++ b/accumulo/src/main/java/org/vertexium/accumulo/AccumuloVertex.java
@@ -163,7 +163,7 @@ public class AccumuloVertex extends AccumuloElement implements Vertex {
 
     @Override
     public Iterable<Edge> getEdges(Direction direction, Authorizations authorizations) {
-        return getEdges(direction, FetchHint.DEFAULT, authorizations);
+        return getEdges(direction, getGraph().getDefaultFetchHints(), authorizations);
     }
 
     @Override
@@ -183,7 +183,7 @@ public class AccumuloVertex extends AccumuloElement implements Vertex {
 
     @Override
     public Iterable<Edge> getEdges(Direction direction, String label, Authorizations authorizations) {
-        return getEdges(direction, label, FetchHint.DEFAULT, authorizations);
+        return getEdges(direction, label, getGraph().getDefaultFetchHints(), authorizations);
     }
 
     @Override
@@ -198,7 +198,7 @@ public class AccumuloVertex extends AccumuloElement implements Vertex {
 
     @Override
     public Iterable<Edge> getEdges(Direction direction, String[] labels, Authorizations authorizations) {
-        return getEdges(direction, labels, FetchHint.DEFAULT, authorizations);
+        return getEdges(direction, labels, getGraph().getDefaultFetchHints(), authorizations);
     }
 
     @Override
@@ -213,7 +213,7 @@ public class AccumuloVertex extends AccumuloElement implements Vertex {
 
     @Override
     public Iterable<Edge> getEdges(Vertex otherVertex, Direction direction, Authorizations authorizations) {
-        return getEdges(otherVertex, direction, FetchHint.DEFAULT, authorizations);
+        return getEdges(otherVertex, direction, getGraph().getDefaultFetchHints(), authorizations);
     }
 
     @Override
@@ -228,7 +228,7 @@ public class AccumuloVertex extends AccumuloElement implements Vertex {
 
     @Override
     public Iterable<Edge> getEdges(Vertex otherVertex, Direction direction, String label, Authorizations authorizations) {
-        return getEdges(otherVertex, direction, label, FetchHint.DEFAULT, authorizations);
+        return getEdges(otherVertex, direction, label, getGraph().getDefaultFetchHints(), authorizations);
     }
 
     @Override
@@ -243,7 +243,7 @@ public class AccumuloVertex extends AccumuloElement implements Vertex {
 
     @Override
     public Iterable<Edge> getEdges(Vertex otherVertex, Direction direction, String[] labels, Authorizations authorizations) {
-        return getEdges(otherVertex, direction, labels, FetchHint.DEFAULT, authorizations);
+        return getEdges(otherVertex, direction, labels, getGraph().getDefaultFetchHints(), authorizations);
     }
 
     @Override
@@ -296,7 +296,7 @@ public class AccumuloVertex extends AccumuloElement implements Vertex {
 
     @Override
     public Iterable<Vertex> getVertices(Direction direction, Authorizations authorizations) {
-        return getVertices(direction, FetchHint.DEFAULT, authorizations);
+        return getVertices(direction, getGraph().getDefaultFetchHints(), authorizations);
     }
 
     @SuppressWarnings("unused")
@@ -411,7 +411,7 @@ public class AccumuloVertex extends AccumuloElement implements Vertex {
 
     @Override
     public Iterable<Vertex> getVertices(Direction direction, String label, Authorizations authorizations) {
-        return getVertices(direction, label, FetchHint.DEFAULT, authorizations);
+        return getVertices(direction, label, getGraph().getDefaultFetchHints(), authorizations);
     }
 
     @Override
@@ -421,7 +421,7 @@ public class AccumuloVertex extends AccumuloElement implements Vertex {
 
     @Override
     public Iterable<Vertex> getVertices(Direction direction, String[] labels, Authorizations authorizations) {
-        return getVertices(direction, labels, FetchHint.DEFAULT, authorizations);
+        return getVertices(direction, labels, getGraph().getDefaultFetchHints(), authorizations);
     }
 
     @Override
@@ -521,7 +521,7 @@ public class AccumuloVertex extends AccumuloElement implements Vertex {
 
     @Override
     public Iterable<EdgeVertexPair> getEdgeVertexPairs(Direction direction, Authorizations authorizations) {
-        return getEdgeVertexPairs(getEdgeInfos(direction, authorizations), FetchHint.DEFAULT, null, authorizations);
+        return getEdgeVertexPairs(getEdgeInfos(direction, authorizations), getGraph().getDefaultFetchHints(), null, authorizations);
     }
 
     @Override
@@ -536,7 +536,7 @@ public class AccumuloVertex extends AccumuloElement implements Vertex {
 
     @Override
     public Iterable<EdgeVertexPair> getEdgeVertexPairs(Direction direction, String label, Authorizations authorizations) {
-        return getEdgeVertexPairs(getEdgeInfos(direction, label, authorizations), FetchHint.DEFAULT, null, authorizations);
+        return getEdgeVertexPairs(getEdgeInfos(direction, label, authorizations), getGraph().getDefaultFetchHints(), null, authorizations);
     }
 
     @Override
@@ -546,7 +546,7 @@ public class AccumuloVertex extends AccumuloElement implements Vertex {
 
     @Override
     public Iterable<EdgeVertexPair> getEdgeVertexPairs(Direction direction, String[] labels, Authorizations authorizations) {
-        return getEdgeVertexPairs(getEdgeInfos(direction, labels, authorizations), FetchHint.DEFAULT, null, authorizations);
+        return getEdgeVertexPairs(getEdgeInfos(direction, labels, authorizations), getGraph().getDefaultFetchHints(), null, authorizations);
     }
 
     @Override

--- a/accumulo/src/main/java/org/vertexium/accumulo/mapreduce/AccumuloEdgeInputFormat.java
+++ b/accumulo/src/main/java/org/vertexium/accumulo/mapreduce/AccumuloEdgeInputFormat.java
@@ -23,7 +23,7 @@ import java.util.EnumSet;
 import java.util.Map;
 
 public class AccumuloEdgeInputFormat extends AccumuloElementInputFormatBase<Edge> {
-    private static EdgeIterator edgeIterator = new EdgeIterator(AccumuloGraph.toIteratorFetchHints(FetchHint.DEFAULT));
+    private static EdgeIterator edgeIterator;
 
     public static void setInputInfo(Job job, AccumuloGraph graph, String instanceName, String zooKeepers, String principal, AuthenticationToken token, String[] authorizations) throws AccumuloSecurityException {
         String tableName = graph.getEdgesTableName();
@@ -37,8 +37,8 @@ public class AccumuloEdgeInputFormat extends AccumuloElementInputFormatBase<Edge
             Authorizations authorizations
     ) {
         try {
-            EnumSet<FetchHint> fetchHints = FetchHint.DEFAULT;
-            EdgeElementData edgeElementData = edgeIterator.createElementDataFromRows(row);
+            EnumSet<FetchHint> fetchHints = graph.getDefaultFetchHints();
+            EdgeElementData edgeElementData = getEdgeIterator(graph).createElementDataFromRows(row);
             if (edgeElementData == null) {
                 return null;
             }
@@ -76,6 +76,13 @@ public class AccumuloEdgeInputFormat extends AccumuloElementInputFormatBase<Edge
         } catch (Throwable ex) {
             throw new VertexiumException("Failed to create vertex", ex);
         }
+    }
+
+    private EdgeIterator getEdgeIterator(AccumuloGraph graph) {
+        if (edgeIterator == null) {
+            edgeIterator = new EdgeIterator(AccumuloGraph.toIteratorFetchHints(graph.getDefaultFetchHints()));
+        }
+        return edgeIterator;
     }
 }
 

--- a/accumulo/src/main/java/org/vertexium/accumulo/mapreduce/AccumuloVertexInputFormat.java
+++ b/accumulo/src/main/java/org/vertexium/accumulo/mapreduce/AccumuloVertexInputFormat.java
@@ -24,7 +24,7 @@ import java.util.Iterator;
 import java.util.Map;
 
 public class AccumuloVertexInputFormat extends AccumuloElementInputFormatBase<Vertex> {
-    private static VertexIterator vertexIterator = new VertexIterator(AccumuloGraph.toIteratorFetchHints(FetchHint.DEFAULT));
+    private static VertexIterator vertexIterator;
 
     public static void setInputInfo(Job job, AccumuloGraph graph, String instanceName, String zooKeepers, String principal, AuthenticationToken token, String[] authorizations) throws AccumuloSecurityException {
         String tableName = graph.getVerticesTableName();
@@ -38,8 +38,8 @@ public class AccumuloVertexInputFormat extends AccumuloElementInputFormatBase<Ve
 
     public static Vertex createVertex(AccumuloGraph graph, Iterator<Map.Entry<Key, Value>> row, Authorizations authorizations) {
         try {
-            EnumSet<FetchHint> fetchHints = FetchHint.DEFAULT;
-            VertexElementData vertexElementData = vertexIterator.createElementDataFromRows(row);
+            EnumSet<FetchHint> fetchHints = graph.getDefaultFetchHints();
+            VertexElementData vertexElementData = getVertexIterator(graph).createElementDataFromRows(row);
             if (vertexElementData == null) {
                 return null;
             }
@@ -75,6 +75,13 @@ public class AccumuloVertexInputFormat extends AccumuloElementInputFormatBase<Ve
         } catch (Throwable ex) {
             throw new VertexiumException("Failed to create vertex", ex);
         }
+    }
+
+    private static VertexIterator getVertexIterator(Graph graph) {
+        if (vertexIterator == null) {
+            vertexIterator = new VertexIterator(AccumuloGraph.toIteratorFetchHints(graph.getDefaultFetchHints()));
+        }
+        return vertexIterator;
     }
 }
 

--- a/accumulo/src/main/java/org/vertexium/accumulo/mapreduce/ElementMapperGraph.java
+++ b/accumulo/src/main/java/org/vertexium/accumulo/mapreduce/ElementMapperGraph.java
@@ -78,6 +78,11 @@ public class ElementMapperGraph extends GraphBase {
     }
 
     @Override
+    public EnumSet<FetchHint> getDefaultFetchHints() {
+        throw new VertexiumException("Not supported");
+    }
+
+    @Override
     protected GraphMetadataStore getGraphMetadataStore() {
         throw new VertexiumException("Not supported");
     }

--- a/accumulo/src/test/java/org/vertexium/accumulo/AccumuloGraphTestBase.java
+++ b/accumulo/src/test/java/org/vertexium/accumulo/AccumuloGraphTestBase.java
@@ -65,7 +65,7 @@ public abstract class AccumuloGraphTestBase extends GraphTestBase {
         assertEquals(0, IterableUtils.count(v1.getEdges(Direction.IN, AUTHORIZATIONS_A)));
         assertEquals(0, IterableUtils.count(v1.getEdges(Direction.OUT, AUTHORIZATIONS_A)));
 
-        v1 = graph.getVertex("v1", FetchHint.DEFAULT, AUTHORIZATIONS_A);
+        v1 = graph.getVertex("v1", graph.getDefaultFetchHints(), AUTHORIZATIONS_A);
         assertNotNull(v1);
         assertEquals(1, IterableUtils.count(v1.getProperties()));
         assertEquals(1, IterableUtils.count(v1.getEdges(Direction.IN, AUTHORIZATIONS_A)));
@@ -101,7 +101,7 @@ public abstract class AccumuloGraphTestBase extends GraphTestBase {
         assertEquals("v1", e1.getVertexId(Direction.OUT));
         assertEquals("v2", e1.getVertexId(Direction.IN));
 
-        e1 = graph.getEdge("e1", FetchHint.DEFAULT, AUTHORIZATIONS_A);
+        e1 = graph.getEdge("e1", graph.getDefaultFetchHints(), AUTHORIZATIONS_A);
         assertEquals(1, IterableUtils.count(e1.getProperties()));
         assertEquals("v1", e1.getVertexId(Direction.OUT));
         assertEquals("v2", e1.getVertexId(Direction.IN));
@@ -133,7 +133,14 @@ public abstract class AccumuloGraphTestBase extends GraphTestBase {
         assertEquals("metavalue1", metadata.getEntry("meta1", VISIBILITY_EMPTY).getValue());
 
         AccumuloGraph accumuloGraph = (AccumuloGraph) graph;
-        ScannerBase vertexScanner = accumuloGraph.createVertexScanner(FetchHint.DEFAULT, AccumuloGraph.SINGLE_VERSION, null, null, new Range("V", "W"), AUTHORIZATIONS_EMPTY);
+        ScannerBase vertexScanner = accumuloGraph.createVertexScanner(
+                graph.getDefaultFetchHints(),
+                AccumuloGraph.SINGLE_VERSION,
+                null,
+                null,
+                new Range("V", "W"),
+                AUTHORIZATIONS_EMPTY
+        );
         RowIterator rows = new RowIterator(vertexScanner.iterator());
         while (rows.hasNext()) {
             Iterator<Map.Entry<Key, Value>> row = rows.next();

--- a/cli/src/main/java/org/vertexium/cli/model/LazyEdgeMap.java
+++ b/cli/src/main/java/org/vertexium/cli/model/LazyEdgeMap.java
@@ -5,7 +5,7 @@ import org.vertexium.FetchHint;
 
 public class LazyEdgeMap extends ModelBase {
     public LazyEdge get(String edgeId) {
-        Edge e = getGraph().getEdge(edgeId, FetchHint.DEFAULT, getTime(), getAuthorizations());
+        Edge e = getGraph().getEdge(edgeId, getGraph().getDefaultFetchHints(), getTime(), getAuthorizations());
         if (e == null) {
             return null;
         }

--- a/cli/src/main/java/org/vertexium/cli/model/LazyEdgeProperty.java
+++ b/cli/src/main/java/org/vertexium/cli/model/LazyEdgeProperty.java
@@ -20,7 +20,7 @@ public class LazyEdgeProperty extends LazyProperty {
 
     @Override
     protected Edge getE() {
-        return getGraph().getEdge(getEdgeId(), FetchHint.DEFAULT, getTime(), getAuthorizations());
+        return getGraph().getEdge(getEdgeId(), getGraph().getDefaultFetchHints(), getTime(), getAuthorizations());
     }
 
     @Override

--- a/cli/src/main/java/org/vertexium/cli/model/LazyExtendedDataTable.java
+++ b/cli/src/main/java/org/vertexium/cli/model/LazyExtendedDataTable.java
@@ -41,9 +41,9 @@ public class LazyExtendedDataTable extends ModelBase {
     public Element getElement() {
         switch (elementType) {
             case VERTEX:
-                return getGraph().getVertex(getElementId(), FetchHint.DEFAULT, getTime(), getAuthorizations());
+                return getGraph().getVertex(getElementId(), getGraph().getDefaultFetchHints(), getTime(), getAuthorizations());
             case EDGE:
-                return getGraph().getEdge(getElementId(), FetchHint.DEFAULT, getTime(), getAuthorizations());
+                return getGraph().getEdge(getElementId(), getGraph().getDefaultFetchHints(), getTime(), getAuthorizations());
             default:
                 throw new VertexiumException("Unhandled element type: " + elementType);
         }

--- a/cli/src/main/java/org/vertexium/cli/model/LazyVertexMap.java
+++ b/cli/src/main/java/org/vertexium/cli/model/LazyVertexMap.java
@@ -10,14 +10,14 @@ public class LazyVertexMap extends ModelBase {
     public Object get(String vertexId) {
         if (vertexId.endsWith("*")) {
             String vertexIdPrefix = vertexId.substring(0, vertexId.length() - 1);
-            Iterable<Vertex> vertices = getGraph().getVerticesWithPrefix(vertexIdPrefix, FetchHint.DEFAULT, getTime(), getAuthorizations());
+            Iterable<Vertex> vertices = getGraph().getVerticesWithPrefix(vertexIdPrefix, getGraph().getDefaultFetchHints(), getTime(), getAuthorizations());
             List<String> results = new ArrayList<>();
             for (Vertex v : vertices) {
                 results.add(v.getId());
             }
             return new LazyVertexList(results);
         } else {
-            Vertex v = getGraph().getVertex(vertexId, FetchHint.DEFAULT, getTime(), getAuthorizations());
+            Vertex v = getGraph().getVertex(vertexId, getGraph().getDefaultFetchHints(), getTime(), getAuthorizations());
             if (v == null) {
                 return null;
             }

--- a/core/src/main/java/org/vertexium/FetchHint.java
+++ b/core/src/main/java/org/vertexium/FetchHint.java
@@ -15,7 +15,6 @@ public enum FetchHint {
     EXTENDED_DATA_TABLE_NAMES;
 
     public static final EnumSet<FetchHint> NONE = EnumSet.noneOf(FetchHint.class);
-    public static final EnumSet<FetchHint> DEFAULT = EnumSet.of(PROPERTIES, IN_EDGE_REFS, OUT_EDGE_REFS, EXTENDED_DATA_TABLE_NAMES);
     public static final EnumSet<FetchHint> ALL = EnumSet.of(PROPERTIES, PROPERTY_METADATA, IN_EDGE_REFS, OUT_EDGE_REFS, EXTENDED_DATA_TABLE_NAMES);
     public static final EnumSet<FetchHint> ALL_INCLUDING_HIDDEN = EnumSet.allOf(FetchHint.class);
     public static final EnumSet<FetchHint> EDGE_REFS = EnumSet.of(IN_EDGE_REFS, OUT_EDGE_REFS);

--- a/core/src/main/java/org/vertexium/Graph.java
+++ b/core/src/main/java/org/vertexium/Graph.java
@@ -1112,4 +1112,9 @@ public interface Graph {
      * Deletes an extended data row
      */
     void deleteExtendedDataRow(ExtendedDataRowId id, Authorizations authorizations);
+
+    /**
+     * The default fetch hints to use if none are provided
+     */
+    EnumSet<FetchHint> getDefaultFetchHints();
 }

--- a/core/src/main/java/org/vertexium/GraphBase.java
+++ b/core/src/main/java/org/vertexium/GraphBase.java
@@ -92,12 +92,12 @@ public abstract class GraphBase implements Graph {
 
     @Override
     public Vertex getVertex(String vertexId, Authorizations authorizations) throws VertexiumException {
-        return getVertex(vertexId, FetchHint.DEFAULT, authorizations);
+        return getVertex(vertexId, getDefaultFetchHints(), authorizations);
     }
 
     @Override
     public Iterable<Vertex> getVerticesWithPrefix(String vertexIdPrefix, Authorizations authorizations) {
-        return getVerticesWithPrefix(vertexIdPrefix, FetchHint.DEFAULT, authorizations);
+        return getVerticesWithPrefix(vertexIdPrefix, getDefaultFetchHints(), authorizations);
     }
 
     @Override
@@ -118,7 +118,7 @@ public abstract class GraphBase implements Graph {
 
     @Override
     public Iterable<Vertex> getVerticesInRange(Range idRange, Authorizations authorizations) {
-        return getVerticesInRange(idRange, FetchHint.DEFAULT, authorizations);
+        return getVerticesInRange(idRange, getDefaultFetchHints(), authorizations);
     }
 
     @Override
@@ -176,7 +176,7 @@ public abstract class GraphBase implements Graph {
 
     @Override
     public Iterable<Vertex> getVertices(final Iterable<String> ids, final Authorizations authorizations) {
-        return getVertices(ids, FetchHint.DEFAULT, authorizations);
+        return getVertices(ids, getDefaultFetchHints(), authorizations);
     }
 
     @Override
@@ -193,12 +193,12 @@ public abstract class GraphBase implements Graph {
 
     @Override
     public List<Vertex> getVerticesInOrder(Iterable<String> ids, Authorizations authorizations) {
-        return getVerticesInOrder(ids, FetchHint.DEFAULT, authorizations);
+        return getVerticesInOrder(ids, getDefaultFetchHints(), authorizations);
     }
 
     @Override
     public Iterable<Vertex> getVertices(Authorizations authorizations) throws VertexiumException {
-        return getVertices(FetchHint.DEFAULT, authorizations);
+        return getVertices(getDefaultFetchHints(), authorizations);
     }
 
     @Override
@@ -277,7 +277,7 @@ public abstract class GraphBase implements Graph {
 
     @Override
     public Edge getEdge(String edgeId, Authorizations authorizations) {
-        return getEdge(edgeId, FetchHint.DEFAULT, authorizations);
+        return getEdge(edgeId, getDefaultFetchHints(), authorizations);
     }
 
     @Override
@@ -454,12 +454,12 @@ public abstract class GraphBase implements Graph {
 
     @Override
     public Iterable<Edge> getEdges(final Iterable<String> ids, final Authorizations authorizations) {
-        return getEdges(ids, FetchHint.DEFAULT, authorizations);
+        return getEdges(ids, getDefaultFetchHints(), authorizations);
     }
 
     @Override
     public Iterable<Edge> getEdges(Authorizations authorizations) {
-        return getEdges(FetchHint.DEFAULT, authorizations);
+        return getEdges(getDefaultFetchHints(), authorizations);
     }
 
     @Override
@@ -472,7 +472,7 @@ public abstract class GraphBase implements Graph {
 
     @Override
     public Iterable<Edge> getEdgesInRange(Range idRange, Authorizations authorizations) {
-        return getEdgesInRange(idRange, FetchHint.DEFAULT, authorizations);
+        return getEdgesInRange(idRange, getDefaultFetchHints(), authorizations);
     }
 
     @Override

--- a/core/src/main/java/org/vertexium/GraphBaseWithSearchIndex.java
+++ b/core/src/main/java/org/vertexium/GraphBaseWithSearchIndex.java
@@ -1,6 +1,5 @@
 package org.vertexium;
 
-import com.google.common.collect.Maps;
 import org.vertexium.id.IdGenerator;
 import org.vertexium.mutation.ElementMutation;
 import org.vertexium.mutation.ExistingElementMutation;
@@ -21,6 +20,7 @@ public abstract class GraphBaseWithSearchIndex extends GraphBase implements Grap
     public static final String METADATA_ID_GENERATOR_CLASSNAME = "idGenerator.classname";
     private final GraphConfiguration configuration;
     private final IdGenerator idGenerator;
+    private final EnumSet<FetchHint> defaultFetchHints;
     private SearchIndex searchIndex;
     private boolean foundIdGeneratorClassnameInMetadata;
 
@@ -29,6 +29,7 @@ public abstract class GraphBaseWithSearchIndex extends GraphBase implements Grap
         this.configuration = configuration;
         this.searchIndex = configuration.createSearchIndex(this);
         this.idGenerator = configuration.createIdGenerator(this);
+        this.defaultFetchHints = FetchHint.parse(configuration.getString(GraphConfiguration.DEFAULT_FETCH_HINTS, GraphConfiguration.DEFAULT_DEFAULT_FETCH_HINTS));
     }
 
     protected GraphBaseWithSearchIndex(GraphConfiguration configuration, IdGenerator idGenerator, SearchIndex searchIndex) {
@@ -36,6 +37,7 @@ public abstract class GraphBaseWithSearchIndex extends GraphBase implements Grap
         this.configuration = configuration;
         this.searchIndex = searchIndex;
         this.idGenerator = idGenerator;
+        this.defaultFetchHints = FetchHint.parse(configuration.getString(GraphConfiguration.DEFAULT_FETCH_HINTS, GraphConfiguration.DEFAULT_DEFAULT_FETCH_HINTS));
     }
 
     protected void setup() {
@@ -253,4 +255,9 @@ public abstract class GraphBaseWithSearchIndex extends GraphBase implements Grap
 
     @Override
     public abstract Authorizations createAuthorizations(String... auths);
+
+    @Override
+    public EnumSet<FetchHint> getDefaultFetchHints() {
+        return defaultFetchHints;
+    }
 }

--- a/core/src/main/java/org/vertexium/GraphConfiguration.java
+++ b/core/src/main/java/org/vertexium/GraphConfiguration.java
@@ -24,6 +24,8 @@ public class GraphConfiguration {
     public static final boolean DEFAULT_STRICT_TYPING = false;
     public static final String CREATE_TABLES = "createTables";
     public static final boolean DEFAULT_CREATE_TABLES = true;
+    public static final String DEFAULT_FETCH_HINTS = "defaultFetchHints";
+    public static final String DEFAULT_DEFAULT_FETCH_HINTS = "PROPERTIES,PROPERTY_METADATA,IN_EDGE_REFS,OUT_EDGE_REFS,EXTENDED_DATA_TABLE_NAMES";
 
     private final Map<String, Object> config;
 

--- a/core/src/main/java/org/vertexium/query/CompositeGraphQuery.java
+++ b/core/src/main/java/org/vertexium/query/CompositeGraphQuery.java
@@ -7,19 +7,25 @@ import org.vertexium.util.SelectManyIterable;
 import java.util.*;
 
 public class CompositeGraphQuery implements Query {
+    private final Graph graph;
     private final List<Query> queries;
 
-    public CompositeGraphQuery(Query... queries) {
-        this(Arrays.asList(queries));
+    public CompositeGraphQuery(Graph graph, Query... queries) {
+        this(graph, Arrays.asList(queries));
     }
 
-    public CompositeGraphQuery(Collection<Query> queries) {
+    public CompositeGraphQuery(Graph graph, Collection<Query> queries) {
+        this.graph = graph;
         this.queries = new ArrayList<>(queries);
     }
 
     @Override
     public QueryResultsIterable<Vertex> vertices() {
-        return vertices(FetchHint.DEFAULT);
+        return vertices(getGraph().getDefaultFetchHints());
+    }
+
+    private Graph getGraph() {
+        return this.graph;
     }
 
     @Override
@@ -49,7 +55,7 @@ public class CompositeGraphQuery implements Query {
 
     @Override
     public QueryResultsIterable<Edge> edges() {
-        return edges(FetchHint.DEFAULT);
+        return edges(getGraph().getDefaultFetchHints());
     }
 
     @Override
@@ -81,7 +87,7 @@ public class CompositeGraphQuery implements Query {
     @Deprecated
     public QueryResultsIterable<Edge> edges(final String label) {
         hasEdgeLabel(label);
-        return edges(FetchHint.DEFAULT);
+        return edges(getGraph().getDefaultFetchHints());
     }
 
     @Override
@@ -93,7 +99,7 @@ public class CompositeGraphQuery implements Query {
 
     @Override
     public QueryResultsIterable<Element> elements() {
-        return elements(FetchHint.DEFAULT);
+        return elements(getGraph().getDefaultFetchHints());
     }
 
     @Override
@@ -123,7 +129,7 @@ public class CompositeGraphQuery implements Query {
 
     @Override
     public QueryResultsIterable<ExtendedDataRow> extendedDataRows() {
-        return extendedDataRows(FetchHint.DEFAULT);
+        return extendedDataRows(getGraph().getDefaultFetchHints());
     }
 
     @Override
@@ -173,7 +179,7 @@ public class CompositeGraphQuery implements Query {
 
     @Override
     public QueryResultsIterable<? extends VertexiumObject> search() {
-        return search(VertexiumObjectType.ALL, FetchHint.DEFAULT);
+        return search(VertexiumObjectType.ALL, getGraph().getDefaultFetchHints());
     }
 
     @Override

--- a/core/src/main/java/org/vertexium/query/QueryBase.java
+++ b/core/src/main/java/org/vertexium/query/QueryBase.java
@@ -28,7 +28,7 @@ public abstract class QueryBase implements Query, SimilarToGraphQuery {
 
     @Override
     public QueryResultsIterable<Vertex> vertices() {
-        return vertices(FetchHint.DEFAULT);
+        return vertices(getGraph().getDefaultFetchHints());
     }
 
     @Override
@@ -44,7 +44,7 @@ public abstract class QueryBase implements Query, SimilarToGraphQuery {
 
     @Override
     public QueryResultsIterable<Edge> edges() {
-        return edges(FetchHint.DEFAULT);
+        return edges(getGraph().getDefaultFetchHints());
     }
 
     @Override
@@ -60,7 +60,7 @@ public abstract class QueryBase implements Query, SimilarToGraphQuery {
 
     @Override
     public QueryResultsIterable<ExtendedDataRow> extendedDataRows() {
-        return extendedDataRows(FetchHint.DEFAULT);
+        return extendedDataRows(getGraph().getDefaultFetchHints());
     }
 
     @Override
@@ -71,7 +71,7 @@ public abstract class QueryBase implements Query, SimilarToGraphQuery {
 
     @Override
     public QueryResultsIterable<? extends VertexiumObject> search() {
-        return search(VertexiumObjectType.ALL, FetchHint.DEFAULT);
+        return search(VertexiumObjectType.ALL, getGraph().getDefaultFetchHints());
     }
 
     @Override
@@ -204,7 +204,7 @@ public abstract class QueryBase implements Query, SimilarToGraphQuery {
 
     @Override
     public QueryResultsIterable<Element> elements() {
-        return elements(FetchHint.DEFAULT);
+        return elements(getGraph().getDefaultFetchHints());
     }
 
     @Override

--- a/inmemory/src/main/java/org/vertexium/inmemory/InMemoryEdge.java
+++ b/inmemory/src/main/java/org/vertexium/inmemory/InMemoryEdge.java
@@ -47,7 +47,7 @@ public class InMemoryEdge extends InMemoryElement<InMemoryEdge> implements Edge 
 
     @Override
     public Vertex getVertex(Direction direction, Authorizations authorizations) {
-        return getVertex(direction, FetchHint.DEFAULT, authorizations);
+        return getVertex(direction, getGraph().getDefaultFetchHints(), authorizations);
     }
 
     @Override
@@ -62,7 +62,7 @@ public class InMemoryEdge extends InMemoryElement<InMemoryEdge> implements Edge 
 
     @Override
     public Vertex getOtherVertex(String myVertexId, Authorizations authorizations) {
-        return getOtherVertex(myVertexId, FetchHint.DEFAULT, authorizations);
+        return getOtherVertex(myVertexId, getGraph().getDefaultFetchHints(), authorizations);
     }
 
     @Override
@@ -72,7 +72,7 @@ public class InMemoryEdge extends InMemoryElement<InMemoryEdge> implements Edge 
 
     @Override
     public EdgeVertices getVertices(Authorizations authorizations) {
-        return getVertices(FetchHint.DEFAULT, authorizations);
+        return getVertices(getGraph().getDefaultFetchHints(), authorizations);
     }
 
     @Override

--- a/inmemory/src/main/java/org/vertexium/inmemory/InMemoryGraph.java
+++ b/inmemory/src/main/java/org/vertexium/inmemory/InMemoryGraph.java
@@ -508,7 +508,7 @@ public class InMemoryGraph extends GraphBaseWithSearchIndex {
         if (sourceVertexId.equals(destVertexId)) {
             foundPaths.add(currentPath);
         } else if (hops > 0) {
-            Stream<Edge> edges = stream(getEdgesFromVertex(sourceVertexId, FetchHint.DEFAULT, null, authorizations))
+            Stream<Edge> edges = stream(getEdgesFromVertex(sourceVertexId, getDefaultFetchHints(), null, authorizations))
                     .filter(edge -> {
                         if (options.getExcludedLabels() != null) {
                             if (ArrayUtils.contains(options.getExcludedLabels(), edge.getLabel())) {

--- a/inmemory/src/main/java/org/vertexium/inmemory/InMemoryVertex.java
+++ b/inmemory/src/main/java/org/vertexium/inmemory/InMemoryVertex.java
@@ -33,7 +33,7 @@ public class InMemoryVertex extends InMemoryElement<InMemoryVertex> implements V
 
     @Override
     public Iterable<Edge> getEdges(Direction direction, Authorizations authorizations) {
-        return getEdges(direction, FetchHint.DEFAULT, authorizations);
+        return getEdges(direction, getGraph().getDefaultFetchHints(), authorizations);
     }
 
     @Override
@@ -115,7 +115,7 @@ public class InMemoryVertex extends InMemoryElement<InMemoryVertex> implements V
 
     @Override
     public Iterable<Edge> getEdges(Direction direction, String label, Authorizations authorizations) {
-        return getEdges(direction, label, FetchHint.DEFAULT, authorizations);
+        return getEdges(direction, label, getGraph().getDefaultFetchHints(), authorizations);
     }
 
     @Override
@@ -130,7 +130,7 @@ public class InMemoryVertex extends InMemoryElement<InMemoryVertex> implements V
 
     @Override
     public Iterable<Edge> getEdges(Direction direction, String[] labels, Authorizations authorizations) {
-        return getEdges(direction, labels, FetchHint.DEFAULT, authorizations);
+        return getEdges(direction, labels, getGraph().getDefaultFetchHints(), authorizations);
     }
 
     @Override
@@ -158,7 +158,7 @@ public class InMemoryVertex extends InMemoryElement<InMemoryVertex> implements V
 
     @Override
     public Iterable<Edge> getEdges(Vertex otherVertex, Direction direction, Authorizations authorizations) {
-        return getEdges(otherVertex, direction, FetchHint.DEFAULT, authorizations);
+        return getEdges(otherVertex, direction, getGraph().getDefaultFetchHints(), authorizations);
     }
 
     @Override
@@ -178,7 +178,7 @@ public class InMemoryVertex extends InMemoryElement<InMemoryVertex> implements V
 
     @Override
     public Iterable<Edge> getEdges(Vertex otherVertex, Direction direction, String label, Authorizations authorizations) {
-        return getEdges(otherVertex, direction, label, FetchHint.DEFAULT, authorizations);
+        return getEdges(otherVertex, direction, label, getGraph().getDefaultFetchHints(), authorizations);
     }
 
     @Override
@@ -198,7 +198,7 @@ public class InMemoryVertex extends InMemoryElement<InMemoryVertex> implements V
 
     @Override
     public Iterable<Edge> getEdges(Vertex otherVertex, Direction direction, String[] labels, Authorizations authorizations) {
-        return getEdges(otherVertex, direction, labels, FetchHint.DEFAULT, authorizations);
+        return getEdges(otherVertex, direction, labels, getGraph().getDefaultFetchHints(), authorizations);
     }
 
     @Override
@@ -233,7 +233,7 @@ public class InMemoryVertex extends InMemoryElement<InMemoryVertex> implements V
 
     @Override
     public Iterable<Vertex> getVertices(Direction direction, Authorizations authorizations) {
-        return getVertices(direction, FetchHint.DEFAULT, authorizations);
+        return getVertices(direction, getGraph().getDefaultFetchHints(), authorizations);
     }
 
     @Override
@@ -243,7 +243,7 @@ public class InMemoryVertex extends InMemoryElement<InMemoryVertex> implements V
 
     @Override
     public Iterable<Vertex> getVertices(Direction direction, String label, Authorizations authorizations) {
-        return getVertices(direction, label, FetchHint.DEFAULT, authorizations);
+        return getVertices(direction, label, getGraph().getDefaultFetchHints(), authorizations);
     }
 
     @Override
@@ -253,7 +253,7 @@ public class InMemoryVertex extends InMemoryElement<InMemoryVertex> implements V
 
     @Override
     public Iterable<Vertex> getVertices(Direction direction, String[] labels, Authorizations authorizations) {
-        return getVertices(direction, labels, FetchHint.DEFAULT, authorizations);
+        return getVertices(direction, labels, getGraph().getDefaultFetchHints(), authorizations);
     }
 
     @Override
@@ -323,7 +323,7 @@ public class InMemoryVertex extends InMemoryElement<InMemoryVertex> implements V
 
     @Override
     public Iterable<EdgeVertexPair> getEdgeVertexPairs(Direction direction, Authorizations authorizations) {
-        return getEdgeVertexPairs(getEdgeInfos(direction, authorizations), FetchHint.DEFAULT, null, authorizations);
+        return getEdgeVertexPairs(getEdgeInfos(direction, authorizations), getGraph().getDefaultFetchHints(), null, authorizations);
     }
 
     @Override
@@ -338,7 +338,7 @@ public class InMemoryVertex extends InMemoryElement<InMemoryVertex> implements V
 
     @Override
     public Iterable<EdgeVertexPair> getEdgeVertexPairs(Direction direction, String label, Authorizations authorizations) {
-        return getEdgeVertexPairs(getEdgeInfos(direction, label, authorizations), FetchHint.DEFAULT, null, authorizations);
+        return getEdgeVertexPairs(getEdgeInfos(direction, label, authorizations), getGraph().getDefaultFetchHints(), null, authorizations);
     }
 
     @Override
@@ -348,7 +348,7 @@ public class InMemoryVertex extends InMemoryElement<InMemoryVertex> implements V
 
     @Override
     public Iterable<EdgeVertexPair> getEdgeVertexPairs(Direction direction, String[] labels, Authorizations authorizations) {
-        return getEdgeVertexPairs(getEdgeInfos(direction, labels, authorizations), FetchHint.DEFAULT, null, authorizations);
+        return getEdgeVertexPairs(getEdgeInfos(direction, labels, authorizations), getGraph().getDefaultFetchHints(), null, authorizations);
     }
 
     @Override

--- a/test/src/main/java/org/vertexium/test/GraphTestBase.java
+++ b/test/src/main/java/org/vertexium/test/GraphTestBase.java
@@ -21,7 +21,6 @@ import org.vertexium.query.*;
 import org.vertexium.search.DefaultSearchIndex;
 import org.vertexium.search.IndexHint;
 import org.vertexium.test.util.LargeStringInputStream;
-import org.vertexium.test.util.VertexiumAssert;
 import org.vertexium.type.*;
 import org.vertexium.util.*;
 
@@ -629,15 +628,15 @@ public abstract class GraphTestBase {
         graph.flush();
 
         assertNull(graph.getEdge(e1.getId(), AUTHORIZATIONS_A));
-        assertNull(graph.getEdge(e1.getId(), FetchHint.DEFAULT, AUTHORIZATIONS_A));
+        assertNull(graph.getEdge(e1.getId(), graph.getDefaultFetchHints(), AUTHORIZATIONS_A));
         assertNull(graph.getEdge(e1.getId(), FetchHint.ALL_INCLUDING_HIDDEN, AUTHORIZATIONS_A));
         assertNull(graph.getVertex(v1.getId(), AUTHORIZATIONS_A));
-        assertNull(graph.getVertex(v1.getId(), FetchHint.DEFAULT, AUTHORIZATIONS_A));
+        assertNull(graph.getVertex(v1.getId(), graph.getDefaultFetchHints(), AUTHORIZATIONS_A));
         assertNull(graph.getVertex(v1.getId(), FetchHint.ALL_INCLUDING_HIDDEN, AUTHORIZATIONS_A));
 
-        assertNotNull(graph.getEdge(e1.getId(), FetchHint.DEFAULT, beforeDeleteTime, AUTHORIZATIONS_A));
+        assertNotNull(graph.getEdge(e1.getId(), graph.getDefaultFetchHints(), beforeDeleteTime, AUTHORIZATIONS_A));
         assertNotNull(graph.getEdge(e1.getId(), FetchHint.ALL_INCLUDING_HIDDEN, beforeDeleteTime, AUTHORIZATIONS_A));
-        assertNotNull(graph.getVertex(v1.getId(), FetchHint.DEFAULT, beforeDeleteTime, AUTHORIZATIONS_A));
+        assertNotNull(graph.getVertex(v1.getId(), graph.getDefaultFetchHints(), beforeDeleteTime, AUTHORIZATIONS_A));
         assertNotNull(graph.getVertex(v1.getId(), FetchHint.ALL_INCLUDING_HIDDEN, beforeDeleteTime, AUTHORIZATIONS_A));
     }
 
@@ -941,7 +940,7 @@ public abstract class GraphTestBase {
         assertEquals(1, count(properties));
         graph.flush();
 
-        v1 = graph.getVertex("v1", FetchHint.DEFAULT, beforeMarkPropertyVisibleTimestamp, AUTHORIZATIONS_A_AND_B);
+        v1 = graph.getVertex("v1", graph.getDefaultFetchHints(), beforeMarkPropertyVisibleTimestamp, AUTHORIZATIONS_A_AND_B);
         assertNotNull("could not find v1 before timestamp " + beforeMarkPropertyVisibleTimestamp + " current time " + t, v1);
         properties = IterableUtils.toList(v1.getProperties());
         assertEquals(0, count(properties));
@@ -1215,7 +1214,7 @@ public abstract class GraphTestBase {
         Assert.assertEquals(1, count(graph.getVertices(AUTHORIZATIONS_A)));
         Assert.assertEquals(0, count(graph.getVertices(AUTHORIZATIONS_B)));
         Assert.assertEquals(0, count(graph.getEdges(AUTHORIZATIONS_A)));
-        assertNull("found v1 but shouldn't have", graph.getVertex("v1", FetchHint.DEFAULT, AUTHORIZATIONS_A));
+        assertNull("found v1 but shouldn't have", graph.getVertex("v1", graph.getDefaultFetchHints(), AUTHORIZATIONS_A));
         Vertex v1Hidden = graph.getVertex("v1", FetchHint.ALL_INCLUDING_HIDDEN, AUTHORIZATIONS_A);
         assertNotNull("did not find v1 but should have", v1Hidden);
         assertTrue("v1 should be hidden", v1Hidden.isHidden(AUTHORIZATIONS_A));
@@ -1290,7 +1289,7 @@ public abstract class GraphTestBase {
         Assert.assertEquals(0, count(graph.findPaths(new FindPathOptions("v1", "v3", 2), AUTHORIZATIONS_A_AND_B)));
         Assert.assertEquals(0, count(graph.findPaths(new FindPathOptions("v1", "v3", 10), AUTHORIZATIONS_A_AND_B)));
         Assert.assertEquals(1, count(graph.findPaths(new FindPathOptions("v1", "v3", 10), AUTHORIZATIONS_A)));
-        assertNull("found e1 but shouldn't have", graph.getEdge("v1tov2", FetchHint.DEFAULT, AUTHORIZATIONS_A_AND_B));
+        assertNull("found e1 but shouldn't have", graph.getEdge("v1tov2", graph.getDefaultFetchHints(), AUTHORIZATIONS_A_AND_B));
         Edge e1Hidden = graph.getEdge("v1tov2", FetchHint.ALL_INCLUDING_HIDDEN, AUTHORIZATIONS_A_AND_B);
         assertNotNull("did not find e1 but should have", e1Hidden);
         assertTrue("e1 should be hidden", e1Hidden.isHidden(AUTHORIZATIONS_A_AND_B));
@@ -1473,14 +1472,14 @@ public abstract class GraphTestBase {
         assertEquals(v2, addedEdgeVertices.getInVertex());
 
         graph.getVertex("v1", FetchHint.NONE, AUTHORIZATIONS_A);
-        graph.getVertex("v1", FetchHint.DEFAULT, AUTHORIZATIONS_A);
+        graph.getVertex("v1", graph.getDefaultFetchHints(), AUTHORIZATIONS_A);
         graph.getVertex("v1", EnumSet.of(FetchHint.PROPERTIES), AUTHORIZATIONS_A);
         graph.getVertex("v1", FetchHint.EDGE_REFS, AUTHORIZATIONS_A);
         graph.getVertex("v1", EnumSet.of(FetchHint.IN_EDGE_REFS), AUTHORIZATIONS_A);
         graph.getVertex("v1", EnumSet.of(FetchHint.OUT_EDGE_REFS), AUTHORIZATIONS_A);
 
         graph.getEdge("e1", FetchHint.NONE, AUTHORIZATIONS_A);
-        graph.getEdge("e1", FetchHint.DEFAULT, AUTHORIZATIONS_A);
+        graph.getEdge("e1", graph.getDefaultFetchHints(), AUTHORIZATIONS_A);
         graph.getEdge("e1", EnumSet.of(FetchHint.PROPERTIES), AUTHORIZATIONS_A);
 
         Edge e = graph.getEdge("e1", AUTHORIZATIONS_B);
@@ -2178,6 +2177,7 @@ public abstract class GraphTestBase {
         Assert.assertEquals(2, count(vertices));
 
         vertices = new CompositeGraphQuery(
+                graph,
                 graph.query(AUTHORIZATIONS_A).has("age", 25),
                 graph.query(AUTHORIZATIONS_A).has("age", 25),
                 graph.query(AUTHORIZATIONS_A).has("age", 30)
@@ -3985,7 +3985,7 @@ public abstract class GraphTestBase {
         assertEquals("value2", v1.getProperty("", "prop1", VISIBILITY_EMPTY).getValue());
         assertNull(v1.getProperty("", "prop1", VISIBILITY_A));
 
-        v1 = graph.getVertex("v1", FetchHint.DEFAULT, beforeAlterTimestamp, AUTHORIZATIONS_A);
+        v1 = graph.getVertex("v1", graph.getDefaultFetchHints(), beforeAlterTimestamp, AUTHORIZATIONS_A);
         assertEquals(2, count(v1.getProperties()));
         assertNotNull(v1.getProperty("", "prop1", VISIBILITY_EMPTY));
         assertEquals("value1", v1.getProperty("", "prop1", VISIBILITY_EMPTY).getValue());
@@ -4625,9 +4625,9 @@ public abstract class GraphTestBase {
         assertEquals(1, count(graph.getEdges(AUTHORIZATIONS_A)));
 
         // verify old version
-        assertEquals(25, graph.getVertex("v1", FetchHint.DEFAULT, time25.getTime(), AUTHORIZATIONS_A).getPropertyValue("", "age"));
-        assertNull("v3 should not exist at time25", graph.getVertex("v3", FetchHint.DEFAULT, time25.getTime(), AUTHORIZATIONS_A));
-        assertEquals("e1 should not exist", 0, count(graph.getEdges(FetchHint.DEFAULT, time25.getTime(), AUTHORIZATIONS_A)));
+        assertEquals(25, graph.getVertex("v1", graph.getDefaultFetchHints(), time25.getTime(), AUTHORIZATIONS_A).getPropertyValue("", "age"));
+        assertNull("v3 should not exist at time25", graph.getVertex("v3", graph.getDefaultFetchHints(), time25.getTime(), AUTHORIZATIONS_A));
+        assertEquals("e1 should not exist", 0, count(graph.getEdges(graph.getDefaultFetchHints(), time25.getTime(), AUTHORIZATIONS_A)));
     }
 
     @Test
@@ -5918,7 +5918,7 @@ public abstract class GraphTestBase {
                 .save(AUTHORIZATIONS_A_AND_B);
         graph.flush();
 
-        Vertex v1 = graph.getVertex("v1", FetchHint.DEFAULT, AUTHORIZATIONS_A);
+        Vertex v1 = graph.getVertex("v1", EnumSet.of(FetchHint.PROPERTIES), AUTHORIZATIONS_A);
         Property prop1 = v1.getProperty("prop1");
         assertThrowsException(prop1::getMetadata);
     }


### PR DESCRIPTION
…will use the default fetch hints specified in the graph configuration

To move 2.6 forward I change the default fetch hints to be configurable. The default will use the old behavior of returning the property metadata.