### PR TITLE
Query.hasAuthorization match elements with hidden properties

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,7 +4,8 @@
 * Fixed: Find path when edge labels are deflated
 * Fixed: Accumulo stream property value in table data length of reference
 * Fixed: Query will now return hidden elements/vertices/edges if FetchHint.INCLUDE_HIDDEN is passed
-* Fixed: Query.hasAuthorization will now match elements whose only use of an authorization is a hidden field
+* Fixed: Query.hasAuthorization will now match elements whose only use of an authorization is that the element is hidden
+* Fixed: Query.hasAuthorization will now match elements whose only use of an authorization is a hidden property
 * Added: Query methods elementIds/vertexIds/edgeIds are overloaded to accept IdFetchHint, which makes it possible to include ids for hidden elements
 * Added: Graph.getExtendedDataInRange in order to bulk load ranges of extended data rows
 * Added: SearchIndex.addExtendedData to allow for reindexing extended data

--- a/accumulo/src/main/java/org/vertexium/accumulo/AccumuloGraph.java
+++ b/accumulo/src/main/java/org/vertexium/accumulo/AccumuloGraph.java
@@ -1380,6 +1380,8 @@ public class AccumuloGraph extends GraphBaseWithSearchIndex implements Traceable
                 addMutations(VertexiumObjectType.EDGE, getMarkHiddenPropertyMutation(element.getId(), property, timestamp, columnVisibility));
             }
 
+            getSearchIndex().markPropertyHidden(this, element, property, visibility, authorizations);
+
             if (hasEventListeners()) {
                 fireGraphEvent(new MarkHiddenPropertyEvent(this, element, property, visibility));
             }
@@ -1414,6 +1416,8 @@ public class AccumuloGraph extends GraphBaseWithSearchIndex implements Traceable
             } else if (element instanceof Edge) {
                 addMutations(VertexiumObjectType.EDGE, getMarkVisiblePropertyMutation(element.getId(), property, timestamp, columnVisibility));
             }
