### PR TITLE
Update the search index properly for hidden elements

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -7,7 +7,8 @@ env:
   - TEST_EXECUTION_PROFILE=accumulo-test
   - TEST_EXECUTION_PROFILE=cypher-test
   - TEST_EXECUTION_PROFILE=elasticsearch-test
-  - TEST_EXECUTION_PROFILE=multimodule-test
+  - TEST_EXECUTION_PROFILE=es17-multimodule-test
+  - TEST_EXECUTION_PROFILE=es5-multimodule-test
 branches:
   only:
     - master

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,7 @@
 * Changed: Reduced DefaultIndexSelectionStrategy cache load time from 1hr to 5min
 * Added: Added a hasId method to the Query class to allow searches to be filtered by element ID.
 * Fix: Extended data element type value for edges
+* Fix: Marking vertices/edges as hidden will now update the document in the search index as well as the data store
 
 # v3.0.0
 * Changed: Removed ES 2 support and replaced it with ES 5 support

--- a/accumulo/src/main/java/org/vertexium/accumulo/AccumuloGraph.java
+++ b/accumulo/src/main/java/org/vertexium/accumulo/AccumuloGraph.java
@@ -644,6 +644,8 @@ public class AccumuloGraph extends GraphBaseWithSearchIndex implements Traceable
 
             addMutations(VertexiumObjectType.VERTEX, getMarkHiddenRowMutation(vertex.getId(), columnVisibility));
 
+            getSearchIndex().markElementHidden(this, vertex, visibility, authorizations);
+
             if (hasEventListeners()) {
                 queueEvent(new MarkHiddenVertexEvent(this, vertex));
             }
@@ -666,6 +668,8 @@ public class AccumuloGraph extends GraphBaseWithSearchIndex implements Traceable
             }
 
             addMutations(VertexiumObjectType.VERTEX, getMarkVisibleRowMutation(vertex.getId(), columnVisibility));
+
+            getSearchIndex().markElementVisible(this, vertex, visibility, authorizations);
 
             if (hasEventListeners()) {
                 queueEvent(new MarkVisibleVertexEvent(this, vertex));
@@ -1171,6 +1175,8 @@ public class AccumuloGraph extends GraphBaseWithSearchIndex implements Traceable
                 ((AccumuloVertex) in).removeInEdge(edge);
             }
 
+            getSearchIndex().markElementHidden(this, edge, visibility, authorizations);
+
             if (hasEventListeners()) {
                 queueEvent(new MarkHiddenEdgeEvent(this, edge));
             }
@@ -1213,6 +1219,8 @@ public class AccumuloGraph extends GraphBaseWithSearchIndex implements Traceable
             if (in instanceof AccumuloVertex) {
                 ((AccumuloVertex) in).addInEdge(edge);
             }
