### PR TITLE
Queue Elasticsearch field removal

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,7 @@
 * Changed: Reduced DefaultIndexSelectionStrategy cache load time from 1hr to 5min
 * Added: Added a hasId method to the Query class to allow searches to be filtered by element ID.
 * Fix: Extended data element type value for edges
+* Changed: Field removal from Elasticsearch documents is now queued as a future instead of immediate
 
 # v3.0.0
 * Changed: Removed ES 2 support and replaced it with ES 5 support

--- a/elasticsearch-singledocument/src/main/java/org/vertexium/elasticsearch/ElasticsearchSingleDocumentSearchIndex.java
+++ b/elasticsearch-singledocument/src/main/java/org/vertexium/elasticsearch/ElasticsearchSingleDocumentSearchIndex.java
@@ -646,7 +646,7 @@ public class ElasticsearchSingleDocumentSearchIndex implements SearchIndex, Sear
     public void markElementVisible(Graph graph, Element element, Visibility visibility, Authorizations authorizations) {
         String hiddenVisibilityPropertyName = addVisibilityToPropertyName(graph, HIDDEN_VERTEX_FIELD_NAME, visibility);
         if (isPropertyInIndex(graph, hiddenVisibilityPropertyName)) {
-            removeFieldsFromDocument(element, hiddenVisibilityPropertyName);
+            removeFieldsFromDocument(graph, element, hiddenVisibilityPropertyName);
         }
     }
 

--- a/elasticsearch-singledocument/src/main/java/org/vertexium/elasticsearch/ElasticsearchSingleDocumentSearchIndex.java
+++ b/elasticsearch-singledocument/src/main/java/org/vertexium/elasticsearch/ElasticsearchSingleDocumentSearchIndex.java
@@ -574,7 +574,7 @@ public class ElasticsearchSingleDocumentSearchIndex implements SearchIndex, Sear
     ) {
         // Remove old element field name
         String oldFieldName = addVisibilityToPropertyName(graph, ELEMENT_TYPE_FIELD_NAME, oldVisibility);
-        removeFieldsFromDocument(element, oldFieldName);
+        removeFieldsFromDocument(graph, element, oldFieldName);
 
         addElement(graph, element, authorizations);
     }
@@ -1332,8 +1332,8 @@ public class ElasticsearchSingleDocumentSearchIndex implements SearchIndex, Sear
     @Override
     public void deleteProperty(Graph graph, Element element, PropertyDescriptor property, Authorizations authorizations) {
         String fieldName = addVisibilityToPropertyName(graph, property.getName(), property.getVisibility());
-        removeFieldsFromDocument(element, fieldName);
-        removeFieldsFromDocument(element, fieldName + "_e");
+        removeFieldsFromDocument(graph, element, fieldName);
+        removeFieldsFromDocument(graph, element, fieldName + "_e");
     }
 
     @Override
@@ -1344,7 +1344,7 @@ public class ElasticsearchSingleDocumentSearchIndex implements SearchIndex, Sear
             fields.add(fieldName);
             fields.add(fieldName + "_e");
         }
-        removeFieldsFromDocument(element, fields);
+        removeFieldsFromDocument(graph, element, fields);
     }
 
     @Override
@@ -1416,10 +1416,11 @@ public class ElasticsearchSingleDocumentSearchIndex implements SearchIndex, Sear
     /**
      * Helper method to remove fields from source. This method will generate a ES update request. Retries on conflict.
      *
+     * @param graph   Graph object configured with the index names
      * @param element Element that can be mapped to an ES document
      * @param fields  fields to remove
      */
-    private void removeFieldsFromDocument(Element element, Collection<String> fields) {
+    private void removeFieldsFromDocument(Graph graph, Element element, Collection<String> fields) {
         String script = "";
         Map<String, Object> params = Maps.newHashMap();
 
@@ -1430,18 +1431,23 @@ public class ElasticsearchSingleDocumentSearchIndex implements SearchIndex, Sear
             params.put(fieldName, field);
         }
 
-        getClient().prepareUpdate()
+        UpdateRequestBuilder updateRequestBuilder = getClient().prepareUpdate()
                 .setIndex(getIndexName(element))
                 .setId(element.getId())
                 .setType(ELEMENT_TYPE)
                 .setScript(script, ScriptService.ScriptType.INLINE)
                 .setRetryOnConflict(MAX_RETRIES)
-                .setScriptParams(params)
-                .get();
+                .setScriptParams(params);
+
+        addActionRequestBuilderForFlush(element.getId(), updateRequestBuilder);
+
+        if (getConfig().isAutoFlush()) {
+            flush(graph);
+        }
     }
 