+
+            getSearchIndex().markPropertyVisible(this, element, property, visibility, authorizations);
 
             if (hasEventListeners()) {
                 fireGraphEvent(new MarkVisiblePropertyEvent(this, element, property, visibility));

--- a/core/src/main/java/org/vertexium/IdFetchHint.java
+++ b/core/src/main/java/org/vertexium/IdFetchHint.java
@@ -7,8 +7,4 @@ public enum IdFetchHint {
 
     public static final EnumSet<IdFetchHint> NONE = EnumSet.noneOf(IdFetchHint.class);
     public static final EnumSet<IdFetchHint> ALL_INCLUDING_HIDDEN = EnumSet.allOf(IdFetchHint.class);
-
-    public static EnumSet<FetchHint> toFetchHints(EnumSet<IdFetchHint> idFetchHints) {
-        return idFetchHints.contains(IdFetchHint.INCLUDE_HIDDEN) ? EnumSet.of(FetchHint.INCLUDE_HIDDEN) : FetchHint.NONE;
-    }
 }

--- a/core/src/main/java/org/vertexium/search/DefaultSearchIndex.java
+++ b/core/src/main/java/org/vertexium/search/DefaultSearchIndex.java
@@ -30,6 +30,20 @@ public class DefaultSearchIndex implements SearchIndex {
     }
 
     @Override
+    public void markPropertyHidden(Graph graph, Element element, Property property, Visibility visibility, Authorizations authorizations) {
+        checkNotNull(element, "element cannot be null");
+        checkNotNull(property, "property cannot be null");
+        checkNotNull(visibility, "visibility cannot be null");
+    }
+
+    @Override
+    public void markPropertyVisible(Graph graph, Element element, Property property, Visibility visibility, Authorizations authorizations) {
+        checkNotNull(element, "element cannot be null");
+        checkNotNull(property, "property cannot be null");
+        checkNotNull(visibility, "visibility cannot be null");
+    }
+
+    @Override
     public void alterElementVisibility(Graph graph, Element element, Visibility oldVisibility, Visibility newVisibility, Authorizations authorizations) {
         checkNotNull(element, "element cannot be null");
         checkNotNull(newVisibility, "newVisibility cannot be null");

--- a/core/src/main/java/org/vertexium/search/SearchIndex.java
+++ b/core/src/main/java/org/vertexium/search/SearchIndex.java
@@ -15,6 +15,10 @@ public interface SearchIndex {
 
     void markElementVisible(Graph graph, Element element, Visibility visibility, Authorizations authorizations);
 
+    void markPropertyHidden(Graph graph, Element element, Property property, Visibility visibility, Authorizations authorizations);
+
+    void markPropertyVisible(Graph graph, Element element, Property property, Visibility visibility, Authorizations authorizations);
+
     /**
      * Default delete property simply calls deleteProperty in a loop. It is up to the SearchIndex implementation to decide
      * if a collective method can be made more efficient

--- a/elasticsearch5/src/main/java/org/vertexium/elasticsearch5/ElasticsearchSearchQueryBase.java
+++ b/elasticsearch5/src/main/java/org/vertexium/elasticsearch5/ElasticsearchSearchQueryBase.java
@@ -459,25 +459,25 @@ public class ElasticsearchSearchQueryBase extends QueryBase {
 
     @Override
     public QueryResultsIterable<String> vertexIds(EnumSet<IdFetchHint> idFetchHints) {
-        EnumSet<FetchHint> fetchHints = IdFetchHint.toFetchHints(idFetchHints);
+        EnumSet<FetchHint> fetchHints = idFetchHintsToElementFetchHints(idFetchHints);
         return new ElasticsearchGraphQueryIdIterable<>(getIdStrategy(), searchHits(EnumSet.of(VertexiumObjectType.VERTEX), fetchHints));
     }
 
     @Override
     public QueryResultsIterable<String> edgeIds(EnumSet<IdFetchHint> idFetchHints) {
-        EnumSet<FetchHint> fetchHints = IdFetchHint.toFetchHints(idFetchHints);
+        EnumSet<FetchHint> fetchHints = idFetchHintsToElementFetchHints(idFetchHints);
         return new ElasticsearchGraphQueryIdIterable<>(getIdStrategy(), searchHits(EnumSet.of(VertexiumObjectType.EDGE), fetchHints));
     }
 
     @Override
     public QueryResultsIterable<ExtendedDataRowId> extendedDataRowIds(EnumSet<IdFetchHint> idFetchHints) {
-        EnumSet<FetchHint> fetchHints = IdFetchHint.toFetchHints(idFetchHints);
+        EnumSet<FetchHint> fetchHints = idFetchHintsToElementFetchHints(idFetchHints);
         return new ElasticsearchGraphQueryIdIterable<>(getIdStrategy(), searchHits(EnumSet.of(VertexiumObjectType.EXTENDED_DATA), fetchHints));
     }
 
     @Override
     public QueryResultsIterable<String> elementIds(EnumSet<IdFetchHint> idFetchHints) {
-        EnumSet<FetchHint> fetchHints = IdFetchHint.toFetchHints(idFetchHints);
+        EnumSet<FetchHint> fetchHints = idFetchHintsToElementFetchHints(idFetchHints);
         return new ElasticsearchGraphQueryIdIterable<>(getIdStrategy(), searchHits(VertexiumObjectType.ELEMENTS, fetchHints));
     }
 
@@ -638,7 +638,11 @@ public class ElasticsearchSearchQueryBase extends QueryBase {
             }
         }
 
-        List<String> internalFields = Arrays.asList(Elasticsearch5SearchIndex.ELEMENT_TYPE_FIELD_NAME, Elasticsearch5SearchIndex.HIDDEN_VERTEX_FIELD_NAME);
+        List<String> internalFields = Arrays.asList(
+                Elasticsearch5SearchIndex.ELEMENT_TYPE_FIELD_NAME,
+                Elasticsearch5SearchIndex.HIDDEN_VERTEX_FIELD_NAME,
+                Elasticsearch5SearchIndex.HIDDEN_PROPERTY_FIELD_NAME
+        );
         internalFields.forEach(fieldName -> {
             Collection<String> fieldHashes = visibilitiesStore.getHashes(graph, fieldName, auths);
             Collection<String> matchingFieldHashes = fieldHashes.stream().filter(hashes::contains).collect(Collectors.toSet());
@@ -1473,6 +1477,10 @@ public class ElasticsearchSearchQueryBase extends QueryBase {
 
     public IdStrategy getIdStrategy() {
         return getSearchIndex().getIdStrategy();
+    }
+
+    protected EnumSet<FetchHint> idFetchHintsToElementFetchHints(EnumSet<IdFetchHint> idFetchHints) {
+        return idFetchHints.contains(IdFetchHint.INCLUDE_HIDDEN) ? EnumSet.of(FetchHint.INCLUDE_HIDDEN) : FetchHint.NONE;
     }
 
     @Override

--- a/inmemory/src/main/java/org/vertexium/inmemory/InMemoryGraph.java
+++ b/inmemory/src/main/java/org/vertexium/inmemory/InMemoryGraph.java
@@ -295,6 +295,8 @@ public class InMemoryGraph extends GraphBaseWithSearchIndex {
                 authorizations
         );
 
+        getSearchIndex().markPropertyHidden(this, element, property, visibility, authorizations);
+
         if (hiddenProperty != null && hasEventListeners()) {
             fireGraphEvent(new MarkHiddenPropertyEvent(this, element, hiddenProperty, visibility));
         }
@@ -306,6 +308,8 @@ public class InMemoryGraph extends GraphBaseWithSearchIndex {
         }
 
         Property property = inMemoryTableElement.appendMarkPropertyVisibleMutation(key, name, propertyVisibility, timestamp, visibility, authorizations);
+
+        getSearchIndex().markPropertyVisible(this, element, property, visibility, authorizations);
 
         if (property != null && hasEventListeners()) {
             fireGraphEvent(new MarkVisiblePropertyEvent(this, element, property, visibility));


### PR DESCRIPTION
If the only use of an authorization was a hidden property, `Query.hasAuthorization` was not returning an element since the search index was not being updated for hidden properties. This PR makes such elements return for `Query.hasAuthorization`, but [does not fix the issue of the hidden properties still being searchable](https://github.com/visallo/vertexium/issues/178). Once that issue is fixed, the `HIDDEN_PROPERTY_FIELD_NAME` can likely be removed.

Known Issue: If a property is marked hidden, it can still be found with a search but it will not be retrieved from the data store.