### PR TITLE
Additional Multi-Property Query Methods

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,7 +1,10 @@
 # v3.0.2
 * Fixed: Elasticsearch5 throwing unsupported operation exception when adding/updating a property
 * Added: Added a has method to the Query class to allow searches on all properties of a particular data type.
+* Added: Added a has method to the Query class to allow searches for any elements with/without a property of a particular data type.
 * Added: Added a has method to the Query class to allow searches for a value across multiple properties.
+* Added: Added a has method to the Query class to allow searches for a elements with a list of properties. The presence of any property in the list will cause the document to match.
+* Added: Added a has method to the Query class to allow searches for a elements without a list of properties. The absence of all properties in the list will cause the document to match.
 * Added: Implemented support all compare operators for DateOnly field types when using Elasticsearch 5.
 * Fixed: Queries with both a query string and aggregations were throwing a "not implemented" exception in the Elasticsearch 5 plugin. 
 

--- a/core/src/main/java/org/vertexium/query/CompositeGraphQuery.java
+++ b/core/src/main/java/org/vertexium/query/CompositeGraphQuery.java
@@ -290,6 +290,38 @@ public class CompositeGraphQuery implements Query {
     }
 
     @Override
+    public <T> Query has(Class dataType) {
+        for (Query query : queries) {
+            query.has(dataType);
+        }
+        return this;
+    }
+
+    @Override
+    public <T> Query hasNot(Class dataType) {
+        for (Query query : queries) {
+            query.hasNot(dataType);
+        }
+        return this;
+    }
+
+    @Override
+    public <T> Query has(Iterable<String> propertyNames) {
+        for (Query query : queries) {
+            query.has(propertyNames);
+        }
+        return this;
+    }
+
+    @Override
+    public <T> Query hasNot(Iterable<String> propertyNames) {
+        for (Query query : queries) {
+            query.hasNot(propertyNames);
+        }
+        return this;
+    }
+
+    @Override
     public <T> Query has(Iterable<String> propertyNames, Predicate predicate, T value) {
         for (Query query : queries) {
             query.has(propertyNames, predicate, value);

--- a/core/src/main/java/org/vertexium/query/Query.java
+++ b/core/src/main/java/org/vertexium/query/Query.java
@@ -158,12 +158,28 @@ public interface Query {
     Query has(String propertyName);
 
     /**
+     * Adds a filter to the query.
+     *
+     * @param propertyNames A document will match if it contains any properties specified.
+     * @return The query object, allowing you to chain methods.
+     */
+    <T> Query has(Iterable<String> propertyNames);
+
+    /**
      * Adds a hasNot filter to the query.
      *
      * @param propertyName The name of the property the element must not contain.
      * @return The query object, allowing you to chain methods.
      */
     Query hasNot(String propertyName);
+
+    /**
+     * Adds a filter to the query.
+     *
+     * @param propertyNames A document will match if it does not contain any properties specified.
+     * @return The query object, allowing you to chain methods.
+     */
+    <T> Query hasNot(Iterable<String> propertyNames);
 
     /**
      * Adds a filter to the query.
@@ -200,6 +216,23 @@ public interface Query {
      * @return The query object, allowing you to chain methods.
      */
     <T> Query has(Class dataType, Predicate predicate, T value);
+
+
+    /**
+     * Adds a has filter to the query.
+     *
+     * @param dataType A document will match if it contains any properties of the specified datatype.
+     * @return The query object, allowing you to chain methods.
+     */
+    <T> Query has(Class dataType);
+
+    /**
+     * Adds a hasNot filter to the query.
+     *
+     * @param dataType A document will match if it does not contain any properties of the specified datatype.
+     * @return The query object, allowing you to chain methods.
+     */
+    <T> Query hasNot(Class dataType);
 
     /**
      * Skips the given number of items.


### PR DESCRIPTION
1. Added `Query.has(Datatype.class)`
1. Added `Query.hasNot(Datatype.class)`
1. Added `Query.has(Iterable<String> propertyNames)`
1. Added `Query.hasNot(Iterable<String> propertyNames)`

As I was updating all of the has containers to support multiple property names, I realized the there was no need for a `MultiPropertyHasValueContainer` so I combined that with the regular `HasValueContainer`.