### PR TITLE
Changed: Removed timestamp from streaming property value row key.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,10 @@
 * Fixed: Issue #135. Passing FetchHint.NONE when retrieving vertices from Accumulo using Elasticsearch will now properly return the vertices rather than an empty Iterable
 * Deprecated: EdgeCountScoringStrategy
 
+# v2.5.5
+
+* Changed: Removed timestamp from streaming property value row key. 
+
 # v2.5.4
 
 * Fixed: Find Path max 2 hops not returning one hop paths

--- a/accumulo/src/main/java/org/vertexium/accumulo/ElementMutationBuilder.java
+++ b/accumulo/src/main/java/org/vertexium/accumulo/ElementMutationBuilder.java
@@ -536,7 +536,7 @@ public abstract class ElementMutationBuilder {
     private StreamingPropertyValueRef saveStreamingPropertyValueSmall(String rowKey, Property property, byte[] data, StreamingPropertyValue propertyValue) {
         String dataTableRowKey = new DataTableRowKey(rowKey, property).getRowKey();
         Mutation dataMutation = new Mutation(dataTableRowKey);
-        dataMutation.put(EMPTY_TEXT, EMPTY_TEXT, new Value(data));
+        dataMutation.put(EMPTY_TEXT, EMPTY_TEXT, property.getTimestamp(), new Value(data));
         saveDataMutation(dataMutation);
         return new StreamingPropertyValueTableRef(dataTableRowKey, propertyValue, data);
     }

--- a/accumulo/src/main/java/org/vertexium/accumulo/LazyMutableProperty.java
+++ b/accumulo/src/main/java/org/vertexium/accumulo/LazyMutableProperty.java
@@ -108,7 +108,7 @@ public class LazyMutableProperty extends MutableProperty {
             }
             cachedPropertyValue = this.vertexiumSerializer.bytesToObject(propertyValue);
             if (cachedPropertyValue instanceof StreamingPropertyValueRef) {
-                cachedPropertyValue = ((StreamingPropertyValueRef) cachedPropertyValue).toStreamingPropertyValue(this.graph);
+                cachedPropertyValue = ((StreamingPropertyValueRef) cachedPropertyValue).toStreamingPropertyValue(this.graph, getTimestamp());
             }
         }
         return cachedPropertyValue;

--- a/accumulo/src/main/java/org/vertexium/accumulo/StreamingPropertyValueHdfsRef.java
+++ b/accumulo/src/main/java/org/vertexium/accumulo/StreamingPropertyValueHdfsRef.java
@@ -22,7 +22,7 @@ public class StreamingPropertyValueHdfsRef extends StreamingPropertyValueRef<Acc
     }
 
     @Override
-    public StreamingPropertyValue toStreamingPropertyValue(AccumuloGraph graph) {
+    public StreamingPropertyValue toStreamingPropertyValue(AccumuloGraph graph, long timestamp) {
         return new StreamingPropertyValueHdfs(graph.getFileSystem(), new Path(graph.getDataDir(), getPath()), this);
     }
 }

