### PR TITLE
fix pagination returning duplicate ids on different pages (3.0.4)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,6 @@
 # v3.0.4
 * Fixed: Infinite loop in PagingIterable if Elasticsearch returned vertices that wasn't saved in the database yet
+* Fixed: Pagination returning duplicate ids on different pages by adding default sort by score and then id. If sorts are specified, sort by score and then id after specified sorts. If sorts are not specified, sort by score and then id.
 
 # v3.0.3
 * Added: Added a hasAuthorization method to the Query class to allow searches for any element that uses an authorization string or strings.

--- a/elasticsearch5/src/main/java/org/vertexium/elasticsearch5/ElasticsearchSearchQueryBase.java
+++ b/elasticsearch5/src/main/java/org/vertexium/elasticsearch5/ElasticsearchSearchQueryBase.java
@@ -264,10 +264,12 @@ public class ElasticsearchSearchQueryBase extends QueryBase {
     }
 
     protected void applySort(SearchRequestBuilder q) {
+        boolean sortedById = false;
         for (SortContainer sortContainer : getParameters().getSortContainers()) {
             SortOrder esOrder = sortContainer.direction == SortDirection.ASCENDING ? SortOrder.ASC : SortOrder.DESC;
             if (Element.ID_PROPERTY_NAME.equals(sortContainer.propertyName)) {
                 q.addSort("_uid", esOrder);
+                sortedById = true;
             } else if (Edge.LABEL_PROPERTY_NAME.equals(sortContainer.propertyName)) {
                 q.addSort(Elasticsearch5SearchIndex.EDGE_LABEL_FIELD_NAME, esOrder);
             } else {
@@ -308,6 +310,11 @@ public class ElasticsearchSearchQueryBase extends QueryBase {
                     q.addSort(sortField, esOrder);
                 }
             }
+        }
+        q.addSort("_score", SortOrder.DESC);
+        if (!sortedById) {
+            // If an id sort isn't specified, default is to sort by score and then sort id by ascending order after specified sorts
+            q.addSort("_uid", SortOrder.ASC);
         }
     }
 

--- a/inmemory/src/main/java/org/vertexium/inmemory/InMemoryTable.java
+++ b/inmemory/src/main/java/org/vertexium/inmemory/InMemoryTable.java
@@ -7,8 +7,10 @@ import org.vertexium.util.LookAheadIterable;
 
 import java.util.EnumSet;
 import java.util.Iterator;
+import java.util.LinkedHashMap;
 import java.util.Map;
 import java.util.concurrent.ConcurrentSkipListMap;
+import java.util.stream.Collectors;
 
 public abstract class InMemoryTable<TElement extends InMemoryElement> {
     private Map<String, InMemoryTableElement<TElement>> rows;
@@ -38,6 +40,11 @@ public abstract class InMemoryTable<TElement extends InMemoryElement> {
         if (inMemoryTableElement == null) {
             inMemoryTableElement = createInMemoryTableElement(id);
             rows.put(id, inMemoryTableElement);
+            // Sort rows by id in ascending order
+            rows = rows.entrySet().stream()
+                    .sorted(Map.Entry.comparingByKey())
+                    .collect(Collectors.toMap(Map.Entry::getKey, Map.Entry::getValue,
+                            (oldValue, newValue) -> oldValue, LinkedHashMap::new));
         }
         inMemoryTableElement.addAll(newMutations);
     }

--- a/test/src/main/java/org/vertexium/test/GraphTestBase.java
+++ b/test/src/main/java/org/vertexium/test/GraphTestBase.java
@@ -1866,6 +1866,44 @@ public abstract class GraphTestBase {
     }
 
     @Test
+    public void testGraphQueryPagingForUniqueIdsSortedOrder() {
+        String namePropertyName = "first.name";
+        graph.defineProperty(namePropertyName).dataType(String.class).sortable(true).textIndexHint(TextIndexHint.ALL).define();
+
+        graph.prepareVertex("v1", VISIBILITY_A)
+                .addPropertyValue("k1", namePropertyName, "B", VISIBILITY_A)
+                .save(AUTHORIZATIONS_A);
+        graph.prepareVertex("v2", VISIBILITY_A)
+                .addPropertyValue("k1", namePropertyName, "A", VISIBILITY_A)
+                .save(AUTHORIZATIONS_A);
+        graph.prepareVertex("v3", VISIBILITY_A)
+                .addPropertyValue("k1", namePropertyName, "C", VISIBILITY_A)
+                .save(AUTHORIZATIONS_A);
+        graph.flush();
+
+        QueryResultsIterable<String> idsIterable = graph.query(AUTHORIZATIONS_A).skip(0).limit(1).vertexIds();
+        assertIdsAnyOrder(idsIterable, "v1");
+        assertResultsCount(1, 3, idsIterable);
+
+        idsIterable = graph.query(AUTHORIZATIONS_A).skip(1).limit(1).vertexIds();
+        assertIdsAnyOrder(idsIterable, "v2");
+
+        idsIterable = graph.query(AUTHORIZATIONS_A).skip(2).limit(1).vertexIds();
+        assertIdsAnyOrder(idsIterable, "v3");
+
+        idsIterable = graph.query(AUTHORIZATIONS_A).sort(namePropertyName, SortDirection.DESCENDING).vertexIds();
+        assertResultsCount(3, 3, idsIterable);
+
+        List<Vertex> vertices = toList(graph.query(AUTHORIZATIONS_A)
+                .sort(namePropertyName, SortDirection.ASCENDING)
+                .skip(0)
+                .limit(1)
+                .vertices());
+        assertEquals(1, vertices.size());
+        assertEquals("v2", vertices.get(0).getId());
+    }
+
+    @Test
     public void testGraphQueryForIds() {
         String namePropertyName = "first.name";
         Vertex v1 = graph.prepareVertex("v1", VISIBILITY_A)


### PR DESCRIPTION
Note: We will probably have to change this when we upgrade to ES 6 (https://www.elastic.co/guide/en/elasticsearch/reference/current/mapping-id-field.html)