### PR TITLE
Add a hasId method to the Query class

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,6 @@
 # v3.0.1
 * Changed: Find Path to not return a path that contains one or more vertices that is can't be retrieved because of visibility restrictions
+* Added: Added a hasId method to the Query class to allow searches to be filtered by element ID.
 
 # v3.0.0
 * Changed: Removed ES 2 support and replaced it with ES 5 support

--- a/core/src/main/java/org/vertexium/query/CompositeGraphQuery.java
+++ b/core/src/main/java/org/vertexium/query/CompositeGraphQuery.java
@@ -207,7 +207,7 @@ public class CompositeGraphQuery implements Query {
     }
 
     @Override
-    public Query hasId(Collection<String> ids) {
+    public Query hasId(Iterable<String> ids) {
         for (Query query : queries) {
             query.hasId(ids);
         }

--- a/core/src/main/java/org/vertexium/query/CompositeGraphQuery.java
+++ b/core/src/main/java/org/vertexium/query/CompositeGraphQuery.java
@@ -199,6 +199,22 @@ public class CompositeGraphQuery implements Query {
     }
 
     @Override
+    public Query hasId(String... ids) {
+        for (Query query : queries) {
+            query.hasId(ids);
+        }
+        return this;
+    }
+
+    @Override
+    public Query hasId(Collection<String> ids) {
+        for (Query query : queries) {
+            query.hasId(ids);
+        }
+        return this;
+    }
+
+    @Override
     public Query hasEdgeLabel(String... edgeLabels) {
         for (Query query : queries) {
             query.hasEdgeLabel(edgeLabels);

--- a/core/src/main/java/org/vertexium/query/DefaultGraphQueryIterable.java
+++ b/core/src/main/java/org/vertexium/query/DefaultGraphQueryIterable.java
@@ -111,6 +111,11 @@ public class DefaultGraphQueryIterable<T> implements
                                 match = false;
                             }
                         }
+                        if (vertexiumElem instanceof Element && parameters.getIds().size() > 0) {
+                            if (!parameters.getIds().contains(((Element) vertexiumElem).getId())) {
+                                match = false;
+                            }
+                        }
                     }
                     if (!match) {
                         continue;

--- a/core/src/main/java/org/vertexium/query/DefaultVertexQuery.java
+++ b/core/src/main/java/org/vertexium/query/DefaultVertexQuery.java
@@ -37,6 +37,14 @@ public class DefaultVertexQuery extends VertexQueryBase implements VertexQuery {
                 }
             };
         }
+        if (getParameters().getIds().size() > 0) {
+            results = new FilterIterable<Vertex>(results) {
+                @Override
+                protected boolean isIncluded(Vertex otherVertex) {
+                    return getParameters().getIds().contains(otherVertex.getId());
+                }
+            };
+        }
         return results;
     }
 

