### PR TITLE
Convert ES5 Groovy scripts to use Painless scripts

### DIFF
--- a/elasticsearch5/src/test/java/org/vertexium/elasticsearch5/Elasticsearch5SearchIndexTest.java
+++ b/elasticsearch5/src/test/java/org/vertexium/elasticsearch5/Elasticsearch5SearchIndexTest.java
@@ -11,4 +11,9 @@ public class Elasticsearch5SearchIndexTest extends Elasticsearch5SearchIndexTest
     protected ElasticsearchResource getElasticsearchResource() {
         return elasticsearchResource;
     }
+
+    @Override
+    protected boolean isPainlessDateMath() {
+        return true;
+    }
 }

--- a/multimodule-test/accumulo-elasticsearch5/src/test/java/org/vertexium/multimodule/AccumuloElasticsearch5Test.java
+++ b/multimodule-test/accumulo-elasticsearch5/src/test/java/org/vertexium/multimodule/AccumuloElasticsearch5Test.java
@@ -87,6 +87,11 @@ public class AccumuloElasticsearch5Test extends AccumuloGraphTestBase {
     }
 
     @Override
+    protected boolean isPainlessDateMath() {
+        return true;
+    }
+
+    @Override
     protected String substitutionDeflate(String str) {
         if (str.equals("author")) {
             return SimpleNameSubstitutionStrategy.SUBS_DELIM + "a" + SimpleNameSubstitutionStrategy.SUBS_DELIM;


### PR DESCRIPTION
The ES5 documentation notes that Painless is safer and several times faster than the alternatives. This PR switches the Vertexium scripts to take advantage of this.