### PR TITLE
If only a string is needed, use decodeString rather than decodeText

### DIFF
--- a/accumulo/src/main/java/org/vertexium/accumulo/AccumuloEdge.java
+++ b/accumulo/src/main/java/org/vertexium/accumulo/AccumuloEdge.java
@@ -80,31 +80,27 @@ public class AccumuloEdge extends AccumuloElement implements Edge {
             String edgeId;
             Visibility vertexVisibility;
             Iterable<Property> properties;
-            Iterable<PropertyDeleteMutation> propertyDeleteMutations = new ArrayList<>();
-            Iterable<PropertySoftDeleteMutation> propertySoftDeleteMutations = new ArrayList<>();
             Iterable<Visibility> hiddenVisibilities;
-            Map<String, org.vertexium.accumulo.iterator.model.EdgeInfo> inEdges;
-            Map<String, org.vertexium.accumulo.iterator.model.EdgeInfo> outEdges;
             long timestamp;
 
             ByteArrayInputStream bain = new ByteArrayInputStream(value.get());
             final DataInputStream in = new DataInputStream(bain);
             DataInputStreamUtils.decodeHeader(in, ElementData.TYPE_ID_EDGE);
-            edgeId = DataInputStreamUtils.decodeText(in).toString();
+            edgeId = DataInputStreamUtils.decodeString(in);
             timestamp = in.readLong();
-            vertexVisibility = new Visibility(DataInputStreamUtils.decodeText(in).toString());
-            hiddenVisibilities = Iterables.transform(DataInputStreamUtils.decodeTextList(in), new Function<Text, Visibility>() {
+            vertexVisibility = new Visibility(DataInputStreamUtils.decodeString(in));
+            hiddenVisibilities = Iterables.transform(DataInputStreamUtils.decodeStringSet(in), new Function<String, Visibility>() {
                 @Nullable
                 @Override
-                public Visibility apply(Text input) {
-                    return new Visibility(input.toString());
+                public Visibility apply(String input) {
+                    return new Visibility(input);
                 }
             });
             properties = DataInputStreamUtils.decodeProperties(graph, in, fetchHints);
             ImmutableSet<String> extendedDataTableNames = DataInputStreamUtils.decodeStringSet(in);
-            String inVertexId = DataInputStreamUtils.decodeText(in).toString();
-            String outVertexId = DataInputStreamUtils.decodeText(in).toString();
-            String label = graph.getNameSubstitutionStrategy().inflate(DataInputStreamUtils.decodeText(in));
+            String inVertexId = DataInputStreamUtils.decodeString(in);
+            String outVertexId = DataInputStreamUtils.decodeString(in);
+            String label = graph.getNameSubstitutionStrategy().inflate(DataInputStreamUtils.decodeString(in));
 
             return new AccumuloEdge(
                     graph,
@@ -115,8 +111,8 @@ public class AccumuloEdge extends AccumuloElement implements Edge {
                     null,
                     vertexVisibility,
                     properties,
-                    propertyDeleteMutations,
-                    propertySoftDeleteMutations,
+                    null,
+                    null,
                     hiddenVisibilities,
                     extendedDataTableNames,
                     timestamp,

--- a/accumulo/src/main/java/org/vertexium/accumulo/AccumuloVertex.java
+++ b/accumulo/src/main/java/org/vertexium/accumulo/AccumuloVertex.java
@@ -116,24 +116,22 @@ public class AccumuloVertex extends AccumuloElement implements Vertex {
             String vertexId;
             Visibility vertexVisibility;
             Iterable<Property> properties;
-            Iterable<PropertyDeleteMutation> propertyDeleteMutations = new ArrayList<>();
-            Iterable<PropertySoftDeleteMutation> propertySoftDeleteMutations = new ArrayList<>();
             Iterable<Visibility> hiddenVisibilities;
             Edges inEdges;
             Edges outEdges;
             long timestamp;
 
             ByteArrayInputStream byteArrayInputStream = new ByteArrayInputStream(value.get());
-            final DataInputStream in = new DataInputStream(byteArrayInputStream);
+            DataInputStream in = new DataInputStream(byteArrayInputStream);
             DataInputStreamUtils.decodeHeader(in, ElementData.TYPE_ID_VERTEX);
-            vertexId = DataInputStreamUtils.decodeText(in).toString();
+            vertexId = DataInputStreamUtils.decodeString(in);
             timestamp = in.readLong();
-            vertexVisibility = new Visibility(DataInputStreamUtils.decodeText(in).toString());
-            hiddenVisibilities = Iterables.transform(DataInputStreamUtils.decodeTextList(in), new Function<Text, Visibility>() {
+            vertexVisibility = new Visibility(DataInputStreamUtils.decodeString(in));
+            hiddenVisibilities = Iterables.transform(DataInputStreamUtils.decodeStringSet(in), new Function<String, Visibility>() {
                 @Nullable
                 @Override
-                public Visibility apply(Text input) {
-                    return new Visibility(input.toString());
+                public Visibility apply(String input) {
+                    return new Visibility(input);
                 }
             });
             properties = DataInputStreamUtils.decodeProperties(graph, in, fetchHints);
@@ -146,8 +144,8 @@ public class AccumuloVertex extends AccumuloElement implements Vertex {
                     vertexId,
                     vertexVisibility,
                     properties,
-                    propertyDeleteMutations,
-                    propertySoftDeleteMutations,
+                    null,
+                    null,
                     hiddenVisibilities,
                     extendedDataTableNames,
                     inEdges,

--- a/accumulo/src/main/java/org/vertexium/accumulo/util/DataInputStreamUtils.java
+++ b/accumulo/src/main/java/org/vertexium/accumulo/util/DataInputStreamUtils.java
@@ -69,7 +69,7 @@ public class DataInputStreamUtils {
             }
             String propertyKey = graph.getNameSubstitutionStrategy().inflate(decodeString(in));
             String propertyName = graph.getNameSubstitutionStrategy().inflate(decodeString(in));
-            Visibility propertyVisibility = new Visibility(decodeText(in).toString());
+            Visibility propertyVisibility = new Visibility(decodeString(in));
             long propertyTimestamp = in.readLong();
             int propertyValueLength = in.readInt();
             byte[] propertyValue = new byte[propertyValueLength];
@@ -77,14 +77,14 @@ public class DataInputStreamUtils {
             if (read != propertyValueLength) {
                 throw new IOException("Unexpected data length expected " + propertyValueLength + " found " + read);
             }
-            List<Text> propertyHiddenVisibilitiesTextList = decodeTextList(in);
+            Set<String> propertyHiddenVisibilitiesStringSet = decodeStringSet(in);
             Set<Visibility> propertyHiddenVisibilities = null;
-            if (propertyHiddenVisibilitiesTextList != null) {
-                propertyHiddenVisibilities = Sets.newHashSet(Iterables.transform(propertyHiddenVisibilitiesTextList, new Function<Text, Visibility>() {
+            if (propertyHiddenVisibilitiesStringSet != null) {
+                propertyHiddenVisibilities = Sets.newHashSet(Iterables.transform(propertyHiddenVisibilitiesStringSet, new Function<String, Visibility>() {
                     @Nullable
                     @Override
-                    public Visibility apply(Text input) {
-                        return new Visibility(input.toString());
+                    public Visibility apply(String input) {
+                        return new Visibility(input);
                     }
                 }));
             }
@@ -148,7 +148,7 @@ public class DataInputStreamUtils {
         EdgesWithEdgeInfo edges = new EdgesWithEdgeInfo();
         int count = in.readInt();
         for (int i = 0; i < count; i++) {
-            String label = new String(decodeByteArray(in), DataOutputStreamUtils.CHARSET);
+            String label = decodeString(in);
             int edgeByLabelCount = in.readInt();
             for (int edgeByLabelIndex = 0; edgeByLabelIndex < edgeByLabelCount; edgeByLabelIndex++) {
                 Text edgeId = decodeText(in);


### PR DESCRIPTION
Using decode Text when only a string is needed causes unnecessary garbage `Text` and `char[]` objects.