### PR TITLE
Fixed: Elasticsearch flush overflow causing excessive exceptions

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,6 @@
 # v3.0.4
 * Fixed: Infinite loop in PagingIterable if Elasticsearch returned vertices that wasn't saved in the database yet
+* Fixed: Elasticsearch flush overflow causing excessive exceptions
 
 # v3.0.3
 * Added: Added a hasAuthorization method to the Query class to allow searches for any element that uses an authorization string or strings.


### PR DESCRIPTION
If many items in the flush queue get backed up and hit the retry limit at the same
time the queue can get overflowed with items and continue to cause exceptions
on subseqent calls to flush.