### PR TITLE
fix pagination returning duplicate ids on different pages

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,7 @@
 
 # v3.0.4
 * Fixed: Infinite loop in PagingIterable if Elasticsearch returned vertices that wasn't saved in the database yet
+* Fixed: Pagination returning duplicate ids on different pages by adding default sort by score and then id. If sorts are specified, sort by score and then id after specified sorts. If sorts are not specified, sort by score and then id.
 
 # v3.0.3
 * Changed: Accumulo default data storage to use in table storage and not overflow to HDFS 

--- a/elasticsearch5/src/main/java/org/vertexium/elasticsearch5/ElasticsearchSearchQueryBase.java
+++ b/elasticsearch5/src/main/java/org/vertexium/elasticsearch5/ElasticsearchSearchQueryBase.java
@@ -264,10 +264,12 @@ public class ElasticsearchSearchQueryBase extends QueryBase {
     }
 
     protected void applySort(SearchRequestBuilder q) {
+        boolean sortedById = false;
         for (SortContainer sortContainer : getParameters().getSortContainers()) {
             SortOrder esOrder = sortContainer.direction == SortDirection.ASCENDING ? SortOrder.ASC : SortOrder.DESC;
             if (Element.ID_PROPERTY_NAME.equals(sortContainer.propertyName)) {
                 q.addSort("_uid", esOrder);
+                sortedById = true;
             } else if (Edge.LABEL_PROPERTY_NAME.equals(sortContainer.propertyName)) {
                 q.addSort(Elasticsearch5SearchIndex.EDGE_LABEL_FIELD_NAME, esOrder);
             } else {
@@ -308,6 +310,11 @@ public class ElasticsearchSearchQueryBase extends QueryBase {
                     q.addSort(sortField, esOrder);
                 }
             }
+        }
+        q.addSort("_score", SortOrder.DESC);
+        if (!sortedById) {
+            // If an id sort isn't specified, default is to sort by score and then sort id by ascending order after specified sorts
+            q.addSort("_uid", SortOrder.ASC);
         }
     }
 


### PR DESCRIPTION
Let's try this again. Please let travis finish running before merging. Running into weird issues where test pass locally but not in Travis.

NOTE: With this new fix, I made ids sorted ascending order instead of descending order in ES
