### PR TITLE
Update Query to Respect FetchHint.INCLUDE_HIDDEN

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,8 @@
 # v3.1.2
 * Fixed: Find path when edge labels are deflated
 * Fixed: Accumulo stream property value in table data length of reference
+* Fixed: Query will now return hidden elements/vertices/edges if FetchHint.INCLUDE_HIDDEN is passed
+* Added: Query methods elementIds/vertexIds/edgeIds are overloaded to accept IdFetchHint, which makes it possible to include ids for hidden elements
 
 # v3.1.1
 * Added: Graph.getExtendedData to get a single extended data row

--- a/core/src/main/java/org/vertexium/IdFetchHint.java
+++ b/core/src/main/java/org/vertexium/IdFetchHint.java
@@ -1,0 +1,14 @@
+package org.vertexium;
+
+import java.util.EnumSet;
+
+public enum IdFetchHint {
+    INCLUDE_HIDDEN;
+
+    public static final EnumSet<IdFetchHint> NONE = EnumSet.noneOf(IdFetchHint.class);
+    public static final EnumSet<IdFetchHint> ALL_INCLUDING_HIDDEN = EnumSet.allOf(IdFetchHint.class);
+
+    public static EnumSet<FetchHint> toFetchHints(EnumSet<IdFetchHint> idFetchHints) {
+        return idFetchHints.contains(IdFetchHint.INCLUDE_HIDDEN) ? EnumSet.of(FetchHint.INCLUDE_HIDDEN) : FetchHint.NONE;
+    }
+}

--- a/core/src/main/java/org/vertexium/query/EmptyResultsGraphQuery.java
+++ b/core/src/main/java/org/vertexium/query/EmptyResultsGraphQuery.java
@@ -26,6 +26,11 @@ public class EmptyResultsGraphQuery implements Query {
     }
 
     @Override
+    public QueryResultsIterable<String> vertexIds(EnumSet<IdFetchHint> idFetchHints) {
+        return new EmptyResultsQueryResultsIterable<>();
+    }
+
+    @Override
     public QueryResultsIterable<Edge> edges() {
         return new EmptyResultsQueryResultsIterable<>();
     }