+
+            getSearchIndex().markElementVisible(this, edge, visibility, authorizations);
 
             if (hasEventListeners()) {
                 queueEvent(new MarkVisibleEdgeEvent(this, edge));

--- a/core/src/main/java/org/vertexium/search/DefaultSearchIndex.java
+++ b/core/src/main/java/org/vertexium/search/DefaultSearchIndex.java
@@ -18,6 +18,18 @@ public class DefaultSearchIndex implements SearchIndex {
     }
 
     @Override
+    public void markElementHidden(Graph graph, Element element, Visibility visibility, Authorizations authorizations) {
+        checkNotNull(element, "element cannot be null");
+        checkNotNull(visibility, "visibility cannot be null");
+    }
+
+    @Override
+    public void markElementVisible(Graph graph, Element element, Visibility visibility, Authorizations authorizations) {
+        checkNotNull(element, "element cannot be null");
+        checkNotNull(visibility, "visibility cannot be null");
+    }
+
+    @Override
     public void alterElementVisibility(Graph graph, Element element, Visibility oldVisibility, Visibility newVisibility, Authorizations authorizations) {
         checkNotNull(element, "element cannot be null");
         checkNotNull(newVisibility, "newVisibility cannot be null");

--- a/core/src/main/java/org/vertexium/search/SearchIndex.java
+++ b/core/src/main/java/org/vertexium/search/SearchIndex.java
@@ -14,6 +14,10 @@ public interface SearchIndex {
 
     void deleteElement(Graph graph, Element element, Authorizations authorizations);
 
+    void markElementHidden(Graph graph, Element element, Visibility visibility, Authorizations authorizations);
+
+    void markElementVisible(Graph graph, Element element, Visibility visibility, Authorizations authorizations);
+
     /**
      * Default delete property simply calls deleteProperty in a loop. It is up to the SearchIndex implementation to decide
      * if a collective method can be made more efficient

--- a/elasticsearch-singledocument/src/main/java/org/vertexium/elasticsearch/ElasticSearchSingleDocumentSearchQueryBase.java
+++ b/elasticsearch-singledocument/src/main/java/org/vertexium/elasticsearch/ElasticSearchSingleDocumentSearchQueryBase.java
@@ -49,6 +49,8 @@ import org.vertexium.util.VertexiumLoggerFactory;
 import java.io.IOException;
 import java.util.*;
 
+import static org.vertexium.elasticsearch.ElasticsearchSingleDocumentSearchIndex.HIDDEN_VERTEX_FIELD_NAME;
+
 public class ElasticSearchSingleDocumentSearchQueryBase extends QueryBase {
     private static final VertexiumLogger LOGGER = VertexiumLoggerFactory.getLogger(ElasticSearchSingleDocumentSearchQueryBase.class);
     public static final VertexiumLogger QUERY_LOGGER = VertexiumLoggerFactory.getQueryLogger(Query.class);
@@ -155,6 +157,14 @@ public class ElasticSearchSingleDocumentSearchQueryBase extends QueryBase {
         List<FilterBuilder> filters = new ArrayList<>();
         if (elementTypes != null) {
             addElementTypeFilter(filters, elementTypes);
+        }
+        String[] hiddenVertexPropertyNames = getPropertyNames(HIDDEN_VERTEX_FIELD_NAME);
+        if (hiddenVertexPropertyNames != null && hiddenVertexPropertyNames.length > 0) {
+            BoolFilterBuilder elementIsNotHiddenQuery = FilterBuilders.boolFilter();
+            for (String hiddenVertexPropertyName : hiddenVertexPropertyNames) {
+                elementIsNotHiddenQuery.mustNot(FilterBuilders.existsFilter(hiddenVertexPropertyName));
+            }
+            filters.add(elementIsNotHiddenQuery);
         }
         for (HasContainer has : getParameters().getHasContainers()) {
             if (has instanceof HasValueContainer) {

--- a/elasticsearch5/src/main/java/org/vertexium/elasticsearch5/Elasticsearch5SearchIndex.java
+++ b/elasticsearch5/src/main/java/org/vertexium/elasticsearch5/Elasticsearch5SearchIndex.java
@@ -4,7 +4,6 @@ import com.carrotsearch.hppc.cursors.ObjectCursor;
 import com.google.common.base.Throwables;
 import com.google.common.collect.ImmutableMap;
 import com.google.common.collect.Lists;
-import com.google.common.collect.Maps;
 import com.google.common.util.concurrent.SettableFuture;
 import org.elasticsearch.action.ActionRequestBuilder;
 import org.elasticsearch.action.ListenableActionFuture;
@@ -26,7 +25,7 @@ import org.elasticsearch.client.transport.TransportClient;
 import org.elasticsearch.cluster.health.ClusterHealthStatus;
 import org.elasticsearch.cluster.metadata.MappingMetaData;
 import org.elasticsearch.common.collect.ImmutableOpenMap;
-import org.elasticsearch.common.geo.builders.*;
+import org.elasticsearch.common.geo.builders.CircleBuilder;
 import org.elasticsearch.common.settings.Settings;
 import org.elasticsearch.common.transport.InetSocketTransportAddress;
 import org.elasticsearch.common.xcontent.XContentBuilder;
@@ -83,6 +82,7 @@ public class Elasticsearch5SearchIndex implements SearchIndex, SearchIndexWithVe
     public static final String ELEMENT_TYPE = "element";
     public static final String ELEMENT_TYPE_FIELD_NAME = "__elementType";
     public static final String VISIBILITY_FIELD_NAME = "__visibility";
+    public static final String HIDDEN_VERTEX_FIELD_NAME = "__hidden";
     public static final String OUT_VERTEX_ID_FIELD_NAME = "__outVertexId";
     public static final String IN_VERTEX_ID_FIELD_NAME = "__inVertexId";
     public static final String EDGE_LABEL_FIELD_NAME = "__edgeLabel";
@@ -623,11 +623,53 @@ public class Elasticsearch5SearchIndex implements SearchIndex, SearchIndexWithVe
             throw new VertexiumException("Unexpected element type " + element.getClass().getName());
         }
 
+        for (Visibility hiddenVisibility : element.getHiddenVisibilities()) {
+            String hiddenVisibilityPropertyName = addVisibilityToPropertyName(graph, HIDDEN_VERTEX_FIELD_NAME, hiddenVisibility);
+            if (!isPropertyInIndex(graph, hiddenVisibilityPropertyName)) {
+                String indexName = getIndexName(element);
+                IndexInfo indexInfo = ensureIndexCreatedAndInitialized(graph, indexName);
+                addPropertyToIndex(graph, indexInfo, hiddenVisibilityPropertyName, hiddenVisibility, Boolean.class, false, false, false);
+            }
+            jsonBuilder.field(hiddenVisibilityPropertyName, true);
+        }
+
         Map<String, Object> fields = getPropertiesAsFields(graph, element);
         addFieldsMap(jsonBuilder, fields);
 
         jsonBuilder.endObject();
         return jsonBuilder;
+    }
+
+    @Override
+    public void markElementHidden(Graph graph, Element element, Visibility visibility, Authorizations authorizations) {
+        try {
+            String hiddenVisibilityPropertyName = addVisibilityToPropertyName(graph, HIDDEN_VERTEX_FIELD_NAME, visibility);
+            if (!isPropertyInIndex(graph, hiddenVisibilityPropertyName)) {
+                String indexName = getIndexName(element);
+                IndexInfo indexInfo = ensureIndexCreatedAndInitialized(graph, indexName);
+                addPropertyToIndex(graph, indexInfo, hiddenVisibilityPropertyName, visibility, Boolean.class, false, false, false);
+            }
+
+            XContentBuilder jsonBuilder = XContentFactory.jsonBuilder().startObject();
+            jsonBuilder.field(hiddenVisibilityPropertyName, true);
+            jsonBuilder.endObject();
+
+            getClient()
+                    .prepareUpdate(getIndexName(element), ELEMENT_TYPE, element.getId())
+                    .setDoc(jsonBuilder)
+                    .setRetryOnConflict(MAX_RETRIES)
+                    .get();
+        } catch (IOException e) {
+            throw new VertexiumException("Could not mark element hidden", e);
+        }
+    }
+
+    @Override
+    public void markElementVisible(Graph graph, Element element, Visibility visibility, Authorizations authorizations) {
+        String hiddenVisibilityPropertyName = addVisibilityToPropertyName(graph, HIDDEN_VERTEX_FIELD_NAME, visibility);
+        if (isPropertyInIndex(graph, hiddenVisibilityPropertyName)) {
+            removeFieldsFromDocument(element, hiddenVisibilityPropertyName);
+        }
     }
 
     private String getElementTypeValueFromElement(Element element) {

--- a/elasticsearch5/src/main/java/org/vertexium/elasticsearch5/ElasticsearchSearchQueryBase.java
+++ b/elasticsearch5/src/main/java/org/vertexium/elasticsearch5/ElasticsearchSearchQueryBase.java
@@ -59,6 +59,7 @@ import java.util.regex.Pattern;
 import java.util.stream.Collectors;
 
 import static org.vertexium.elasticsearch5.Elasticsearch5SearchIndex.FIELDNAME_DOT_REPLACEMENT;
+import static org.vertexium.elasticsearch5.Elasticsearch5SearchIndex.HIDDEN_VERTEX_FIELD_NAME;
 
 public class ElasticsearchSearchQueryBase extends QueryBase {
     private static final VertexiumLogger LOGGER = VertexiumLoggerFactory.getLogger(ElasticsearchSearchQueryBase.class);
@@ -201,6 +202,14 @@ public class ElasticsearchSearchQueryBase extends QueryBase {
         List<QueryBuilder> filters = new ArrayList<>();
         if (elementTypes != null) {
             addElementTypeFilter(filters, elementTypes);
+        }
+        String[] hiddenVertexPropertyNames = getPropertyNames(HIDDEN_VERTEX_FIELD_NAME);
+        if (hiddenVertexPropertyNames != null && hiddenVertexPropertyNames.length > 0) {
+            BoolQueryBuilder elementIsNotHiddenQuery = QueryBuilders.boolQuery();
+            for (String hiddenVertexPropertyName : hiddenVertexPropertyNames) {
+                elementIsNotHiddenQuery.mustNot(QueryBuilders.existsQuery(hiddenVertexPropertyName));
+            }
+            filters.add(elementIsNotHiddenQuery);
         }
         for (HasContainer has : getParameters().getHasContainers()) {
             if (has instanceof HasValueContainer) {

--- a/inmemory/src/main/java/org/vertexium/inmemory/InMemoryGraph.java
+++ b/inmemory/src/main/java/org/vertexium/inmemory/InMemoryGraph.java
@@ -230,7 +230,7 @@ public class InMemoryGraph extends GraphBaseWithSearchIndex {
 
         this.vertices.getTableElement(vertex.getId()).appendMarkHiddenMutation(visibility);
         refreshVertexInMemoryTableElement(vertex);
-        getSearchIndex().addElement(this, vertex, authorizations);
+        getSearchIndex().markElementHidden(this, vertex, visibility, authorizations);
 
         if (hasEventListeners()) {
             fireGraphEvent(new MarkHiddenVertexEvent(this, vertex));
@@ -250,7 +250,7 @@ public class InMemoryGraph extends GraphBaseWithSearchIndex {
 
         this.vertices.getTableElement(vertex.getId()).appendMarkVisibleMutation(visibility);
         refreshVertexInMemoryTableElement(vertex);
-        getSearchIndex().addElement(this, vertex, authorizations);
+        getSearchIndex().markElementVisible(this, vertex, visibility, authorizations);
 
         if (hasEventListeners()) {
             fireGraphEvent(new MarkVisibleVertexEvent(this, vertex));
@@ -429,7 +429,7 @@ public class InMemoryGraph extends GraphBaseWithSearchIndex {
         checkNotNull(outVertex, "Could not find out vertex \"" + edge.getVertexId(Direction.OUT) + "\" on edge \"" + edge.getId() + "\"");
 
         this.edges.getTableElement(edge.getId()).appendMarkHiddenMutation(visibility);
-        getSearchIndex().addElement(this, edge, authorizations);
+        getSearchIndex().markElementHidden(this, edge, visibility, authorizations);
 
         if (hasEventListeners()) {
             fireGraphEvent(new MarkHiddenEdgeEvent(this, edge));
@@ -448,7 +448,7 @@ public class InMemoryGraph extends GraphBaseWithSearchIndex {
         checkNotNull(outVertex, "Could not find out vertex \"" + edge.getVertexId(Direction.OUT) + "\" on edge \"" + edge.getId() + "\"");
 
         this.edges.getTableElement(edge.getId()).appendMarkVisibleMutation(visibility);
-        getSearchIndex().addElement(this, edge, authorizations);
+        getSearchIndex().markElementVisible(this, edge, visibility, authorizations);
 
         if (hasEventListeners()) {
             fireGraphEvent(new MarkVisibleEdgeEvent(this, edge));

--- a/pom.xml
+++ b/pom.xml
@@ -532,7 +532,7 @@
             </build>
         </profile>
         <profile>
-            <id>multimodule-test</id>
+            <id>es17-multimodule-test</id>
             <build>
                 <plugins>
                     <plugin>
@@ -541,7 +541,27 @@
                         <configuration>
                             <skipTests>false</skipTests>
                             <includes>
-                                <include>%regex[.*(multimodule).*Test.*]</include>
+                                <include>%regex[.*(multimodule).*ElasticsearchSingleDocumentTest.*]</include>
+                            </includes>
+                            <excludes>
+                                <exclude>%regex[.*(elasticsearch|cypher|accumulo).*]</exclude>
+                            </excludes>
+                        </configuration>
+                    </plugin>
+                </plugins>
+            </build>
+        </profile>
+        <profile>
+            <id>es5-multimodule-test</id>
+            <build>
+                <plugins>
+                    <plugin>
+                        <groupId>org.apache.maven.plugins</groupId>
+                        <artifactId>maven-surefire-plugin</artifactId>
+                        <configuration>
+                            <skipTests>false</skipTests>
+                            <includes>
+                                <include>%regex[.*(multimodule).*Elasticsearch5Test.*]</include>
                             </includes>
                             <excludes>
                                 <exclude>%regex[.*(elasticsearch|cypher|accumulo).*]</exclude>


### PR DESCRIPTION
When the `markVertexHidden`, `markVertexVisible`, `markEdgeHidden`, and `markEdgeVisible` methods of the `Graph` were being called, the search index was not properly being updated to reflect that. 

This change adds/removes a new field named `__hidden` to the search index document to reflect the fact that it has been hidden for a particular visibility.

NOTE: This problem exists for properties as well, but I did not fix it in this PR. I [opened a new issue to track that bug](https://github.com/visallo/vertexium/issues/178).