--- a/core/src/main/java/org/vertexium/query/Query.java
+++ b/core/src/main/java/org/vertexium/query/Query.java
@@ -76,7 +76,7 @@ public interface Query {
      * @param ids The ids to filter on.
      * @return The query object, allowing you to chain methods.
      */
-    Query hasId(Collection<String> ids);
+    Query hasId(Iterable<String> ids);
 
     /**
      * Adds a edge label filter to the query.

--- a/core/src/main/java/org/vertexium/query/Query.java
+++ b/core/src/main/java/org/vertexium/query/Query.java
@@ -63,6 +63,22 @@ public interface Query {
     <T> Query range(String propertyName, T startValue, boolean inclusiveStartValue, T endValue, boolean inclusiveEndValue);
 
     /**
+     * Adds an id filter to the query.
+     *
+     * @param ids The ids to filter on.
+     * @return The query object, allowing you to chain methods.
+     */
+    Query hasId(String... ids);
+
+    /**
+     * Adds an id filter to the query.
+     *
+     * @param ids The ids to filter on.
+     * @return The query object, allowing you to chain methods.
+     */
+    Query hasId(Collection<String> ids);
+
+    /**
      * Adds a edge label filter to the query.
      *
      * @param edgeLabels The edge labels to filter on.

--- a/core/src/main/java/org/vertexium/query/QueryBase.java
+++ b/core/src/main/java/org/vertexium/query/QueryBase.java
@@ -175,7 +175,7 @@ public abstract class QueryBase implements Query, SimilarToGraphQuery {
     }
 
     @Override
-    public Query hasId(Collection<String> ids) {
+    public Query hasId(Iterable<String> ids) {
         for (String id : ids) {
             getParameters().addId(id);
         }

--- a/core/src/main/java/org/vertexium/query/QueryBase.java
+++ b/core/src/main/java/org/vertexium/query/QueryBase.java
@@ -167,6 +167,22 @@ public abstract class QueryBase implements Query, SimilarToGraphQuery {
     }
 
     @Override
+    public Query hasId(String... ids) {
+        for (String id : ids) {
+            getParameters().addId(id);
+        }
+        return this;
+    }
+
+    @Override
+    public Query hasId(Collection<String> ids) {
+        for (String id : ids) {
+            getParameters().addId(id);
+        }
+        return this;
+    }
+
+    @Override
     public Query hasExtendedData(ElementType elementType, String elementId) {
         return hasExtendedData(elementType, elementId, null);
     }

--- a/core/src/main/java/org/vertexium/query/QueryParameters.java
+++ b/core/src/main/java/org/vertexium/query/QueryParameters.java
@@ -15,6 +15,7 @@ public abstract class QueryParameters {
     private final List<QueryBase.HasContainer> hasContainers = new ArrayList<>();
     private final List<QueryBase.SortContainer> sortContainers = new ArrayList<>();
     private final List<String> edgeLabels = new ArrayList<>();
+    private final List<String> ids = new ArrayList<>();
 
     public QueryParameters(Authorizations authorizations) {
         this.authorizations = authorizations;
@@ -72,6 +73,14 @@ public abstract class QueryParameters {
         this.edgeLabels.add(edgeLabel);
     }
 
+    public List<String> getIds() {
+        return ids;
+    }
+
+    public void addId(String id) {
+        this.ids.add(id);
+    }
+
     public abstract QueryParameters clone();
 
     protected QueryParameters cloneTo(QueryParameters result) {
@@ -79,6 +88,8 @@ public abstract class QueryParameters {
         result.setLimit(this.getLimit());
         result.hasContainers.addAll(this.getHasContainers());
         result.sortContainers.addAll(this.getSortContainers());
+        result.edgeLabels.addAll(this.getEdgeLabels());
+        result.ids.addAll(this.getIds());
         return result;
     }
 
@@ -91,6 +102,7 @@ public abstract class QueryParameters {
                 ", hasContainers=" + Joiner.on(", ").join(hasContainers) +
                 ", sortContainers=" + Joiner.on(", ").join(sortContainers) +
                 ", edgeLabels=" + Joiner.on(", ").join(edgeLabels) +
+                ", ids=" + Joiner.on(", ").join(ids) +
                 '}';
     }
 }

--- a/elasticsearch-singledocument/src/main/java/org/vertexium/elasticsearch/ElasticSearchSingleDocumentSearchMultiVertexQuery.java
+++ b/elasticsearch-singledocument/src/main/java/org/vertexium/elasticsearch/ElasticSearchSingleDocumentSearchMultiVertexQuery.java
@@ -1,0 +1,33 @@
+package org.vertexium.elasticsearch;
+
+import org.elasticsearch.client.Client;
+import org.vertexium.Authorizations;
+import org.vertexium.Graph;
+import org.vertexium.query.MultiVertexQuery;
+
+public class ElasticSearchSingleDocumentSearchMultiVertexQuery extends ElasticSearchSingleDocumentSearchGraphQuery implements MultiVertexQuery {
+    public ElasticSearchSingleDocumentSearchMultiVertexQuery(
+            Client client,
+            Graph graph,
+            String[] vertexIds,
+            String queryString,
+            Options options,
+            Authorizations authorizations
+    ) {
+        super(client, graph, queryString, options, authorizations);
+        hasId(vertexIds);
+    }
+
+    public ElasticSearchSingleDocumentSearchMultiVertexQuery(
+            Client client,
+            Graph graph,
+            String[] vertexIds,
+            String[] similarToFields,
+            String similarToText,
+            Options options,
+            Authorizations authorizations
+    ) {
+        super(client, graph, similarToFields, similarToText, options, authorizations);
+        hasId(vertexIds);
+    }
+}

--- a/elasticsearch-singledocument/src/main/java/org/vertexium/elasticsearch/ElasticSearchSingleDocumentSearchQueryBase.java
+++ b/elasticsearch-singledocument/src/main/java/org/vertexium/elasticsearch/ElasticSearchSingleDocumentSearchQueryBase.java
@@ -175,6 +175,12 @@ public class ElasticSearchSingleDocumentSearchQueryBase extends QueryBase {
             filters.add(FilterBuilders.inFilter(ElasticsearchSingleDocumentSearchIndex.EDGE_LABEL_FIELD_NAME, edgeLabelsArray));
         }
 
+        if ((elementTypes == null || elementTypes.contains(ElasticsearchDocumentType.EDGE) || elementTypes.contains(ElasticsearchDocumentType.VERTEX))
+                && getParameters().getIds().size() > 0) {
+            String[] idsArray = getParameters().getIds().toArray(new String[getParameters().getIds().size()]);
+            filters.add(FilterBuilders.idsFilter().addIds(idsArray));
+        }
+
         if (getParameters() instanceof QueryStringQueryParameters) {
             String queryString = ((QueryStringQueryParameters) getParameters()).getQueryString();
             if (queryString == null || queryString.equals("*")) {

--- a/elasticsearch-singledocument/src/main/java/org/vertexium/elasticsearch/ElasticSearchSingleDocumentSearchVertexQuery.java
+++ b/elasticsearch-singledocument/src/main/java/org/vertexium/elasticsearch/ElasticSearchSingleDocumentSearchVertexQuery.java
@@ -98,6 +98,9 @@ public class ElasticSearchSingleDocumentSearchVertexQuery extends ElasticSearchS
         if (otherVertexId != null) {
             edgeInfos = edgeInfos.filter(ei -> ei.getVertexId().equals(otherVertexId));
         }
+        if (getParameters().getIds().size() > 0) {
+            edgeInfos = edgeInfos.filter(ei -> getParameters().getIds().contains(ei.getVertexId()));
+        }
         String[] ids = edgeInfos.map(EdgeInfo::getVertexId).toArray(String[]::new);
 
         if (elementTypes.contains(ElasticsearchDocumentType.VERTEX)) {

--- a/elasticsearch-singledocument/src/main/java/org/vertexium/elasticsearch/ElasticsearchSingleDocumentSearchIndex.java
+++ b/elasticsearch-singledocument/src/main/java/org/vertexium/elasticsearch/ElasticsearchSingleDocumentSearchIndex.java
@@ -1385,7 +1385,20 @@ public class ElasticsearchSingleDocumentSearchIndex implements SearchIndex, Sear
 
     @Override
     public MultiVertexQuery queryGraph(Graph graph, String[] vertexIds, String queryString, Authorizations authorizations) {
-        return new DefaultMultiVertexQuery(graph, vertexIds, queryString, authorizations);
+        return new ElasticSearchSingleDocumentSearchMultiVertexQuery(
+                getClient(),
+                graph,
+                vertexIds,
+                queryString,
+                new ElasticSearchSingleDocumentSearchQueryBase.Options()
+                        .setScoringStrategy(getConfig().getScoringStrategy())
+                        .setIndexSelectionStrategy(getIndexSelectionStrategy())
+                        .setPageSize(getConfig().getQueryPageSize())
+                        .setPagingLimit(getConfig().getPagingLimit())
+                        .setScrollKeepAlive(getConfig().getScrollKeepAlive())
+                        .setTermAggregationShardSize(getConfig().getTermAggregationShardSize()),
+                authorizations
+        );
     }
 
     @Override

--- a/elasticsearch5/src/main/java/org/vertexium/elasticsearch5/Elasticsearch5SearchIndex.java
+++ b/elasticsearch5/src/main/java/org/vertexium/elasticsearch5/Elasticsearch5SearchIndex.java
@@ -1400,7 +1400,21 @@ public class Elasticsearch5SearchIndex implements SearchIndex, SearchIndexWithVe
 
     @Override
     public MultiVertexQuery queryGraph(Graph graph, String[] vertexIds, String queryString, Authorizations authorizations) {
-        return new DefaultMultiVertexQuery(graph, vertexIds, queryString, authorizations);
+        return new ElasticsearchSearchMultiVertexQuery(
+                getClient(),
+                graph,
+                vertexIds,
+                queryString,
+                new ElasticsearchSearchQueryBase.Options()
+                        .setScoringStrategy(getConfig().getScoringStrategy())
+                        .setIndexSelectionStrategy(getIndexSelectionStrategy())
+                        .setPageSize(getConfig().getQueryPageSize())
+                        .setPagingLimit(getConfig().getPagingLimit())
+                        .setScrollKeepAlive(getConfig().getScrollKeepAlive())
+                        .setTermAggregationShardSize(getConfig().getTermAggregationShardSize()),
+                authorizations
+        );
+
     }
 
     @Override

--- a/elasticsearch5/src/main/java/org/vertexium/elasticsearch5/ElasticsearchSearchMultiVertexQuery.java
+++ b/elasticsearch5/src/main/java/org/vertexium/elasticsearch5/ElasticsearchSearchMultiVertexQuery.java
@@ -1,0 +1,33 @@
+package org.vertexium.elasticsearch5;
+
+import org.elasticsearch.client.Client;
+import org.vertexium.Authorizations;
+import org.vertexium.Graph;
+import org.vertexium.query.MultiVertexQuery;
+
+public class ElasticsearchSearchMultiVertexQuery extends ElasticsearchSearchGraphQuery implements MultiVertexQuery {
+    public ElasticsearchSearchMultiVertexQuery(
+            Client client,
+            Graph graph,
+            String[] vertexIds,
+            String queryString,
+            Options options,
+            Authorizations authorizations
+    ) {
+        super(client, graph, queryString, options, authorizations);
+        hasId(vertexIds);
+    }
+
+    public ElasticsearchSearchMultiVertexQuery(
+            Client client,
+            Graph graph,
+            String[] vertexIds,
+            String[] similarToFields,
+            String similarToText,
+            Options options,
+            Authorizations authorizations
+    ) {
+        super(client, graph, similarToFields, similarToText, options, authorizations);
+        hasId(vertexIds);
+    }
+}

--- a/elasticsearch5/src/main/java/org/vertexium/elasticsearch5/ElasticsearchSearchQueryBase.java
+++ b/elasticsearch5/src/main/java/org/vertexium/elasticsearch5/ElasticsearchSearchQueryBase.java
@@ -221,6 +221,12 @@ public class ElasticsearchSearchQueryBase extends QueryBase {
             filters.add(QueryBuilders.termsQuery(Elasticsearch5SearchIndex.EDGE_LABEL_FIELD_NAME, edgeLabelsArray));
         }
 
+        if ((elementTypes == null || elementTypes.contains(ElasticsearchDocumentType.EDGE) || elementTypes.contains(ElasticsearchDocumentType.VERTEX))
+                && getParameters().getIds().size() > 0) {
+            String[] idsArray = getParameters().getIds().toArray(new String[getParameters().getIds().size()]);
+            filters.add(QueryBuilders.idsQuery().addIds(idsArray));
+        }
+
         if (getParameters() instanceof QueryStringQueryParameters) {
             String queryString = ((QueryStringQueryParameters) getParameters()).getQueryString();
             if (queryString == null || queryString.equals("*")) {

--- a/elasticsearch5/src/main/java/org/vertexium/elasticsearch5/ElasticsearchSearchVertexQuery.java
+++ b/elasticsearch5/src/main/java/org/vertexium/elasticsearch5/ElasticsearchSearchVertexQuery.java
@@ -106,6 +106,9 @@ public class ElasticsearchSearchVertexQuery extends ElasticsearchSearchQueryBase
         if (otherVertexId != null) {
             edgeInfos = edgeInfos.filter(ei -> ei.getVertexId().equals(otherVertexId));
         }
+        if (getParameters().getIds().size() > 0) {
+            edgeInfos = edgeInfos.filter(ei -> getParameters().getIds().contains(ei.getVertexId()));
+        }
         String[] ids = edgeInfos.map(EdgeInfo::getVertexId).toArray(String[]::new);
 
         if (elementTypes.contains(ElasticsearchDocumentType.VERTEX)) {


### PR DESCRIPTION
This PR adds the ability to filter a query by id, which improves the performance of multivertex queries.

When [running a MultiVertexQuery](https://github.com/visallo/vertexium/blob/master/core/src/main/java/org/vertexium/Graph.java#L760-L777), the [ElasticSearch code was using the DefaultMultiVertexQuery](https://github.com/visallo/vertexium/blob/master/elasticsearch-singledocument/src/main/java/org/vertexium/elasticsearch/ElasticsearchSingleDocumentSearchIndex.java#L1387-L1389) which applies all of the search filters after loading all of the elements. This PR will improve performance by filtering the elements in Elasticsearch before loading them from the datastore.