### PR TITLE
Query.hasAuthorization Missing Hidden Elements

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,7 @@
 * Fixed: Find path when edge labels are deflated
 * Fixed: Accumulo stream property value in table data length of reference
 * Fixed: Query will now return hidden elements/vertices/edges if FetchHint.INCLUDE_HIDDEN is passed
+* Fixed: Query.hasAuthorization will now match elements whose only use of an authorization is a hidden field
 * Added: Query methods elementIds/vertexIds/edgeIds are overloaded to accept IdFetchHint, which makes it possible to include ids for hidden elements
 
 # v3.1.1

--- a/core/src/main/java/org/vertexium/query/QueryBase.java
+++ b/core/src/main/java/org/vertexium/query/QueryBase.java
@@ -452,6 +452,12 @@ public abstract class QueryBase implements Query, SimilarToGraphQuery {
                     return true;
                 }
 
+                boolean hiddenVisibilityMatches = StreamSupport.stream(element.getHiddenVisibilities().spliterator(), false)
+                        .anyMatch(visibility -> visibility.hasAuthorization(authorization));
+                if (hiddenVisibilityMatches) {
+                    return true;
+                }
+
                 boolean propertyMatches = StreamSupport.stream(element.getProperties().spliterator(), false)
                         .anyMatch(property -> property.getVisibility().hasAuthorization(authorization));
                 if (propertyMatches) {

--- a/test/src/main/java/org/vertexium/test/GraphTestBase.java
+++ b/test/src/main/java/org/vertexium/test/GraphTestBase.java
@@ -2607,6 +2607,69 @@ public abstract class GraphTestBase {
     }
 
     @Test
+    public void testGraphQueryHasAuthorizationWithHidden() {
+        Vertex v1 = graph.addVertex("v1", Visibility.EMPTY, AUTHORIZATIONS_A);
+        Vertex v2 = graph.addVertex("v2", Visibility.EMPTY, AUTHORIZATIONS_A);
+        Edge e1 = graph.addEdge("e1", v1.getId(), v2.getId(), "junit edge", Visibility.EMPTY, AUTHORIZATIONS_A);
+        graph.flush();
+
+        graph.markEdgeHidden(e1, VISIBILITY_A, AUTHORIZATIONS_A);
+        graph.markVertexHidden(v1, VISIBILITY_A, AUTHORIZATIONS_A);
+        graph.flush();
+
+        QueryResultsIterable<Vertex> vertices = graph.query(AUTHORIZATIONS_A).hasAuthorization(VISIBILITY_A_STRING).vertices(FetchHint.ALL);
+        assertResultsCount(0, vertices);
+
+        QueryResultsIterable<String> vertexIds = graph.query(AUTHORIZATIONS_A).hasAuthorization(VISIBILITY_A_STRING).vertexIds(IdFetchHint.NONE);
+        assertResultsCount(0, 0, vertexIds);
+
+        vertexIds = graph.query(AUTHORIZATIONS_A).hasAuthorization(VISIBILITY_A_STRING).vertexIds();
+        assertResultsCount(0, 0, vertexIds);
+
+        vertices = graph.query(AUTHORIZATIONS_A).hasAuthorization(VISIBILITY_A_STRING).vertices(FetchHint.ALL_INCLUDING_HIDDEN);
+        assertResultsCount(1, vertices);
+        assertVertexIdsAnyOrder(vertices, v1.getId());
+
+        vertexIds = graph.query(AUTHORIZATIONS_A).hasAuthorization(VISIBILITY_A_STRING).vertexIds(IdFetchHint.ALL_INCLUDING_HIDDEN);
+        assertResultsCount(1, 1, vertexIds);
+        assertIdsAnyOrder(vertexIds, v1.getId());
+
+        QueryResultsIterable<Edge> edges = graph.query(AUTHORIZATIONS_A).hasAuthorization(VISIBILITY_A_STRING).edges(FetchHint.ALL);
+        assertResultsCount(0, edges);
+
+        QueryResultsIterable<String> edgeIds = graph.query(AUTHORIZATIONS_A).hasAuthorization(VISIBILITY_A_STRING).edgeIds(IdFetchHint.NONE);
+        assertResultsCount(0, 0, edgeIds);
+
+        edgeIds = graph.query(AUTHORIZATIONS_A).hasAuthorization(VISIBILITY_A_STRING).edgeIds();
+        assertResultsCount(0, 0, edgeIds);
+
+        edges = graph.query(AUTHORIZATIONS_A).hasAuthorization(VISIBILITY_A_STRING).edges(FetchHint.ALL_INCLUDING_HIDDEN);
+        assertResultsCount(1, edges);
+        assertEdgeIdsAnyOrder(edges, e1.getId());
+
+        edgeIds = graph.query(AUTHORIZATIONS_A).hasAuthorization(VISIBILITY_A_STRING).edgeIds(IdFetchHint.ALL_INCLUDING_HIDDEN);
+        assertResultsCount(1, 1, edgeIds);
+        assertIdsAnyOrder(edgeIds, e1.getId());
+
+        QueryResultsIterable<Element> elements = graph.query(AUTHORIZATIONS_A).hasAuthorization(VISIBILITY_A_STRING).elements(FetchHint.ALL);
+        assertResultsCount(0, elements);
+
+        QueryResultsIterable<String> elementIds = graph.query(AUTHORIZATIONS_A).hasAuthorization(VISIBILITY_A_STRING).elementIds(IdFetchHint.NONE);
+        assertResultsCount(0, 0, elementIds);
+
+        elementIds = graph.query(AUTHORIZATIONS_A).hasAuthorization(VISIBILITY_A_STRING).elementIds();
+        assertResultsCount(0, 0, elementIds);
+
+        elements = graph.query(AUTHORIZATIONS_A).hasAuthorization(VISIBILITY_A_STRING).elements(FetchHint.ALL_INCLUDING_HIDDEN);
+        assertResultsCount(2, elements);
+        assertElementIdsAnyOrder(elements, v1.getId(), e1.getId());
+
+        elementIds = graph.query(AUTHORIZATIONS_A).hasAuthorization(VISIBILITY_A_STRING).elementIds(IdFetchHint.ALL_INCLUDING_HIDDEN);
+        assertResultsCount(2, 2, elementIds);
+        assertIdsAnyOrder(elementIds, v1.getId(), e1.getId());
+    }
+
+    @Test
     public void testGraphQueryContainsNotIn() {
         graph.prepareVertex("v1", VISIBILITY_A)
                 .setProperty("status", "0", VISIBILITY_A)


### PR DESCRIPTION
If an element's only use of an authorization was for the `__hidden` field, it was not matching as a result for the `Query.hasAuthorization` method.