### PR TITLE
Apply ExistingElementMutations with Painless Script in Elasticsearch

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,6 @@
+# v3.2.1
+* Changed: When saving an ExistingElementMutation, the Elastisearch5Index will now apply the mutations using a painless script rather than making multiple requests.
+
 # v3.2.0
 * Changed: Elasticsearch _id and _type fields to be much smaller to minimize the size of the _uid field data cache 
 * Changed: Elasticsearch to only refresh the indices that were changed

--- a/accumulo/src/main/java/org/vertexium/accumulo/AccumuloGraph.java
+++ b/accumulo/src/main/java/org/vertexium/accumulo/AccumuloGraph.java
@@ -441,9 +441,7 @@ public class AccumuloGraph extends GraphBaseWithSearchIndex implements Traceable
             AccumuloElement element,
             Iterable<Property> properties,
             Iterable<PropertyDeleteMutation> propertyDeletes,
-            Iterable<PropertySoftDeleteMutation> propertySoftDeletes,
-            IndexHint indexHint,
-            Authorizations authorizations
+            Iterable<PropertySoftDeleteMutation> propertySoftDeletes
     ) {
         String elementRowKey = element.getId();
         Mutation m = new Mutation(elementRowKey);
@@ -462,23 +460,6 @@ public class AccumuloGraph extends GraphBaseWithSearchIndex implements Traceable
         }
         if (hasProperty) {
             addMutations(element, m);
-        }
-
-        if (indexHint != IndexHint.DO_NOT_INDEX) {
-            // Bulk delete properties
-            List<PropertyDescriptor> propertyList = Lists.newArrayList();
-            propertyDeletes.forEach(p -> propertyList.add(PropertyDescriptor.fromPropertyDeleteMutation(p)));
-            propertySoftDeletes.forEach(p -> propertyList.add(PropertyDescriptor.fromPropertySoftDeleteMutation(p)));
-
-            if (!propertyList.isEmpty()) {
-                getSearchIndex().deleteProperties(
-                        this,
-                        element,
-                        propertyList,
-                        authorizations
-                );
-            }
-            getSearchIndex().addElement(this, element, authorizations);
         }
 
         if (hasEventListeners()) {
@@ -2038,9 +2019,8 @@ public class AccumuloGraph extends GraphBaseWithSearchIndex implements Traceable
         return ranges;
     }
 
-    void alterElementVisibility(AccumuloElement element, Visibility newVisibility, Authorizations authorizations) {
+    void alterElementVisibility(AccumuloElement element, Visibility newVisibility) {
         String elementRowKey = element.getId();
-        Visibility oldVisibility = element.getVisibility();
         Span trace = Trace.start("alterElementVisibility");
         trace.data("elementRowKey", elementRowKey);
         try {
@@ -2065,13 +2045,6 @@ public class AccumuloGraph extends GraphBaseWithSearchIndex implements Traceable
                 addMutations(element, m);
             }
             element.setVisibility(newVisibility);
-            getSearchIndex().alterElementVisibility(
-                    AccumuloGraph.this,
-                    element,
-                    oldVisibility,
-                    newVisibility,
-                    authorizations
-            );
         } finally {
             trace.stop();
         }
@@ -2081,11 +2054,7 @@ public class AccumuloGraph extends GraphBaseWithSearchIndex implements Traceable
         elementMutationBuilder.alterEdgeLabel(edge, newEdgeLabel);
     }
 
