### PR TITLE
Fixed: Accumulo stream property value in table data length of reference

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,6 @@
+# v3.1.2
+* Fixed: Accumulo stream property value in table data length of reference
+
 # v3.1.1
 * Added: Graph.getExtendedData to get a single extended data row
 * Fixed: InMemory update extended data with different value

--- a/accumulo/src/main/java/org/vertexium/accumulo/StreamingPropertyValueTableDataRef.java
+++ b/accumulo/src/main/java/org/vertexium/accumulo/StreamingPropertyValueTableDataRef.java
@@ -16,11 +16,11 @@ public class StreamingPropertyValueTableDataRef extends StreamingPropertyValueRe
         length = null;
     }
 
-    public StreamingPropertyValueTableDataRef(String dataRowKey, StreamingPropertyValue propertyValue) {
+    public StreamingPropertyValueTableDataRef(String dataRowKey, StreamingPropertyValue propertyValue, long length) {
         super(propertyValue);
         this.dataRowKey = dataRowKey;
-        valueType = propertyValue.getValueType();
-        length = propertyValue.getLength();
+        this.valueType = propertyValue.getValueType();
+        this.length = length;
     }
 
     @Override

--- a/accumulo/src/main/java/org/vertexium/accumulo/util/DataInDataTableStreamingPropertyValueStorageStrategy.java
+++ b/accumulo/src/main/java/org/vertexium/accumulo/util/DataInDataTableStreamingPropertyValueStorageStrategy.java
@@ -63,7 +63,7 @@ public class DataInDataTableStreamingPropertyValueStorageStrategy implements Str
             dataMutation.put(METADATA_COLUMN_FAMILY, METADATA_LENGTH_COLUMN_QUALIFIER, property.getTimestamp(), new Value(Longs.toByteArray(offset)));
             elementMutationBuilder.saveDataMutation(dataMutation);
 
-            return new StreamingPropertyValueTableDataRef(dataTableRowKey, streamingPropertyValue);
+            return new StreamingPropertyValueTableDataRef(dataTableRowKey, streamingPropertyValue, offset);
         } catch (Exception ex) {
             throw new VertexiumException("Could not store streaming property value", ex);
         }

--- a/core/src/main/java/org/vertexium/property/StreamingPropertyValue.java
+++ b/core/src/main/java/org/vertexium/property/StreamingPropertyValue.java
@@ -45,8 +45,8 @@ public abstract class StreamingPropertyValue extends PropertyValue implements Se
         return new DefaultStreamingPropertyValue(data, String.class);
     }
 
-    public static StreamingPropertyValue create(InputStream inputStream, Class type, Integer length) {
-        return new DefaultStreamingPropertyValue(inputStream, type, length == null ? null : (long) length);
+    public static StreamingPropertyValue create(InputStream inputStream, Class type, Long length) {
+        return new DefaultStreamingPropertyValue(inputStream, type, length);
     }
 
     public static StreamingPropertyValue create(InputStream inputStream, Class type) {

--- a/test/src/main/java/org/vertexium/test/GraphTestBase.java
+++ b/test/src/main/java/org/vertexium/test/GraphTestBase.java
@@ -186,7 +186,7 @@ public abstract class GraphTestBase {
     @Test
     public void testAddStreamingPropertyValue() throws IOException, InterruptedException {
         String expectedLargeValue = IOUtils.toString(new LargeStringInputStream(LARGE_PROPERTY_VALUE_SIZE));
-        PropertyValue propSmall = StreamingPropertyValue.create(new ByteArrayInputStream("value1".getBytes()), String.class, 6);
+        PropertyValue propSmall = StreamingPropertyValue.create(new ByteArrayInputStream("value1".getBytes()), String.class, 6L);
         PropertyValue propLarge = StreamingPropertyValue.create(
                 new ByteArrayInputStream(expectedLargeValue.getBytes()),
                 String.class,
@@ -275,7 +275,7 @@ public abstract class GraphTestBase {
         PropertyValue propLarge = StreamingPropertyValue.create(
                 new ByteArrayInputStream(expectedValue.getBytes()),
                 String.class,
-                expectedValue.length()
+                (long) expectedValue.length()
         );
         graph.prepareVertex("v1", VISIBILITY_A)
                 .addPropertyValue("key1", "largeProp", propLarge, metadata, timestamp, VISIBILITY_A)
@@ -291,7 +291,7 @@ public abstract class GraphTestBase {
         propLarge = StreamingPropertyValue.create(
                 new ByteArrayInputStream(expectedValue.getBytes()),
                 String.class,
-                expectedValue.length()
+                (long) expectedValue.length()
         );
         graph.prepareVertex("v1", VISIBILITY_A)
                 .addPropertyValue("key1", "largeProp", propLarge, metadata, timestamp + 1, VISIBILITY_A)

--- a/test/src/main/java/org/vertexium/test/GraphTestBase.java
+++ b/test/src/main/java/org/vertexium/test/GraphTestBase.java
@@ -190,7 +190,7 @@ public abstract class GraphTestBase {
         PropertyValue propLarge = StreamingPropertyValue.create(
                 new ByteArrayInputStream(expectedLargeValue.getBytes()),
                 String.class,
-                expectedLargeValue.length()
+                null
         );
         String largePropertyName = "propLarge/\\*!@#$%^&*()[]{}|";
         Vertex v1 = graph.prepareVertex("v1", VISIBILITY_A)
@@ -4480,8 +4480,11 @@ public abstract class GraphTestBase {
 
         Vertex v1 = graph.getVertex("v1", AUTHORIZATIONS_A_AND_B);
         StreamingPropertyValue spvA = (StreamingPropertyValue) v1.getPropertyValue("a");
+        assertEquals(12L, (long) spvA.getLength());
         StreamingPropertyValue spvB = (StreamingPropertyValue) v1.getPropertyValue("b");
+        assertEquals(12L, (long) spvA.getLength());
         StreamingPropertyValue spvC = (StreamingPropertyValue) v1.getPropertyValue("c");
+        assertEquals(12L, (long) spvA.getLength());
         ArrayList<StreamingPropertyValue> spvs = Lists.newArrayList(spvA, spvB, spvC);
         List<InputStream> streams = graph.getStreamingPropertyValueInputStreams(spvs);
         assertEquals("Test Value A", IOUtils.toString(streams.get(0)));


### PR DESCRIPTION
Users of `getLength` should still check null lengths though.