-    private void removeFieldsFromDocument(Element element, String field) {
-        removeFieldsFromDocument(element, Lists.newArrayList(field));
+    private void removeFieldsFromDocument(Graph graph, Element element, String field) {
+        removeFieldsFromDocument(graph, element, Lists.newArrayList(field));
     }
 
 

--- a/elasticsearch-singledocument/src/test/java/org/vertexium/elasticsearch/ElasticsearchResource.java
+++ b/elasticsearch-singledocument/src/test/java/org/vertexium/elasticsearch/ElasticsearchResource.java
@@ -32,18 +32,20 @@ public class ElasticsearchResource extends ExternalResource {
     private static final VertexiumLogger LOGGER = VertexiumLoggerFactory.getLogger(ElasticsearchResource.class);
 
     private static final String ES_INDEX_NAME = "vertexium-test";
-    private static final String ES_CLUSTER_NAME = "vertexium-test-cluster";
     private static final String ES_EXTENDED_DATA_INDEX_NAME_PREFIX = "vertexium-test-";
     private static final String PLUGIN_CLASS_PATH = "/vertexium-elasticsearch-singledocument-plugin.zip";
 
     private ElasticsearchClusterRunner runner;
+    private String clusterName;
 
     private Map extraConfig = null;
 
-    public ElasticsearchResource() {
+    public ElasticsearchResource(String clusterName) {
+        this.clusterName = clusterName;
     }
 
-    public ElasticsearchResource(Map extraConfig) {
+    public ElasticsearchResource(String clusterName, Map extraConfig) {
+        this.clusterName = clusterName;
         this.extraConfig = extraConfig;
     }
 
@@ -59,7 +61,7 @@ public class ElasticsearchResource extends ExternalResource {
                 builder.put("script.disable_dynamic", "false")
                         .put("gateway.type", "local")
                         .put("index.number_of_shards", "1")
-                        .put("cluster.name", ES_CLUSTER_NAME)
+                        .put("cluster.name", clusterName)
                         .put("index.number_of_replicas", "0")
         ).build(newConfigs().basePath(basePath.getAbsolutePath()).ramIndexStore().numOfNode(1));
 
@@ -94,7 +96,7 @@ public class ElasticsearchResource extends ExternalResource {
         configMap.put(SEARCH_INDEX_PROP_PREFIX + "." + CONFIG_INDEX_NAME, ES_INDEX_NAME);
         configMap.put(SEARCH_INDEX_PROP_PREFIX + "." + CONFIG_EXTENDED_DATA_INDEX_NAME_PREFIX, ES_EXTENDED_DATA_INDEX_NAME_PREFIX);
         configMap.put(SEARCH_INDEX_PROP_PREFIX + "." + STORE_SOURCE_DATA, "true");
-        configMap.put(SEARCH_INDEX_PROP_PREFIX + "." + CLUSTER_NAME, ES_CLUSTER_NAME);
+        configMap.put(SEARCH_INDEX_PROP_PREFIX + "." + CLUSTER_NAME, clusterName);
         configMap.put(SEARCH_INDEX_PROP_PREFIX + "." + ES_LOCATIONS, getLocation());
         configMap.put(SEARCH_INDEX_PROP_PREFIX + "." + NUMBER_OF_SHARDS, 1);
         configMap.put(SEARCH_INDEX_PROP_PREFIX + "." + NUMBER_OF_REPLICAS, 0);

--- a/elasticsearch-singledocument/src/test/java/org/vertexium/elasticsearch/ElasticsearchSingleDocumentSearchIndexTest.java
+++ b/elasticsearch-singledocument/src/test/java/org/vertexium/elasticsearch/ElasticsearchSingleDocumentSearchIndexTest.java
@@ -16,7 +16,7 @@ import static org.vertexium.test.util.VertexiumAssert.assertResultsCount;
 public class ElasticsearchSingleDocumentSearchIndexTest extends ElasticsearchSingleDocumentSearchIndexTestBase {
 
     @ClassRule
-    public static ElasticsearchResource elasticsearchResource = new ElasticsearchResource();
+    public static ElasticsearchResource elasticsearchResource = new ElasticsearchResource(ElasticsearchSingleDocumentSearchIndexTest.class.getName());
 
     @Override
     protected ElasticsearchResource getElasticsearchResource() {

--- a/elasticsearch5/src/main/java/org/vertexium/elasticsearch5/Elasticsearch5SearchIndex.java
+++ b/elasticsearch5/src/main/java/org/vertexium/elasticsearch5/Elasticsearch5SearchIndex.java
@@ -664,7 +664,7 @@ public class Elasticsearch5SearchIndex implements SearchIndex, SearchIndexWithVe
     public void markElementVisible(Graph graph, Element element, Visibility visibility, Authorizations authorizations) {
         String hiddenVisibilityPropertyName = addVisibilityToPropertyName(graph, HIDDEN_VERTEX_FIELD_NAME, visibility);
         if (isPropertyInIndex(graph, hiddenVisibilityPropertyName)) {
-            removeFieldsFromDocument(element, hiddenVisibilityPropertyName);
+            removeFieldsFromDocument(graph, element, hiddenVisibilityPropertyName);
         }
     }
 

--- a/elasticsearch5/src/main/java/org/vertexium/elasticsearch5/Elasticsearch5SearchIndex.java
+++ b/elasticsearch5/src/main/java/org/vertexium/elasticsearch5/Elasticsearch5SearchIndex.java
@@ -590,14 +590,10 @@ public class Elasticsearch5SearchIndex implements SearchIndex, SearchIndexWithVe
             Visibility newVisibility,
             Authorizations authorizations
     ) {
+        // Remove old element field name
         String oldFieldName = addVisibilityToPropertyName(graph, ELEMENT_TYPE_FIELD_NAME, oldVisibility);
-        Script script = new Script(ScriptType.INLINE, "painless", "ctx._source.remove(params.oldFieldName);", ImmutableMap.of("oldFieldName", oldFieldName));
-        getClient().prepareUpdate()
-                .setIndex(getIndexName(element))
-                .setId(element.getId())
-                .setType(ELEMENT_TYPE)
-                .setScript(script)
-                .get();
+        removeFieldsFromDocument(graph, element, oldFieldName);
+
         addElement(graph, element, authorizations);
     }
 
@@ -1351,8 +1347,8 @@ public class Elasticsearch5SearchIndex implements SearchIndex, SearchIndexWithVe
     @Override
     public void deleteProperty(Graph graph, Element element, PropertyDescriptor property, Authorizations authorizations) {
         String fieldName = addVisibilityToPropertyName(graph, property.getName(), property.getVisibility());
-        removeFieldsFromDocument(element, fieldName);
-        removeFieldsFromDocument(element, fieldName + "_e");
+        removeFieldsFromDocument(graph, element, fieldName);
+        removeFieldsFromDocument(graph, element, fieldName + "_e");
     }
 
     @Override
@@ -1363,7 +1359,7 @@ public class Elasticsearch5SearchIndex implements SearchIndex, SearchIndexWithVe
             fields.add(fieldName);
             fields.add(fieldName + "_e");
         }
-        removeFieldsFromDocument(element, fields);
+        removeFieldsFromDocument(graph, element, fields);
     }
 
     @Override
@@ -1432,12 +1428,13 @@ public class Elasticsearch5SearchIndex implements SearchIndex, SearchIndexWithVe
     /**
      * Helper method to remove fields from source. This method will generate a ES update request. Retries on conflict.
      *
+     * @param graph   Graph object configured with the index names
      * @param element Element that can be mapped to an ES document
      * @param fields  fields to remove
      */
-    private void removeFieldsFromDocument(Element element, Collection<String> fields) {
+    private void removeFieldsFromDocument(Graph graph, Element element, Collection<String> fields) {
         List<String> fieldNames = fields.stream().map(field -> field.replace(".", FIELDNAME_DOT_REPLACEMENT)).collect(Collectors.toList());
-        getClient().prepareUpdate()
+        UpdateRequestBuilder updateRequestBuilder = getClient().prepareUpdate()
                 .setIndex(getIndexName(element))
                 .setId(element.getId())
                 .setType(ELEMENT_TYPE)
@@ -1447,12 +1444,17 @@ public class Elasticsearch5SearchIndex implements SearchIndex, SearchIndexWithVe
                         "for (def fieldName : params.fieldNames) { ctx._source.remove(fieldName); }",
                         ImmutableMap.of("fieldNames", fieldNames)
                 ))
-                .setRetryOnConflict(MAX_RETRIES)
-                .get();
+                .setRetryOnConflict(MAX_RETRIES);
+
+        addActionRequestBuilderForFlush(element.getId(), updateRequestBuilder);
+
+        if (getConfig().isAutoFlush()) {
+            flush(graph);
+        }
     }
 
-    private void removeFieldsFromDocument(Element element, String field) {
-        removeFieldsFromDocument(element, Lists.newArrayList(field));
+    private void removeFieldsFromDocument(Graph graph, Element element, String field) {
+        removeFieldsFromDocument(graph, element, Lists.newArrayList(field));
     }
 
     private void flushFlushObjectQueue() {

--- a/elasticsearch5/src/test/java/org/vertexium/elasticsearch5/Elasticsearch5SearchIndexTest.java
+++ b/elasticsearch5/src/test/java/org/vertexium/elasticsearch5/Elasticsearch5SearchIndexTest.java
@@ -28,7 +28,7 @@ import static org.vertexium.util.IterableUtils.count;
 public class Elasticsearch5SearchIndexTest extends GraphTestBase {
 
     @ClassRule
-    public static ElasticsearchResource elasticsearchResource = new ElasticsearchResource();
+    public static ElasticsearchResource elasticsearchResource = new ElasticsearchResource(Elasticsearch5SearchIndexTest.class.getName());
 
     @Override
     protected Authorizations createAuthorizations(String... auths) {

--- a/elasticsearch5/src/test/java/org/vertexium/elasticsearch5/ElasticsearchResource.java
+++ b/elasticsearch5/src/test/java/org/vertexium/elasticsearch5/ElasticsearchResource.java
@@ -29,16 +29,19 @@ public class ElasticsearchResource extends ExternalResource {
     private static final VertexiumLogger LOGGER = VertexiumLoggerFactory.getLogger(ElasticsearchResource.class);
 
     private static final String ES_INDEX_NAME = "vertexium-test";
-    private static final String ES_CLUSTER_NAME = "vertexium-test-cluster";
     private static final String ES_EXTENDED_DATA_INDEX_NAME_PREFIX = "vertexium-test-";
+
     private ElasticsearchClusterRunner runner;
+    private String clusterName;
 
     private Map extraConfig = null;
 
-    public ElasticsearchResource() {
+    public ElasticsearchResource(String clusterName) {
+        this.clusterName = clusterName;
     }
 
-    public ElasticsearchResource(Map extraConfig) {
+    public ElasticsearchResource(String clusterName, Map extraConfig) {
+        this.clusterName = clusterName;
         this.extraConfig = extraConfig;
     }
 
@@ -57,7 +60,7 @@ public class ElasticsearchResource extends ExternalResource {
         runner = new ElasticsearchClusterRunner();
         runner.onBuild((i, builder) ->
                                builder.put("script.inline", "true")
-                                       .put("cluster.name", ES_CLUSTER_NAME)
+                                       .put("cluster.name", clusterName)
                                         .put("http.type", "netty3")
                                         .put("transport.type", "netty3")
         ).build(newConfigs().basePath(basePath.getAbsolutePath()).numOfNode(1));
@@ -111,7 +114,7 @@ public class ElasticsearchResource extends ExternalResource {
         configMap.put(SEARCH_INDEX_PROP_PREFIX, Elasticsearch5SearchIndex.class.getName());
         configMap.put(SEARCH_INDEX_PROP_PREFIX + "." + CONFIG_INDEX_NAME, ES_INDEX_NAME);
         configMap.put(SEARCH_INDEX_PROP_PREFIX + "." + CONFIG_EXTENDED_DATA_INDEX_NAME_PREFIX, ES_EXTENDED_DATA_INDEX_NAME_PREFIX);
-        configMap.put(SEARCH_INDEX_PROP_PREFIX + "." + CLUSTER_NAME, ES_CLUSTER_NAME);
+        configMap.put(SEARCH_INDEX_PROP_PREFIX + "." + CLUSTER_NAME, clusterName);
         configMap.put(SEARCH_INDEX_PROP_PREFIX + "." + ES_LOCATIONS, getLocation());
         configMap.put(SEARCH_INDEX_PROP_PREFIX + "." + NUMBER_OF_SHARDS, 1);
         configMap.put(SEARCH_INDEX_PROP_PREFIX + "." + NUMBER_OF_REPLICAS, 0);

--- a/multimodule-test/accumulo-elasticsearch/src/test/java/org/vertexium/multimodule/AccumuloElasticsearchSingleDocumentTest.java
+++ b/multimodule-test/accumulo-elasticsearch/src/test/java/org/vertexium/multimodule/AccumuloElasticsearchSingleDocumentTest.java
@@ -21,7 +21,7 @@ public class AccumuloElasticsearchSingleDocumentTest extends AccumuloGraphTestBa
     public static final AccumuloResource accumuloResource = new AccumuloResource();
 
     @ClassRule
-    public static final ElasticsearchResource elasticsearchResource = new ElasticsearchResource();
+    public static final ElasticsearchResource elasticsearchResource = new ElasticsearchResource(AccumuloElasticsearchSingleDocumentTest.class.getName());
 
     @Before
     @Override

--- a/multimodule-test/accumulo-elasticsearch5/src/test/java/org/vertexium/multimodule/AccumuloElasticsearch5Test.java
+++ b/multimodule-test/accumulo-elasticsearch5/src/test/java/org/vertexium/multimodule/AccumuloElasticsearch5Test.java
@@ -39,7 +39,7 @@ public class AccumuloElasticsearch5Test extends AccumuloGraphTestBase {
 
 
     @ClassRule
-    public static final ElasticsearchResource elasticsearchResource = new ElasticsearchResource();
+    public static final ElasticsearchResource elasticsearchResource = new ElasticsearchResource(AccumuloElasticsearch5Test.class.getName());
 
     @Before
     @Override

--- a/pom.xml
+++ b/pom.xml
@@ -403,7 +403,6 @@
         <module>kryo-serializer</module>
         <module>xstream-serializer</module>
 
-        <module>multimodule-test</module>
     </modules>
 
     <profiles>
@@ -550,6 +549,9 @@
                     </plugin>
                 </plugins>
             </build>
+            <modules>
+                <module>multimodule-test</module>
+            </modules>
         </profile>
         <profile>
             <id>es5-multimodule-test</id>
@@ -570,6 +572,9 @@
                     </plugin>
                 </plugins>
             </build>
+            <modules>
+                <module>multimodule-test</module>
+            </modules>
         </profile>
     </profiles>
 </project>

--- a/test/src/main/java/org/vertexium/test/GraphTestBase.java
+++ b/test/src/main/java/org/vertexium/test/GraphTestBase.java
@@ -2647,15 +2647,16 @@ public abstract class GraphTestBase {
 
     @Test
     public void testGraphQueryVertexWithVisibilityChange() {
-        graph.prepareVertex("v1", VISIBILITY_A)
+        Vertex v1 = graph.prepareVertex("v1", VISIBILITY_A)
                 .save(AUTHORIZATIONS_A);
         graph.flush();
 
-        Iterable<Vertex> vertices = graph.query(AUTHORIZATIONS_A).vertices();
-        Assert.assertEquals(1, count(vertices));
+        QueryResultsIterable<Vertex> vertices = graph.query(AUTHORIZATIONS_A).vertices();
+        assertResultsCount(1, vertices);
+        assertVertexIds(vertices, v1.getId());
 
         // change to same visibility
-        Vertex v1 = graph.getVertex("v1", AUTHORIZATIONS_A);
+        v1 = graph.getVertex("v1", AUTHORIZATIONS_A);
         v1 = v1.prepareMutation()
                 .alterElementVisibility(VISIBILITY_EMPTY)
                 .save(AUTHORIZATIONS_A);
@@ -2663,7 +2664,19 @@ public abstract class GraphTestBase {
         Assert.assertEquals(VISIBILITY_EMPTY, v1.getVisibility());
 
         vertices = graph.query(AUTHORIZATIONS_A).vertices();
-        Assert.assertEquals(1, count(vertices));
+        assertResultsCount(1, vertices);
+        assertVertexIds(vertices, v1.getId());
+
+        // change to new visibility
+        v1 = graph.getVertex("v1", AUTHORIZATIONS_A);
+        v1.prepareMutation()
+                .alterElementVisibility(VISIBILITY_B)
+                .save(AUTHORIZATIONS_A_AND_B);
+        graph.flush();
+
+        vertices = graph.query(AUTHORIZATIONS_A).vertices();
+        assertResultsCount(0, vertices);
+        assertEquals(0, count(vertices));
     }
 
     @Test


### PR DESCRIPTION
In the Elasticsearch plugins, adding/updating documents to the index is queued as a future but field removal was immediate. This update also queues field removal to avoid timing issues.

In particular, there was a problem in [AccumuloElement#saveExistingElementMutation](https://github.com/visallo/vertexium/blob/14f748037bf3ec0081324f7cff7a483aecc0cfa6/accumulo/src/main/java/org/vertexium/accumulo/AccumuloElement.java#L128) if there were property changes as well as an element visibility update.  The ES document was [updated on this line](https://github.com/visallo/vertexium/blob/14f748037bf3ec0081324f7cff7a483aecc0cfa6/accumulo/src/main/java/org/vertexium/accumulo/AccumuloElement.java#L146). The elementType property was removed and then the ES document was updated again [on this line](https://github.com/visallo/vertexium/blob/14f748037bf3ec0081324f7cff7a483aecc0cfa6/accumulo/src/main/java/org/vertexium/accumulo/AccumuloElement.java#L156). Logically, the order should have been: "update doc", "remove field", "update doc". Because updates were queued and removals weren't, the actual order was _somtimes:_ "remove field", "update doc", "update doc".