@@ -37,6 +42,11 @@ public class EmptyResultsGraphQuery implements Query {
 
     @Override
     public QueryResultsIterable<String> edgeIds() {
+        return new EmptyResultsQueryResultsIterable<>();
+    }
+
+    @Override
+    public QueryResultsIterable<String> edgeIds(EnumSet<IdFetchHint> idFetchHints) {
         return new EmptyResultsQueryResultsIterable<>();
     }
 
@@ -68,6 +78,11 @@ public class EmptyResultsGraphQuery implements Query {
     }
 
     @Override
+    public QueryResultsIterable<String> elementIds(EnumSet<IdFetchHint> idFetchHints) {
+        return new EmptyResultsQueryResultsIterable<>();
+    }
+
+    @Override
     public QueryResultsIterable<ExtendedDataRow> extendedDataRows() {
         return new EmptyResultsQueryResultsIterable<>();
     }
@@ -79,6 +94,11 @@ public class EmptyResultsGraphQuery implements Query {
 
     @Override
     public QueryResultsIterable<ExtendedDataRowId> extendedDataRowIds() {
+        return new EmptyResultsQueryResultsIterable<>();
+    }
+
+    @Override
+    public QueryResultsIterable<ExtendedDataRowId> extendedDataRowIds(EnumSet<IdFetchHint> idFetchHints) {
         return new EmptyResultsQueryResultsIterable<>();
     }
 

--- a/core/src/main/java/org/vertexium/query/Query.java
+++ b/core/src/main/java/org/vertexium/query/Query.java
@@ -10,19 +10,75 @@ public interface Query {
 
     QueryResultsIterable<Vertex> vertices(EnumSet<FetchHint> fetchHints);
 
+    /**
+     * Execute the query and return the ids of all matching vertices.
+     * This method will not load the data from storage, which is more
+     * efficient in cases where you only need to know the ids of matching vertices.
+     * Hidden vertices are not included in the results.
+     *
+     * @return The ids of vertices that match this query.
+     */
     QueryResultsIterable<String> vertexIds();
+
+    /**
+     * Execute the query and return the ids of all matching vertices.
+     * This method will not load the data from storage, which is more
+     * efficient in cases where you only need to know the ids of matching vertices.
+     *
+     * @param fetchHints Details about which data to fetch.
+     * @return The ids of vertices that match this query.
+     */
+    QueryResultsIterable<String> vertexIds(EnumSet<IdFetchHint> fetchHints);
 
     QueryResultsIterable<Edge> edges();
 
     QueryResultsIterable<Edge> edges(EnumSet<FetchHint> fetchHints);
 
+    /**
+     * Execute the query and return the ids of all matching edges.
+     * This method will not load the data from storage, which is more
+     * efficient in cases where you only need to know the ids of matching edges.
+     * Hidden edges are not included in the results.
+     *
+     * @return The ids of edges that match this query.
+     */
     QueryResultsIterable<String> edgeIds();
+
+    /**
+     * Execute the query and return the ids of all matching edges.
+     * This method will not load the data from storage, which is more
+     * efficient in cases where you only need to know the ids of matching edges.
+     * Hidden edges are not included in the results.
+     *
+     * @param fetchHints Details about which data to fetch.
+     * @return The ids of edges that match this query.
+     */
+    QueryResultsIterable<String> edgeIds(EnumSet<IdFetchHint> fetchHints);
 
     QueryResultsIterable<ExtendedDataRow> extendedDataRows();
 
     QueryResultsIterable<ExtendedDataRow> extendedDataRows(EnumSet<FetchHint> fetchHints);
 
+    /**
+     * Execute the query and return the ids of all matching extended data rows.
+     * This method will not load the data from storage, which is more
+     * efficient in cases where you only need to know the ids of matching extended data rows.
+     * Hidden extended data rows are not included in the results.
+     *
+     * @return The ids of extended data rows that match this query.
+     */
     QueryResultsIterable<ExtendedDataRowId> extendedDataRowIds();
+
+    /**
+     * Execute the query and return the ids of all matching extended data rows.
+     * This method will not load the data from storage, which is more
+     * efficient in cases where you only need to know the ids of matching extended data rows.
+     * Hidden extended data rows are not included in the results.
+     *
+     * @param fetchHints Details about which data to fetch.
+     * @return The ids of extended data rows that match this query.
+     */
+    QueryResultsIterable<ExtendedDataRowId> extendedDataRowIds(EnumSet<IdFetchHint> fetchHints);
 
     @Deprecated
     QueryResultsIterable<Edge> edges(String label);
@@ -34,7 +90,26 @@ public interface Query {
 
     QueryResultsIterable<Element> elements(EnumSet<FetchHint> fetchHints);
 
+    /**
+     * Execute the query and return the ids of all matching elements.
+     * This method will not load the data from storage, which is more
+     * efficient in cases where you only need to know the ids of matching elements.
+     * Hidden elements are not included in the results.
+     *
+     * @return The ids of elements that match this query.
+     */
     QueryResultsIterable<String> elementIds();
+
+    /**
+     * Execute the query and return the ids of all matching elements.
+     * This method will not load the data from storage, which is more
+     * efficient in cases where you only need to know the ids of matching elements.
+     * Hidden elements are not included in the results.
+     *
+     * @param includeHidden Whether or not to include hidden elements in the results
+     * @return The ids of elements that match this query.
+     */
+    QueryResultsIterable<String> elementIds(EnumSet<IdFetchHint> fetchHints);
 
     QueryResultsIterable<? extends VertexiumObject> search(EnumSet<VertexiumObjectType> objectTypes, EnumSet<FetchHint> fetchHints);
 

--- a/core/src/main/java/org/vertexium/query/QueryBase.java
+++ b/core/src/main/java/org/vertexium/query/QueryBase.java
@@ -42,7 +42,12 @@ public abstract class QueryBase implements Query, SimilarToGraphQuery {
 
     @Override
     public QueryResultsIterable<String> vertexIds() {
-        return new DefaultGraphQueryIdIterable<>(vertices(FetchHint.NONE));
+        return vertexIds(IdFetchHint.NONE);
+    }
+
+    @Override
+    public QueryResultsIterable<String> vertexIds(EnumSet<IdFetchHint> idFetchHints) {
+        return new DefaultGraphQueryIdIterable<>(vertices(IdFetchHint.toFetchHints(idFetchHints)));
     }
 
     @Override
@@ -58,7 +63,12 @@ public abstract class QueryBase implements Query, SimilarToGraphQuery {
 
     @Override
     public QueryResultsIterable<String> edgeIds() {
-        return new DefaultGraphQueryIdIterable<>(edges(FetchHint.NONE));
+        return edgeIds(IdFetchHint.NONE);
+    }
+
+    @Override
+    public QueryResultsIterable<String> edgeIds(EnumSet<IdFetchHint> idFetchHints) {
+        return new DefaultGraphQueryIdIterable<>(edges(IdFetchHint.toFetchHints(idFetchHints)));
     }
 
     @Override
@@ -152,7 +162,13 @@ public abstract class QueryBase implements Query, SimilarToGraphQuery {
 
     @Override
     public QueryResultsIterable<ExtendedDataRowId> extendedDataRowIds() {
-        QueryResultsIterable<? extends VertexiumObject> vertexiumObjects = search(EnumSet.of(VertexiumObjectType.EXTENDED_DATA), FetchHint.NONE);
+        return extendedDataRowIds(IdFetchHint.NONE);
+    }
+
+    @Override
+    public QueryResultsIterable<ExtendedDataRowId> extendedDataRowIds(EnumSet<IdFetchHint> idFetchHints) {
+        EnumSet<FetchHint> fetchHints = IdFetchHint.toFetchHints(idFetchHints);
+        QueryResultsIterable<? extends VertexiumObject> vertexiumObjects = search(EnumSet.of(VertexiumObjectType.EXTENDED_DATA), fetchHints);
         return new DefaultGraphQueryIdIterable<>(vertexiumObjects);
     }
 
@@ -249,7 +265,12 @@ public abstract class QueryBase implements Query, SimilarToGraphQuery {
 
     @Override
     public QueryResultsIterable<String> elementIds() {
-        return new DefaultGraphQueryIdIterable<>(elements(FetchHint.NONE));
+        return elementIds(IdFetchHint.NONE);
+    }
+
+    @Override
+    public QueryResultsIterable<String> elementIds(EnumSet<IdFetchHint> idFetchHints) {
+        return new DefaultGraphQueryIdIterable<>(elements(IdFetchHint.toFetchHints(idFetchHints)));
     }
 
     @Override

--- a/elasticsearch5/src/main/java/org/vertexium/elasticsearch5/ElasticsearchSearchExtendedDataQuery.java
+++ b/elasticsearch5/src/main/java/org/vertexium/elasticsearch5/ElasticsearchSearchExtendedDataQuery.java
@@ -4,6 +4,7 @@ import org.elasticsearch.client.Client;
 import org.elasticsearch.index.query.QueryBuilder;
 import org.elasticsearch.index.query.QueryBuilders;
 import org.vertexium.Authorizations;
+import org.vertexium.FetchHint;
 import org.vertexium.Graph;
 import org.vertexium.query.GraphQuery;
 
@@ -29,8 +30,8 @@ public class ElasticsearchSearchExtendedDataQuery extends ElasticsearchSearchQue
     }
 
     @Override
-    protected List<QueryBuilder> getFilters(EnumSet<ElasticsearchDocumentType> elementTypes) {
-        List<QueryBuilder> filters = super.getFilters(elementTypes);
+    protected List<QueryBuilder> getFilters(EnumSet<ElasticsearchDocumentType> elementTypes, EnumSet<FetchHint> fetchHints) {
+        List<QueryBuilder> filters = super.getFilters(elementTypes, fetchHints);
         filters.add(
                 QueryBuilders.boolQuery()
                         .must(QueryBuilders.termsQuery(

--- a/elasticsearch5/src/main/java/org/vertexium/elasticsearch5/ElasticsearchSearchVertexQuery.java
+++ b/elasticsearch5/src/main/java/org/vertexium/elasticsearch5/ElasticsearchSearchVertexQuery.java
@@ -32,8 +32,8 @@ public class ElasticsearchSearchVertexQuery extends ElasticsearchSearchQueryBase
     }
 
     @Override
-    protected List<QueryBuilder> getFilters(EnumSet<ElasticsearchDocumentType> elementTypes) {
-        List<QueryBuilder> filters = super.getFilters(elementTypes);
+    protected List<QueryBuilder> getFilters(EnumSet<ElasticsearchDocumentType> elementTypes, EnumSet<FetchHint> fetchHints) {
+        List<QueryBuilder> filters = super.getFilters(elementTypes, fetchHints);
 
         List<QueryBuilder> relatedFilters = new ArrayList<>();
 

--- a/test/src/main/java/org/vertexium/test/GraphTestBase.java
+++ b/test/src/main/java/org/vertexium/test/GraphTestBase.java
@@ -3033,6 +3033,80 @@ public abstract class GraphTestBase {
     }
 
     @Test
+    public void testGraphQueryHidden() {
+        Vertex v1 = graph.addVertex("v1", VISIBILITY_A, AUTHORIZATIONS_A);
+        Vertex v2 = graph.addVertex("v2", VISIBILITY_A, AUTHORIZATIONS_A);
+        Vertex v3 = graph.addVertex("v3", VISIBILITY_A, AUTHORIZATIONS_A);
+        Edge e1 = graph.addEdge("e1", "v1", "v2", "junit edge", VISIBILITY_A, AUTHORIZATIONS_A);
+        Edge e2 = graph.addEdge("e2", "v2", "v3", "junit edge", VISIBILITY_A, AUTHORIZATIONS_A);
+        graph.flush();
+
+        graph.markEdgeHidden(e1, VISIBILITY_A, AUTHORIZATIONS_A);
+        graph.markVertexHidden(v1, VISIBILITY_A, AUTHORIZATIONS_A);
+        graph.flush();
+
+        QueryResultsIterable<Vertex> vertices = graph.query(AUTHORIZATIONS_A).vertices(FetchHint.ALL);
+        assertResultsCount(2, vertices);
+        assertVertexIdsAnyOrder(vertices, v2.getId(), v3.getId());
+
+        QueryResultsIterable<String> vertexIds = graph.query(AUTHORIZATIONS_A).vertexIds(IdFetchHint.NONE);
+        assertResultsCount(2, 2, vertexIds);
+        assertIdsAnyOrder(vertexIds, v2.getId(), v3.getId());
+
+        vertexIds = graph.query(AUTHORIZATIONS_A).vertexIds();
+        assertResultsCount(2, 2, vertexIds);
+        assertIdsAnyOrder(vertexIds, v2.getId(), v3.getId());
+
+        vertices = graph.query(AUTHORIZATIONS_A).vertices(FetchHint.ALL_INCLUDING_HIDDEN);
+        assertResultsCount(3, vertices);
+        assertVertexIdsAnyOrder(vertices, v1.getId(), v2.getId(), v3.getId());
+
+        vertexIds = graph.query(AUTHORIZATIONS_A).vertexIds(IdFetchHint.ALL_INCLUDING_HIDDEN);
+        assertResultsCount(3, 3, vertexIds);
+        assertIdsAnyOrder(vertexIds, v1.getId(), v2.getId(), v3.getId());
+
+        QueryResultsIterable<Edge> edges = graph.query(AUTHORIZATIONS_A).edges(FetchHint.ALL);
+        assertResultsCount(1, edges);
+        assertEdgeIdsAnyOrder(edges, e2.getId());
+
+        QueryResultsIterable<String> edgeIds = graph.query(AUTHORIZATIONS_A).edgeIds(IdFetchHint.NONE);
+        assertResultsCount(1, 1, edgeIds);
+        assertIdsAnyOrder(edgeIds, e2.getId());
+
+        edgeIds = graph.query(AUTHORIZATIONS_A).edgeIds();
+        assertResultsCount(1, 1, edgeIds);
+        assertIdsAnyOrder(edgeIds, e2.getId());
+
+        edges = graph.query(AUTHORIZATIONS_A).edges(FetchHint.ALL_INCLUDING_HIDDEN);
+        assertResultsCount(2, edges);
+        assertEdgeIdsAnyOrder(edges, e1.getId(), e2.getId());
+
+        edgeIds = graph.query(AUTHORIZATIONS_A).edgeIds(IdFetchHint.ALL_INCLUDING_HIDDEN);
+        assertResultsCount(2, 2, edgeIds);
+        assertIdsAnyOrder(edgeIds, e1.getId(), e2.getId());
+
+        QueryResultsIterable<Element> elements = graph.query(AUTHORIZATIONS_A).elements(FetchHint.ALL);
+        assertResultsCount(3, elements);
+        assertElementIdsAnyOrder(elements, v2.getId(), v3.getId(), e2.getId());
+
+        QueryResultsIterable<String> elementIds = graph.query(AUTHORIZATIONS_A).elementIds(IdFetchHint.NONE);
+        assertResultsCount(3, 3, elementIds);
+        assertIdsAnyOrder(elementIds, v2.getId(), v3.getId(), e2.getId());
+
+        elementIds = graph.query(AUTHORIZATIONS_A).elementIds();
+        assertResultsCount(3, 3, elementIds);
+        assertIdsAnyOrder(elementIds, v2.getId(), v3.getId(), e2.getId());
+
+        elements = graph.query(AUTHORIZATIONS_A).elements(FetchHint.ALL_INCLUDING_HIDDEN);
+        assertResultsCount(5, elements);
+        assertElementIdsAnyOrder(elements, v1.getId(), v2.getId(), v3.getId(), e1.getId(), e2.getId());
+
+        elementIds = graph.query(AUTHORIZATIONS_A).elementIds(IdFetchHint.ALL_INCLUDING_HIDDEN);
+        assertResultsCount(5, 5, elementIds);
+        assertIdsAnyOrder(elementIds, v1.getId(), v2.getId(), v3.getId(), e1.getId(), e2.getId());
+    }
+
+    @Test
     public void testGraphQueryVertexWithVisibilityChange() {
         Vertex v1 = graph.prepareVertex("v1", VISIBILITY_A)
                 .save(AUTHORIZATIONS_A);

--- a/test/src/main/java/org/vertexium/test/util/VertexiumAssert.java
+++ b/test/src/main/java/org/vertexium/test/util/VertexiumAssert.java
@@ -32,29 +32,11 @@ public class VertexiumAssert {
     }
 
     public static void assertVertexIdsAnyOrder(Iterable<Vertex> vertices, String... expectedIds) {
-        List<Vertex> sortedVertices = stream(vertices)
-                .sorted(Comparator.comparing(Element::getId))
-                .collect(Collectors.toList());
-        Arrays.sort(expectedIds);
-        assertVertexIds(sortedVertices, expectedIds);
+        assertElementIdsAnyOrder(vertices, expectedIds);
     }
 
     public static void assertVertexIds(Iterable<Vertex> vertices, String... expectedIds) {
-        String verticesIdsString = vertexIdsToString(vertices);
-        String expectedIdsString = idsToString(expectedIds);
-        List<Vertex> verticesList = toList(vertices);
-        assertEquals("ids length mismatch found:[" + verticesIdsString + "] expected:[" + expectedIdsString + "]", expectedIds.length, verticesList.size());
-        for (int i = 0; i < expectedIds.length; i++) {
-            assertEquals("at offset: " + i + " found:[" + verticesIdsString + "] expected:[" + expectedIdsString + "]", expectedIds[i], verticesList.get(i).getId());
-        }
-    }
-
-    public static String vertexIdsToString(Iterable<Vertex> vertices) {
-        List<String> idsList = stream(vertices)
-                .map(Element::getId)
-                .collect(Collectors.toList());
-        String[] idsArray = idsList.toArray(new String[idsList.size()]);
-        return idsToString(idsArray);
+        assertElementIds(vertices, expectedIds);
     }
 
     public static String idsToString(String[] ids) {
@@ -76,20 +58,29 @@ public class VertexiumAssert {
     }
 
     public static void assertEdgeIdsAnyOrder(Iterable<Edge> edges, String... expectedIds) {
-        List<Edge> sortedEdges = stream(edges)
-                .sorted(Comparator.comparing(Element::getId))
-                .collect(Collectors.toList());
-        Arrays.sort(expectedIds);
-        assertEdgeIds(sortedEdges, expectedIds);
+        assertElementIdsAnyOrder(edges, expectedIds);
     }
 
     public static void assertEdgeIds(Iterable<Edge> edges, String... ids) {
-        List<Edge> edgesList = toList(edges);
-        assertEquals("ids length mismatch", ids.length, edgesList.size());
+        assertElementIds(edges, ids);
+    }
+
+    public static void assertElementIdsAnyOrder(Iterable<? extends Element> elements, String... expectedIds) {
+        List<Element> sortedElements = stream(elements)
+                .sorted(Comparator.comparing(Element::getId))
+                .collect(Collectors.toList());
+        Arrays.sort(expectedIds);
+        assertElementIds(sortedElements, expectedIds);
+    }
+
+    public static void assertElementIds(Iterable<? extends Element> elements, String... ids) {
+        List<Element> elementList = toList(elements);
+        assertEquals("ids length mismatch", ids.length, elementList.size());
         for (int i = 0; i < ids.length; i++) {
-            assertEquals("at offset: " + i, ids[i], edgesList.get(i).getId());
+            assertEquals("at offset: " + i, ids[i], elementList.get(i).getId());
         }
     }
+
 
     public static void assertResultsCount(int expectedCountAndTotalHits, QueryResultsIterable<? extends Element> results) {
         assertEquals(expectedCountAndTotalHits, results.getTotalHits());


### PR DESCRIPTION
Previously, the search index classes were always filtering out results that are hidden. Now, if the FetchHints contain INCLUDE_HIDDEN that filtering will be skipped.

In order to allow this behavior for loadign id's, I also added overloaded versions of `vertexIds`, `edgeIds`, `elementIds`, and `extendedDataRowIds` that take EnumSet<IdFetchHint> indicating whether or not to include hidden.