### PR TITLE
Fix: Extra Elasticsearch Query with Limit and Skip

### DIFF
--- a/elasticsearch-singledocument/src/main/java/org/vertexium/elasticsearch/utils/InfiniteScrollIterable.java
+++ b/elasticsearch-singledocument/src/main/java/org/vertexium/elasticsearch/utils/InfiniteScrollIterable.java
@@ -82,6 +82,7 @@ public abstract class InfiniteScrollIterable<T> implements QueryResultsIterable<
         private Iterator<T> it;
         private T next;
         private T current;
+        private long currentResultNumber = 0;
 
         public InfiniteIterator(String scrollId, Iterator<T> it) {
             this.scrollId = scrollId;
@@ -112,14 +113,20 @@ public abstract class InfiniteScrollIterable<T> implements QueryResultsIterable<
 
             if (it.hasNext()) {
                 this.next = it.next();
+                currentResultNumber++;
             } else {
                 CloseableUtils.closeQuietly(it);
-                QueryResultsIterable<T> iterable = searchResponseToIterable(getNextSearchResponse(scrollId));
-                it = iterable.iterator();
-                if (!it.hasNext()) {
-                    it = null;
-                } else {
-                    this.next = it.next();
+                it = null;
+
+                if (getTotalHits() > currentResultNumber) {
+                    QueryResultsIterable<T> iterable = searchResponseToIterable(getNextSearchResponse(scrollId));
+                    it = iterable.iterator();
+                    if (!it.hasNext()) {
+                        it = null;
+                    } else {
+                        this.next = it.next();
+                        currentResultNumber++;
+                    }
                 }
             }
         }

--- a/elasticsearch-singledocument/src/test/java/org/vertexium/elasticsearch/ElasticsearchResource.java
+++ b/elasticsearch-singledocument/src/test/java/org/vertexium/elasticsearch/ElasticsearchResource.java
@@ -135,4 +135,7 @@ public class ElasticsearchResource extends ExternalResource {
         return true;
     }
 
+    public ElasticsearchClusterRunner getRunner() {
+        return runner;
+    }
 }

--- a/elasticsearch-singledocument/src/test/java/org/vertexium/elasticsearch/ElasticsearchSingleDocumentSearchIndexTest.java
+++ b/elasticsearch-singledocument/src/test/java/org/vertexium/elasticsearch/ElasticsearchSingleDocumentSearchIndexTest.java
@@ -1,6 +1,17 @@
 package org.vertexium.elasticsearch;
 
+import org.elasticsearch.action.admin.cluster.node.stats.NodeStats;
+import org.elasticsearch.action.admin.cluster.node.stats.NodesStatsRequestBuilder;
+import org.elasticsearch.action.admin.cluster.node.stats.NodesStatsResponse;
+import org.elasticsearch.client.AdminClient;
+import org.elasticsearch.index.search.stats.SearchStats;
 import org.junit.ClassRule;
+import org.junit.Test;
+import org.vertexium.Vertex;
+import org.vertexium.query.QueryResultsIterable;
+
+import static org.junit.Assert.assertEquals;
+import static org.vertexium.test.util.VertexiumAssert.assertResultsCount;
 
 public class ElasticsearchSingleDocumentSearchIndexTest extends ElasticsearchSingleDocumentSearchIndexTestBase {
 
@@ -10,5 +21,43 @@ public class ElasticsearchSingleDocumentSearchIndexTest extends ElasticsearchSin
     @Override
     protected ElasticsearchResource getElasticsearchResource() {
         return elasticsearchResource;
+    }
+
+    @Test
+    public void testQueryExecutionCountWhenPaging() {
+        graph.prepareVertex("v1", VISIBILITY_A).save(AUTHORIZATIONS_A);
+        graph.addVertex("v2", VISIBILITY_A, AUTHORIZATIONS_A);
+        graph.flush();
+
+        long startingNumQueries = getNumQueries();
+
+        QueryResultsIterable<Vertex> vertices = graph.query(AUTHORIZATIONS_A).vertices();
+        assertEquals(startingNumQueries, getNumQueries());
+
+        assertResultsCount(2, 2, vertices);
+        assertEquals(startingNumQueries + 1, getNumQueries());
+
+        vertices = graph.query(AUTHORIZATIONS_A).limit(1).vertices();
+        assertEquals(startingNumQueries + 2, getNumQueries());
+
+        assertResultsCount(1, 2, vertices);
+        assertEquals(startingNumQueries + 2, getNumQueries());
+
+        vertices = graph.query(AUTHORIZATIONS_A).limit(10).vertices();
+        assertEquals(startingNumQueries + 3, getNumQueries());
+
+        assertResultsCount(2, 2, vertices);
+        assertEquals(startingNumQueries + 3, getNumQueries());
+    }
+
+    private long getNumQueries() {
+        AdminClient adminClient = elasticsearchResource.getRunner().client().admin();
+        NodesStatsResponse nodeStats = new NodesStatsRequestBuilder(adminClient.cluster()).get();
+
+        NodeStats[] nodes = nodeStats.getNodes();
+        assertEquals(1, nodes.length);
+
+        SearchStats searchStats = nodes[0].getIndices().getSearch();
+        return searchStats.getTotal().getQueryCount();
     }
 }

