### PR TITLE
Don't compile a regular expression for every id generation

### DIFF
--- a/core/src/main/java/org/vertexium/id/UUIDIdGenerator.java
+++ b/core/src/main/java/org/vertexium/id/UUIDIdGenerator.java
@@ -1,5 +1,6 @@
 package org.vertexium.id;
 
+import org.apache.commons.lang3.StringUtils;
 import org.vertexium.GraphConfiguration;
 
 import java.util.UUID;
@@ -11,6 +12,6 @@ public class UUIDIdGenerator implements IdGenerator {
 
     @Override
     public String nextId() {
-        return UUID.randomUUID().toString().replaceAll("-", "");
+        return StringUtils.remove(UUID.randomUUID().toString(), '-');
     }
 }


### PR DESCRIPTION
Java's `String.replaceAll` compiles and executes a new regular expression with every call. Since all we need is to remove a single character, the `StringUtils.remove` method in apache commons is more efficient.