### PR TITLE
Fixed: Mixed case searching on exact match properties

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,7 @@
 * Added: Option to execute a script from the shell
 * Fixed: Streaming property value input stream from data table
 * Fixed: Elasticsearch5 retry logic to sleep per request failure instead of batch of failures
+* Fixed: Mixed case searching on exact match properties
 * Removed: ElasticSearch 1.x support
 
 # v3.0.4

--- a/core/src/main/java/org/vertexium/query/Compare.java
+++ b/core/src/main/java/org/vertexium/query/Compare.java
@@ -109,6 +109,13 @@ public enum Compare implements Predicate {
             second = ((StreamingPropertyValue) second).readToString();
         }
 
+        if (first instanceof String) {
+            first = ((String) first).toLowerCase();
+        }
+        if (second instanceof String) {
+            second = ((String) second).toLowerCase();
+        }
+
         if (first instanceof Long && second instanceof Long) {
             long firstLong = (long) first;
             long secondLong = (long) second;


### PR DESCRIPTION
ES keyword fields fail to be found if the case did not match perfectly. This changes allows for case insensitive searching of exact match fields