### PR TITLE
Fix Queries with Query String and Aggregations

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,7 @@
 * Added: Added a has method to the Query class to allow searches on all properties of a particular data type.
 * Added: Added a has method to the Query class to allow searches for a value across multiple properties.
 * Added: Implemented support all compare operators for DateOnly field types when using Elasticsearch 5.
+* Fixed: Queries with both a query string and aggregations were throwing a "not implemented" exception in the Elasticsearch 5 plugin. 
 
 # v3.0.1
 * Changed: Find Path to not return a path that contains one or more vertices that is can't be retrieved because of visibility restrictions

--- a/elasticsearch5-plugin/src/main/java/org/vertexium/elasticsearch5/plugin/VertexiumQueryStringQueryBuilder.java
+++ b/elasticsearch5-plugin/src/main/java/org/vertexium/elasticsearch5/plugin/VertexiumQueryStringQueryBuilder.java
@@ -10,6 +10,7 @@ import org.elasticsearch.index.query.QueryStringQueryBuilder;
 
 import java.io.IOException;
 import java.util.Map;
+import java.util.Objects;
 import java.util.Optional;
 
 public class VertexiumQueryStringQueryBuilder extends QueryStringQueryBuilder {
@@ -25,12 +26,22 @@ public class VertexiumQueryStringQueryBuilder extends QueryStringQueryBuilder {
 
     @Override
     protected void doWriteTo(StreamOutput out) throws IOException {
-        throw new RuntimeException("not implemented");
+        super.doWriteTo(out);
+        out.writeStringArray(authorizations);
     }
 
     @Override
     protected void doXContent(XContentBuilder builder, Params params) throws IOException {
-        throw new RuntimeException("not implemented");
+        builder.startObject("vertexium_query_string");
+        super.doXContent(builder, params);
+
+        builder.startArray("authorizations");
+        for (String authorization : authorizations) {
+            builder.value(authorization);
+        }
+        builder.endArray();
+
+        builder.endObject();
     }
 
     @Override
@@ -41,12 +52,14 @@ public class VertexiumQueryStringQueryBuilder extends QueryStringQueryBuilder {
 
     @Override
     protected boolean doEquals(QueryStringQueryBuilder other) {
-        throw new RuntimeException("not implemented");
+        return other instanceof VertexiumQueryStringQueryBuilder &&
+                super.doEquals(other) &&
+                Objects.deepEquals(this.authorizations, ((VertexiumQueryStringQueryBuilder)other).authorizations);
     }
 
     @Override
     protected int doHashCode() {
-        throw new RuntimeException("not implemented");
+        return Objects.hash(super.doHashCode(), authorizations);
     }
 
     @Override

--- a/elasticsearch5/src/main/java/org/vertexium/elasticsearch5/VertexiumQueryStringQueryBuilder.java
+++ b/elasticsearch5/src/main/java/org/vertexium/elasticsearch5/VertexiumQueryStringQueryBuilder.java
@@ -10,6 +10,7 @@ import org.vertexium.Authorizations;
 import org.vertexium.VertexiumException;
 
 import java.io.IOException;
+import java.util.Objects;
 
 public class VertexiumQueryStringQueryBuilder extends QueryStringQueryBuilder {
     public static final String NAME = "vertexium_query_string";
@@ -51,12 +52,14 @@ public class VertexiumQueryStringQueryBuilder extends QueryStringQueryBuilder {
 
     @Override
     protected boolean doEquals(QueryStringQueryBuilder other) {
-        throw new VertexiumException("not implemented");
+        return other instanceof VertexiumQueryStringQueryBuilder &&
+                super.doEquals(other) &&
+                Objects.deepEquals(this.authorizations, ((VertexiumQueryStringQueryBuilder)other).authorizations);
     }
 
     @Override
     protected int doHashCode() {
-        throw new VertexiumException("not implemented");
+        return Objects.hash(super.doHashCode(), authorizations);
     }
 
     @Override


### PR DESCRIPTION
When executing a query with both a query string and aggregations, the ES5 plugin was failing by throwing a "not implemented" exception in it's doWriteTo method. This method was being called on the server side when ES5 was trying to cache the shard level results. 

I added a new test to demonstrate the error and after fleshing out the methods on the ES5 plugin it is now passing.