-    void alterElementPropertyVisibilities(
-            AccumuloElement element,
-            List<AlterPropertyVisibility> alterPropertyVisibilities,
-            Authorizations authorizations
-    ) {
+    void alterElementPropertyVisibilities(AccumuloElement element, List<AlterPropertyVisibility> alterPropertyVisibilities) {
         if (alterPropertyVisibilities.size() == 0) {
             return;
         }
@@ -2121,13 +2090,6 @@ public class AccumuloGraph extends GraphBaseWithSearchIndex implements Traceable
 
 
         if (!propertyList.isEmpty()) {
-            // delete the property with the old/existing visibility from the search index
-            getSearchIndex().deleteProperties(
-                    this,
-                    element,
-                    propertyList,
-                    authorizations
-            );
             addMutations(element, m);
         }
     }

--- a/core/src/main/java/org/vertexium/mutation/ExistingElementMutation.java
+++ b/core/src/main/java/org/vertexium/mutation/ExistingElementMutation.java
@@ -4,6 +4,8 @@ import org.vertexium.Element;
 import org.vertexium.Property;
 import org.vertexium.Visibility;
 
+import java.util.List;
+
 public interface ExistingElementMutation<T extends Element> extends ElementMutation<T> {
     /**
      * Alters the visibility of a property.
@@ -31,11 +33,26 @@ public interface ExistingElementMutation<T extends Element> extends ElementMutat
     ExistingElementMutation<T> alterPropertyVisibility(String name, Visibility visibility);
 
     /**
+     * Gets the properties whose visibilities are being altered in this mutation.
+     */
+    List<AlterPropertyVisibility> getAlterPropertyVisibilities();
+
+    /**
      * Alters the visibility of the element (vertex or edge).
      *
      * @param visibility The new visibility.
      */
     ExistingElementMutation<T> alterElementVisibility(Visibility visibility);
+
+    /**
+     * Get the new element visibility or null if not being altered in this mutation.
+     */
+    Visibility getNewElementVisibility();
+
+    /**
+     * Get the old element visibility.
+     */
+    Visibility getOldElementVisibility();
 
     /**
      * Sets a property metadata value on a property.
@@ -67,6 +84,11 @@ public interface ExistingElementMutation<T extends Element> extends ElementMutat
      * @param visibility   The visibility of the metadata item
      */
     ExistingElementMutation<T> setPropertyMetadata(String propertyName, String metadataName, Object newValue, Visibility visibility);
+
+    /**
+     * Gets all of the property metadata changes that are part of this mutation.
+     */
+    List<SetPropertyMetadata> getSetPropertyMetadatas();
 
     /**
      * Permanently deletes all default properties with that name irregardless of visibility.

--- a/core/src/main/java/org/vertexium/mutation/ExistingElementMutationImpl.java
+++ b/core/src/main/java/org/vertexium/mutation/ExistingElementMutationImpl.java
@@ -19,10 +19,14 @@ public abstract class ExistingElementMutationImpl<T extends Element> implements 
     private final List<ExtendedDataDeleteMutation> extendedDataDeletes = new ArrayList<>();
     private final T element;
     private Visibility newElementVisibility;
+    private Visibility oldElementVisibility;
     private IndexHint indexHint = IndexHint.INDEX;
 
     public ExistingElementMutationImpl(T element) {
         this.element = element;
+        if (element != null) {
+            this.oldElementVisibility = element.getVisibility();
+        }
     }
 
     public abstract T save(Authorizations authorizations);
@@ -238,6 +242,11 @@ public abstract class ExistingElementMutationImpl<T extends Element> implements 
 
     public Visibility getNewElementVisibility() {
         return newElementVisibility;
+    }
+
+    @Override
+    public Visibility getOldElementVisibility() {
+        return oldElementVisibility;
     }
 
     public List<AlterPropertyVisibility> getAlterPropertyVisibilities() {

--- a/core/src/main/java/org/vertexium/search/DefaultSearchIndex.java
+++ b/core/src/main/java/org/vertexium/search/DefaultSearchIndex.java
@@ -1,6 +1,7 @@
 package org.vertexium.search;
 
 import org.vertexium.*;
+import org.vertexium.mutation.ExistingElementMutation;
 import org.vertexium.mutation.ExtendedDataMutation;
 import org.vertexium.query.*;
 
@@ -15,6 +16,11 @@ public class DefaultSearchIndex implements SearchIndex {
     @Override
     public void addElement(Graph graph, Element element, Authorizations authorizations) {
         checkNotNull(element, "element cannot be null");
+    }
+
+    @Override
+    public <TElement extends Element> void updateElement(Graph graph, ExistingElementMutation<TElement> mutation, Authorizations authorizations) {
+        checkNotNull(mutation, "mutation cannot be null");
     }
 
     @Override

--- a/core/src/main/java/org/vertexium/search/SearchIndex.java
+++ b/core/src/main/java/org/vertexium/search/SearchIndex.java
@@ -1,6 +1,7 @@
 package org.vertexium.search;
 
 import org.vertexium.*;
+import org.vertexium.mutation.ExistingElementMutation;
 import org.vertexium.mutation.ExtendedDataMutation;
 import org.vertexium.query.*;
 
@@ -8,6 +9,8 @@ import java.util.Collection;
 
 public interface SearchIndex {
     void addElement(Graph graph, Element element, Authorizations authorizations);
+
+    <TElement extends Element> void updateElement(Graph graph, ExistingElementMutation<TElement> mutation, Authorizations authorizations);
 
     void deleteElement(Graph graph, Element element, Authorizations authorizations);
 

--- a/test/src/main/java/org/vertexium/test/GraphTestBase.java
+++ b/test/src/main/java/org/vertexium/test/GraphTestBase.java
@@ -4832,6 +4832,8 @@ public abstract class GraphTestBase {
         graph.createAuthorizations(AUTHORIZATIONS_ALL);
         graph.flush();
 
+        assertResultsCount(1, 1, graph.query(AUTHORIZATIONS_A).has("age", 25).vertices());
+
         Vertex v1 = graph.getVertex("v1", FetchHint.ALL, AUTHORIZATIONS_ALL);
         ExistingElementMutation<Vertex> m = v1.prepareMutation();
         m.alterElementVisibility(VISIBILITY_B);
@@ -4859,15 +4861,8 @@ public abstract class GraphTestBase {
         v1 = graph.getVertex("v1", AUTHORIZATIONS_A);
         assertNull("v1 should not be returned for auth a", v1);
 
-        List<Vertex> vertices = toList(graph.query(AUTHORIZATIONS_B)
-                .has("age", Compare.EQUAL, 25)
-                .vertices());
-        assertEquals(1, vertices.size());
-
-        vertices = toList(graph.query(AUTHORIZATIONS_A)
-                .has("age", Compare.EQUAL, 25)
-                .vertices());
-        assertEquals(0, vertices.size());
+        assertResultsCount(0, 0, graph.query(AUTHORIZATIONS_A).has("age", 25).vertices());
+        assertResultsCount(1, 1, graph.query(AUTHORIZATIONS_B).has("age", 25).vertices());
     }
 
     @Test
@@ -4965,8 +4960,8 @@ public abstract class GraphTestBase {
         assertNull(v1.getProperty("prop1"));
         assertNotNull(v1.getProperty("prop2"));
 
-        Assert.assertEquals(1, count(graph.query(AUTHORIZATIONS_B).has("prop1", "value1").vertices()));
-        Assert.assertEquals(0, count(graph.query(AUTHORIZATIONS_A).has("prop1", "value1").vertices()));
+        assertResultsCount(0, 0, graph.query(AUTHORIZATIONS_A).has("prop1", "value1").vertices());
+        assertResultsCount(1, 1, graph.query(AUTHORIZATIONS_B).has("prop1", "value1").vertices());
 
         Map<Object, Long> propertyCountByValue = queryGraphQueryWithTermsAggregation("prop1", ElementType.VERTEX, AUTHORIZATIONS_A);
         if (propertyCountByValue != null) {
@@ -4993,6 +4988,11 @@ public abstract class GraphTestBase {
                 .save(AUTHORIZATIONS_A_AND_B);
         graph.flush();
 
+        assertResultsCount(0, 0, graph.query(AUTHORIZATIONS_B).has("prop1", "value1").vertices());
+        assertResultsCount(0, 0, graph.query(AUTHORIZATIONS_A).has("prop1", "value1").vertices());
+        assertResultsCount(0, 0, graph.query(AUTHORIZATIONS_B).has("prop1", "value1New").vertices());
+        assertResultsCount(1, 1, graph.query(AUTHORIZATIONS_A).has("prop1", "value1New").vertices());
+
         v1 = graph.getVertex("v1", AUTHORIZATIONS_A_AND_B);
         assertNotNull(v1.getProperty("prop1"));
         assertEquals("value1New", v1.getPropertyValue("prop1"));
@@ -5008,6 +5008,13 @@ public abstract class GraphTestBase {
         v1 = graph.getVertex("v1", AUTHORIZATIONS_A_AND_B);
         assertNotNull(v1.getProperty("prop1"));
         assertEquals("value1New2", v1.getPropertyValue("prop1"));
+
+        assertResultsCount(0, 0, graph.query(AUTHORIZATIONS_B).has("prop1", "value1").vertices());
+        assertResultsCount(0, 0, graph.query(AUTHORIZATIONS_A).has("prop1", "value1").vertices());
+        assertResultsCount(0, 0, graph.query(AUTHORIZATIONS_B).has("prop1", "value1New").vertices());
+        assertResultsCount(0, 0, graph.query(AUTHORIZATIONS_A).has("prop1", "value1New").vertices());
+        assertResultsCount(0, 0, graph.query(AUTHORIZATIONS_B).has("prop1", "value1New2").vertices());
+        assertResultsCount(1, 1, graph.query(AUTHORIZATIONS_A).has("prop1", "value1New2").vertices());
     }
 
     @Test


### PR DESCRIPTION
When saving an ExistingElementMutation, the AccumuloElement/AccumuloGraph code would previously make multiple index update requests and up to two refreshes of the search index. This change adds a new method to the SearchIndex to apply an ExistingElementMutation directly. This allows the ES index to be updated with a single request using a painless script. 

As an additional benefit, we were previously sending the entire document as an upsert request which potentially sent more data than necessary. Now we only send the property value for fields that are added by the mutation.