--- a/elasticsearch5/src/main/java/org/vertexium/elasticsearch5/utils/InfiniteScrollIterable.java
+++ b/elasticsearch5/src/main/java/org/vertexium/elasticsearch5/utils/InfiniteScrollIterable.java
@@ -82,6 +82,7 @@ public abstract class InfiniteScrollIterable<T> implements QueryResultsIterable<
         private Iterator<T> it;
         private T next;
         private T current;
+        private long currentResultNumber = 0;
 
         public InfiniteIterator(String scrollId, Iterator<T> it) {
             this.scrollId = scrollId;
@@ -112,14 +113,20 @@ public abstract class InfiniteScrollIterable<T> implements QueryResultsIterable<
 
             if (it.hasNext()) {
                 this.next = it.next();
+                currentResultNumber++;
             } else {
                 CloseableUtils.closeQuietly(it);
-                QueryResultsIterable<T> iterable = searchResponseToIterable(getNextSearchResponse(scrollId));
-                it = iterable.iterator();
-                if (!it.hasNext()) {
-                    it = null;
-                } else {
-                    this.next = it.next();
+                it = null;
+
+                if (getTotalHits() > currentResultNumber) {
+                    QueryResultsIterable<T> iterable = searchResponseToIterable(getNextSearchResponse(scrollId));
+                    it = iterable.iterator();
+                    if (!it.hasNext()) {
+                        it = null;
+                    } else {
+                        this.next = it.next();
+                        currentResultNumber++;
+                    }
                 }
             }
         }

--- a/elasticsearch5/src/main/java/org/vertexium/elasticsearch5/utils/PagingIterable.java
+++ b/elasticsearch5/src/main/java/org/vertexium/elasticsearch5/utils/PagingIterable.java
@@ -18,20 +18,20 @@ public abstract class PagingIterable<T> implements
         IterableWithScores<T>,
         QueryResultsIterable<T> {
     private final long skip;
-    private final Long limit;
+    private final long limit;
     private boolean isFirstCallToIterator;
     private final ElasticsearchGraphQueryIterable<T> firstIterable;
     private final int pageSize;
 
     public PagingIterable(long skip, Long limit, int pageSize) {
         this.skip = skip;
-        this.limit = limit;
+        this.limit = limit == null ? Long.MAX_VALUE : limit;
         this.pageSize = pageSize;
 
         // This is a bit of a hack. Because the underlying iterable is the iterable with geohash results, histogram results, etc.
         //   we need to grab the first iterable to get the results out.
-        int firstIterableLimit = Math.min(pageSize, limit == null ? Integer.MAX_VALUE : limit.intValue());
-        this.firstIterable = getPageIterable((int) this.skip, firstIterableLimit, true);
+        long firstIterableLimit = Math.min(pageSize, this.limit);
+        this.firstIterable = getPageIterable((int) this.skip, (int)firstIterableLimit, true);
         this.isFirstCallToIterator = true;
     }
 
@@ -59,30 +59,19 @@ public abstract class PagingIterable<T> implements
 
     @Override
     public Iterator<T> iterator() {
-        MyIterator<T> it = new MyIterator<>(isFirstCallToIterator ? firstIterable : null, skip, limit, pageSize, PagingIterable.this::getPageIterable);
+        MyIterator it = new MyIterator(isFirstCallToIterator ? firstIterable : null);
         isFirstCallToIterator = false;
         return it;
     }
 
-    private interface GetPageIterableFunction<T> {
-        Iterable<T> getPageIterable(int skip, int limit, boolean includeAggregations);
-    }
-
-    private static class MyIterator<T> implements Iterator<T> {
-        private Iterable<T> firstIterable;
-        private final int pageSize;
-        private final GetPageIterableFunction<T> getPageIterableFunction;
-        private int nextSkip;
-        private int limit;
-        private int currentIteratorCount;
+    private class MyIterator implements Iterator<T> {
+        private ElasticsearchGraphQueryIterable<T> firstIterable;
+        private long currentResultNumber = 0;
         private Iterator<T> currentIterator;
 
-        public MyIterator(Iterable<T> firstIterable, long skip, Long limit, int pageSize, GetPageIterableFunction<T> getPageIterableFunction) {
+        public MyIterator(ElasticsearchGraphQueryIterable<T> firstIterable) {
             this.firstIterable = firstIterable;
-            this.pageSize = pageSize;
-            this.getPageIterableFunction = getPageIterableFunction;
-            this.nextSkip = (int) skip;
-            this.limit = (int) (limit == null ? Integer.MAX_VALUE : limit);
+            this.currentResultNumber = skip;
             this.currentIterator = getNextIterator();
         }
 
@@ -90,9 +79,6 @@ public abstract class PagingIterable<T> implements
         public boolean hasNext() {
             while (true) {
                 if (currentIterator == null) {
-                    if (currentIteratorCount == 0) {
-                        return false;
-                    }
                     currentIterator = getNextIterator();
                     if (currentIterator == null) {
                         return false;
@@ -108,25 +94,23 @@ public abstract class PagingIterable<T> implements
         @Override
         public T next() {
             if (hasNext()) {
-                limit--;
-                currentIteratorCount++;
+                currentResultNumber++;
                 return currentIterator.next();
             }
             throw new NoSuchElementException();
         }
 
         private Iterator<T> getNextIterator() {
-            if (limit <= 0) {
+            long totalReturned = currentResultNumber - skip;
+            if (totalReturned >= limit || currentResultNumber >= getTotalHits()) {
                 return null;
             }
-            int limit = Math.min(pageSize, this.limit);
-            currentIteratorCount = 0;
+            long nextPageSize = Math.min(pageSize, limit - currentResultNumber);
             if (firstIterable == null) {
-                firstIterable = getPageIterableFunction.getPageIterable(nextSkip, limit, false);
+                firstIterable = getPageIterable((int)currentResultNumber, (int)nextPageSize, false);
             }
             Iterator<T> it = firstIterable.iterator();
             firstIterable = null;
-            nextSkip += limit;
             return it;
         }
 

--- a/elasticsearch5/src/test/java/org/vertexium/elasticsearch5/ElasticsearchResource.java
+++ b/elasticsearch5/src/test/java/org/vertexium/elasticsearch5/ElasticsearchResource.java
@@ -31,7 +31,7 @@ public class ElasticsearchResource extends ExternalResource {
     private static final String ES_INDEX_NAME = "vertexium-test";
     private static final String ES_CLUSTER_NAME = "vertexium-test-cluster";
     private static final String ES_EXTENDED_DATA_INDEX_NAME_PREFIX = "vertexium-test-";
-    private static ElasticsearchClusterRunner runner;
+    private ElasticsearchClusterRunner runner;
 
     private Map extraConfig = null;
 
@@ -140,5 +140,9 @@ public class ElasticsearchResource extends ExternalResource {
         Elasticsearch5SearchIndex searchIndex = (Elasticsearch5SearchIndex) ((GraphWithSearchIndex) graph).getSearchIndex();
         searchIndex.getConfig().getGraphConfiguration().set(SEARCH_INDEX_PROP_PREFIX + "." + INDEX_EDGES, "false");
         return true;
+    }
+
+    public ElasticsearchClusterRunner getRunner() {
+        return runner;
     }
 }


### PR DESCRIPTION
Under some situations, when using the limit/skip parameters an extra Elasticsearch query was issued by Vertexium.