### PR TITLE
Fixed: Elasticsearch flush overflow causing excessive exceptions

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,7 @@
 
 # v3.0.4
 * Fixed: Infinite loop in PagingIterable if Elasticsearch returned vertices that wasn't saved in the database yet
+* Fixed: Elasticsearch flush overflow causing excessive exceptions
 
 # v3.0.3
 * Changed: Accumulo default data storage to use in table storage and not overflow to HDFS 


### PR DESCRIPTION
If many items in the flush queue get backed up and hit the retry limit at the same
time the queue can get overflowed with items and continue to cause exceptions
on subseqent calls to flush.