### PR TITLE
Fixed: DeleteHistoricalLegacyStreamingPropertyValueData with property keys having common prefix

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,7 @@
+# v2.5.6
+
+* Fixed: DeleteHistoricalLegacyStreamingPropertyValueData with property keys having common prefix
+
 # v2.5.5
 
 * Changed: Removed timestamp from streaming property value row key. 

--- a/accumulo/src/main/java/org/vertexium/accumulo/tools/DeleteHistoricalLegacyStreamingPropertyValueData.java
+++ b/accumulo/src/main/java/org/vertexium/accumulo/tools/DeleteHistoricalLegacyStreamingPropertyValueData.java
@@ -22,7 +22,7 @@ import static org.vertexium.accumulo.ElementMutationBuilder.EMPTY_TEXT;
 
 /**
  * To run in the Vertexium CLI
- * 
+ * <p>
  * d = new org.vertexium.accumulo.tools.DeleteHistoricalLegacyStreamingPropertyValueData(g)
  * options = new org.vertexium.accumulo.tools.DeleteHistoricalLegacyStreamingPropertyValueData.Options()
  * options.setDryRun(false)
@@ -68,7 +68,7 @@ public class DeleteHistoricalLegacyStreamingPropertyValueData {
                         continue;
                     }
 
-                    if (lastRowIdPrefix == null || !rowId.startsWith(lastRowIdPrefix)) {
+                    if (lastRowIdPrefix == null || !isSameProperty(lastRowIdPrefix, rowId)) {
                         deleteRows(writer, rowsToDelete, options);
                         rowsToDelete.clear();
                         lastRowIdPrefix = rowIdParts[0]
@@ -87,6 +87,11 @@ public class DeleteHistoricalLegacyStreamingPropertyValueData {
         } catch (Exception ex) {
             throw new VertexiumException("Could not delete old SPV data", ex);
         }
+    }
+
+    private boolean isSameProperty(String lastRowIdPrefix, String rowId) {
+        return rowId.startsWith(lastRowIdPrefix + DataTableRowKey.VALUE_SEPARATOR)
+                || lastRowIdPrefix.equals(rowId);
     }
 
     private void deleteRows(BatchWriter writer, List<Key> rowsToDelete, Options options) throws MutationsRejectedException {


### PR DESCRIPTION
I lost some data running `DeleteHistoricalLegacyStreamingPropertyValueData` but thankfully it was recoverable. This should fix this issue.

If you have multiple properties on the same vertex with a common key prefix (eg v1.prop1.key and v1.prop1.keyLonger1 and v1.prop1.keyLonger2) the old code would end up deleting all but one.
