### PR TITLE
fix version in pom for multi-module test

### DIFF
--- a/multimodule-test/accumulo-elasticsearch/pom.xml
+++ b/multimodule-test/accumulo-elasticsearch/pom.xml
@@ -5,7 +5,7 @@
     <parent>
         <groupId>org.vertexium</groupId>
         <artifactId>vertexium-multimodule-test</artifactId>
-        <version>3.0.1-SNAPSHOT</version>
+        <version>3.0.2-SNAPSHOT</version>
     </parent>
 
     <artifactId>vertexium-accumulo-elasticsearch-multimodule-test</artifactId>

--- a/multimodule-test/accumulo-elasticsearch5/pom.xml
+++ b/multimodule-test/accumulo-elasticsearch5/pom.xml
@@ -5,7 +5,7 @@
     <parent>
         <groupId>org.vertexium</groupId>
         <artifactId>vertexium-multimodule-test</artifactId>
-        <version>3.0.1-SNAPSHOT</version>
+        <version>3.0.2-SNAPSHOT</version>
     </parent>
 
     <artifactId>vertexium-accumulo-elasticsearch5-multimodule-test</artifactId>

--- a/multimodule-test/pom.xml
+++ b/multimodule-test/pom.xml
@@ -5,7 +5,7 @@
     <parent>
         <groupId>org.vertexium</groupId>
         <artifactId>vertexium-root</artifactId>
-        <version>3.0.1-SNAPSHOT</version>
+        <version>3.0.2-SNAPSHOT</version>
     </parent>
 
     <artifactId>vertexium-multimodule-test</artifactId>


### PR DESCRIPTION
We missed the multi-test module poms when releasing vertexium 3.0.1. Might be because the multi-test modules are not enabled by default, they are enabled by a profile.