### PR TITLE
 Fix Timing Issue and Potential Infinite Loop

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,8 @@
 * Fix: Extended data element type value for edges
 * Changed: Field removal from Elasticsearch documents is now queued as a future instead of immediate
 * Fix: Marking vertices/edges as hidden will now update the document in the search index as well as the data store
+* Fix: Fixed an infinite looping problem in the PagingIterable that may have resulted from a malformed ES document
+* Fix: `Elasticsearch5SearchIndex.removeFieldsFromDocument` will not run the removal script in Elasticsearch if there are no properties to remove
 
 # v3.0.0
 * Changed: Removed ES 2 support and replaced it with ES 5 support

--- a/accumulo/src/main/java/org/vertexium/accumulo/AccumuloElement.java
+++ b/accumulo/src/main/java/org/vertexium/accumulo/AccumuloElement.java
@@ -153,6 +153,7 @@ public abstract class AccumuloElement extends ElementBase implements Serializabl
         );
 
         if (mutation.getNewElementVisibility() != null) {
+            getGraph().flush();
             getGraph().alterElementVisibility((AccumuloElement) mutation.getElement(), mutation.getNewElementVisibility(), authorizations);
         }
 

--- a/accumulo/src/main/java/org/vertexium/accumulo/AccumuloElement.java
+++ b/accumulo/src/main/java/org/vertexium/accumulo/AccumuloElement.java
@@ -153,6 +153,9 @@ public abstract class AccumuloElement extends ElementBase implements Serializabl
         );
 
         if (mutation.getNewElementVisibility() != null) {
+            // Flushing here is important!
+            // The call to graph.saveProperties above will issue an update request to the search index.
+            // If we don't ensure that it has completed first, we run the risk of it re-adding the visibility property we are about to remove.
             getGraph().flush();
             getGraph().alterElementVisibility((AccumuloElement) mutation.getElement(), mutation.getNewElementVisibility(), authorizations);
         }

--- a/accumulo/src/main/java/org/vertexium/accumulo/AccumuloGraph.java
+++ b/accumulo/src/main/java/org/vertexium/accumulo/AccumuloGraph.java
@@ -403,12 +403,14 @@ public class AccumuloGraph extends GraphBaseWithSearchIndex implements Traceable
             propertyDeletes.forEach(p -> propertyList.add(PropertyDescriptor.fromPropertyDeleteMutation(p)));
             propertySoftDeletes.forEach(p -> propertyList.add(PropertyDescriptor.fromPropertySoftDeleteMutation(p)));
 
-            getSearchIndex().deleteProperties(
-                    this,
-                    element,
-                    propertyList,
-                    authorizations
-            );
+            if (!propertyList.isEmpty()) {
+                getSearchIndex().deleteProperties(
+                        this,
+                        element,
+                        propertyList,
+                        authorizations
+                );
+            }
             getSearchIndex().addElement(this, element, authorizations);
         }
 

--- a/elasticsearch-singledocument/src/main/java/org/vertexium/elasticsearch/ElasticsearchSingleDocumentSearchIndex.java
+++ b/elasticsearch-singledocument/src/main/java/org/vertexium/elasticsearch/ElasticsearchSingleDocumentSearchIndex.java
@@ -1464,6 +1464,10 @@ public class ElasticsearchSingleDocumentSearchIndex implements SearchIndex, Sear
      * @param fields  fields to remove
      */
     private void removeFieldsFromDocument(Graph graph, Element element, Collection<String> fields) {
+        if (fields == null || fields.isEmpty()) {
+            return;
+        }
+
         String script = "";
         Map<String, Object> params = Maps.newHashMap();
 

--- a/elasticsearch-singledocument/src/main/java/org/vertexium/elasticsearch/utils/PagingIterable.java
+++ b/elasticsearch-singledocument/src/main/java/org/vertexium/elasticsearch/utils/PagingIterable.java
@@ -67,6 +67,8 @@ public abstract class PagingIterable<T> implements
     private class MyIterator implements Iterator<T> {
         private ElasticSearchGraphQueryIterable<T> firstIterable;
         private long currentResultNumber = 0;
+        private long lastIterableResultNumber = 0;
+        private long lastPageSize = 0;
         private Iterator<T> currentIterator;
 
         public MyIterator(ElasticSearchGraphQueryIterable<T> firstIterable) {
@@ -102,15 +104,17 @@ public abstract class PagingIterable<T> implements
 
         private Iterator<T> getNextIterator() {
             long totalReturned = currentResultNumber - skip;
-            if (totalReturned >= limit || currentResultNumber >= getTotalHits()) {
+            long lastIterableCount = currentResultNumber - lastIterableResultNumber;
+            if (totalReturned >= limit || currentResultNumber >= getTotalHits() || lastIterableCount < lastPageSize) {
                 return null;
             }
-            long nextPageSize = Math.min(pageSize, limit - currentResultNumber);
+            long nextPageSize = lastPageSize = Math.min(pageSize, limit - currentResultNumber);
             if (firstIterable == null) {
                 firstIterable = getPageIterable((int)currentResultNumber, (int)nextPageSize, false);
             }
             Iterator<T> it = firstIterable.iterator();
             firstIterable = null;
+            lastIterableResultNumber = currentResultNumber;
             return it;
         }
 

--- a/elasticsearch5/src/main/java/org/vertexium/elasticsearch5/Elasticsearch5SearchIndex.java
+++ b/elasticsearch5/src/main/java/org/vertexium/elasticsearch5/Elasticsearch5SearchIndex.java
@@ -1475,7 +1475,15 @@ public class Elasticsearch5SearchIndex implements SearchIndex, SearchIndexWithVe
      * @param fields  fields to remove
      */
     private void removeFieldsFromDocument(Graph graph, Element element, Collection<String> fields) {
+        if (fields == null || fields.isEmpty()) {
+            return;
+        }
+
         List<String> fieldNames = fields.stream().map(field -> field.replace(".", FIELDNAME_DOT_REPLACEMENT)).collect(Collectors.toList());
+        if (fieldNames.isEmpty()) {
+            return;
+        }
+
         UpdateRequestBuilder updateRequestBuilder = getClient().prepareUpdate()
                 .setIndex(getIndexName(element))
                 .setId(element.getId())


### PR DESCRIPTION
`PagingIterable`: Fixed an infinite looping problem in the PagingIterable that may have resulted from a malformed ES document.  

`AccumuloElement`: Fixed a timing issue in `AccumuloElement.saveExistingElementMutation` that resulted in an ES document having both the old and new visibility. Since the update `Future`s happen in parallel, it's important to ensure that the removal of the old permission happens after the updating of the properties.

`Elasticsearch5SearchIndex`: Made a small performance improvement in `Elasticsearch5SearchIndex.removeFieldsFromDocument` that will not bother running the script in Elasticsearch if there are no properties to remove.

`ElasticsearchSingleDocumentSearchIndex`: Same improve as described above for `Elasticsearch5SearchIndex`