--- a/accumulo/src/main/java/org/vertexium/accumulo/StreamingPropertyValueTable.java
+++ b/accumulo/src/main/java/org/vertexium/accumulo/StreamingPropertyValueTable.java
@@ -8,10 +8,12 @@ import java.io.InputStream;
 class StreamingPropertyValueTable extends StreamingPropertyValue {
     private final AccumuloGraph graph;
     private final String dataRowKey;
+    private final long timestamp;
     private transient byte[] data;
 
-    StreamingPropertyValueTable(AccumuloGraph graph, String dataRowKey, StreamingPropertyValueTableRef valueRef) {
+    StreamingPropertyValueTable(AccumuloGraph graph, String dataRowKey, StreamingPropertyValueTableRef valueRef, long timestamp) {
         super(null, valueRef.getValueType());
+        this.timestamp = timestamp;
         this.store(valueRef.isStore());
         this.searchIndex(valueRef.isSearchIndex());
         this.graph = graph;
@@ -47,7 +49,7 @@ class StreamingPropertyValueTable extends StreamingPropertyValue {
 
     private void ensureDataLoaded() {
         if (!isDataLoaded()) {
-            this.data = this.graph.streamingPropertyValueTableData(this.dataRowKey);
+            this.data = this.graph.streamingPropertyValueTableData(this.dataRowKey, this.timestamp);
         }
     }
 }

--- a/accumulo/src/main/java/org/vertexium/accumulo/StreamingPropertyValueTableRef.java
+++ b/accumulo/src/main/java/org/vertexium/accumulo/StreamingPropertyValueTableRef.java
@@ -27,7 +27,7 @@ public class StreamingPropertyValueTableRef extends StreamingPropertyValueRef<Ac
     }
 
     @Override
-    public StreamingPropertyValue toStreamingPropertyValue(AccumuloGraph graph) {
-        return new StreamingPropertyValueTable(graph, getDataRowKey(), this);
+    public StreamingPropertyValue toStreamingPropertyValue(AccumuloGraph graph, long timestamp) {
+        return new StreamingPropertyValueTable(graph, getDataRowKey(), this, timestamp);
     }
 }

--- a/accumulo/src/main/java/org/vertexium/accumulo/keys/DataTableRowKey.java
+++ b/accumulo/src/main/java/org/vertexium/accumulo/keys/DataTableRowKey.java
@@ -1,21 +1,25 @@
 package org.vertexium.accumulo.keys;
 
+import org.apache.commons.lang.StringUtils;
 import org.vertexium.Property;
 import org.vertexium.accumulo.iterator.model.KeyBase;
 
 public class DataTableRowKey extends KeyBase {
+    private static final int LEGACY_VALUE_SEPARATOR_COUNT = 3;
     private static final int PARTS_INDEX_ELEMENT_ROW_KEY = 0;
     private static final int PARTS_INDEX_PROPERTY_NAME = 1;
     private static final int PARTS_INDEX_PROPERTY_KEY = 2;
-    private static final int PARTS_INDEX_PROPERTY_TIMESTAMP = 3;
     private final String[] parts;
 
     public DataTableRowKey(String elementRowKey, Property property) {
+        this(elementRowKey, property.getKey(), property.getName());
+    }
+
+    public DataTableRowKey(String elementRowKey, String propertyKey, String propertyName) {
         this.parts = new String[]{
                 elementRowKey,
-                property.getName(),
-                property.getKey(),
-                Long.toString(property.getTimestamp())
+                propertyName,
+                propertyKey
         };
     }
 
@@ -25,8 +29,7 @@ public class DataTableRowKey extends KeyBase {
         assertNoValueSeparator(getPropertyKey());
         return getElementRowKey()
                 + VALUE_SEPARATOR + getPropertyName()
-                + VALUE_SEPARATOR + getPropertyKey()
-                + VALUE_SEPARATOR + getPropertyTimestamp();
+                + VALUE_SEPARATOR + getPropertyKey();
     }
 
     public String getElementRowKey() {
@@ -41,7 +44,10 @@ public class DataTableRowKey extends KeyBase {
         return parts[PARTS_INDEX_PROPERTY_KEY];
     }
 
-    public long getPropertyTimestamp() {
-        return Long.parseLong(parts[PARTS_INDEX_PROPERTY_TIMESTAMP]);
+    public static boolean isLegacy(String dataRowKey) {
+        if (StringUtils.countMatches(dataRowKey, "" + VALUE_SEPARATOR) == LEGACY_VALUE_SEPARATOR_COUNT) {
+            return true;
+        }
+        return false;
     }
 }

--- a/core/src/main/java/org/vertexium/property/StreamingPropertyValueRef.java
+++ b/core/src/main/java/org/vertexium/property/StreamingPropertyValueRef.java
@@ -39,5 +39,5 @@ public abstract class StreamingPropertyValueRef<T extends Graph> implements Seri
         return store;
     }
 
-    public abstract StreamingPropertyValue toStreamingPropertyValue(T graph);
+    public abstract StreamingPropertyValue toStreamingPropertyValue(T graph, long timestamp);
 }

--- a/inmemory/src/main/java/org/vertexium/inmemory/InMemoryStreamingPropertyValueRef.java
+++ b/inmemory/src/main/java/org/vertexium/inmemory/InMemoryStreamingPropertyValueRef.java
@@ -20,7 +20,7 @@ class InMemoryStreamingPropertyValueRef extends StreamingPropertyValueRef<InMemo
     }
 
     @Override
-    public StreamingPropertyValue toStreamingPropertyValue(InMemoryGraph graph) {
+    public StreamingPropertyValue toStreamingPropertyValue(InMemoryGraph graph, long timestamp) {
         return new InMemoryStreamingPropertyValue(
                 valueData, getValueType()).store(isStore()).searchIndex(isSearchIndex());
 

--- a/inmemory/src/main/java/org/vertexium/inmemory/InMemoryTableElement.java
+++ b/inmemory/src/main/java/org/vertexium/inmemory/InMemoryTableElement.java
@@ -177,7 +177,7 @@ public abstract class InMemoryTableElement<TElement extends InMemoryElement> imp
             } else if (m instanceof AddPropertyValueMutation) {
                 AddPropertyValueMutation apvm = (AddPropertyValueMutation) m;
                 Object value = apvm.getValue();
-                value = loadIfStreamingPropertyValue(value);
+                value = loadIfStreamingPropertyValue(value, m.getTimestamp());
 
                 builder.propertyVisibility(m.getPropertyVisibility())
                         .timestamp(m.getTimestamp())
@@ -284,20 +284,20 @@ public abstract class InMemoryTableElement<TElement extends InMemoryElement> imp
         if (propertyKey == null) {
             return null;
         }
-        value = loadIfStreamingPropertyValue(value);
+        value = loadIfStreamingPropertyValue(value, timestamp);
         return new MutablePropertyImpl(propertyKey, propertyName, value, metadata, timestamp, hiddenVisibilities, visibility, fetchHints);
     }
 
-    private Object loadIfStreamingPropertyValue(Object value) {
+    private Object loadIfStreamingPropertyValue(Object value, long timestamp) {
         if (value instanceof StreamingPropertyValueRef) {
-            value = loadStreamingPropertyValue((StreamingPropertyValueRef) value);
+            value = loadStreamingPropertyValue((StreamingPropertyValueRef) value, timestamp);
         }
         return value;
     }
 
-    protected StreamingPropertyValue loadStreamingPropertyValue(StreamingPropertyValueRef<?> streamingPropertyValueRef) {
+    protected StreamingPropertyValue loadStreamingPropertyValue(StreamingPropertyValueRef<?> streamingPropertyValueRef, long timestamp) {
         // There's no need to have a Graph object for the pure in-memory implementation. Subclasses should override.
-        return streamingPropertyValueRef.toStreamingPropertyValue(null);
+        return streamingPropertyValueRef.toStreamingPropertyValue(null, timestamp);
     }
 
     private String toMapKey(PropertyMutation m) {

--- a/sql/src/main/java/org/vertexium/sql/SqlStreamingPropertyValueRef.java
+++ b/sql/src/main/java/org/vertexium/sql/SqlStreamingPropertyValueRef.java
@@ -22,7 +22,7 @@ class SqlStreamingPropertyValueRef extends StreamingPropertyValueRef<SqlGraph> {
     }
 
     @Override
-    public StreamingPropertyValue toStreamingPropertyValue(SqlGraph graph) {
+    public StreamingPropertyValue toStreamingPropertyValue(SqlGraph graph, long timestamp) {
         return graph.getStreamingPropertyTable().get(elementId, key, name, visibility, timestamp)
                 .store(isStore()).searchIndex(isSearchIndex());
     }

--- a/sql/src/main/java/org/vertexium/sql/SqlTableElement.java
+++ b/sql/src/main/java/org/vertexium/sql/SqlTableElement.java
@@ -111,7 +111,7 @@ public abstract class SqlTableElement<TElement extends InMemoryElement>
 
     @SuppressWarnings("unchecked")
     @Override
-    protected StreamingPropertyValue loadStreamingPropertyValue(StreamingPropertyValueRef<?> streamingPropertyValueRef) {
-        return ((StreamingPropertyValueRef<SqlGraph>) streamingPropertyValueRef).toStreamingPropertyValue(graph);
+    protected StreamingPropertyValue loadStreamingPropertyValue(StreamingPropertyValueRef<?> streamingPropertyValueRef, long timestamp) {
+        return ((StreamingPropertyValueRef<SqlGraph>) streamingPropertyValueRef).toStreamingPropertyValue(graph, timestamp);
     }
 }


### PR DESCRIPTION
With the timestamp in the SPV row key it prevents the cleanup of history.

Cherry picked from 2.5.x branch

don't merge until verified