### PR TITLE
Fixed: Elasticsearch5 retry logic to sleep per request failure instead of batch of failures

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,7 @@
 * Added: Sorting and aggregating of row ids and table names
 * Added: Option to execute a script from the shell
 * Fixed: Streaming property value input stream from data table
+* Fixed: Elasticsearch5 retry logic to sleep per request failure instead of batch of failures
 * Removed: ElasticSearch 1.x support
 
 # v3.0.4


### PR DESCRIPTION
Before this change ES5 could get into a state where large batches would fail again and again because the retry logic would try a batch, sleep, then try the whole batch again, which would typically fail. This change makes it so that a batch is tried, if any of those requests in the batch fails the time between requests will be increased until the requests no longer fail.