### PR TITLE
Fix calling InputStream.reset if mark is called before reading data

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,7 @@
 * Changed: When saving an ExistingElementMutation, the Elastisearch5Index will now apply the mutations using a painless script rather than making multiple requests.
 * Changed: When using Accumulo, all threads now share a single batch writer rather than creating a new writer for every thread. This allows client programs to more effectively use multi-threading.
 * Fixed: Prevent concurrent modification exceptions when using InMemoryGraph through synchronizing the methods and also returning Collection copies. 
+* Fixed: The InputStream for a StreamingPropertyValue stored in Accumulo now supports mark/reset.  
 
 # v3.2.0
 * Changed: Elasticsearch _id and _type fields to be much smaller to minimize the size of the _uid field data cache 

--- a/accumulo/src/main/java/org/vertexium/accumulo/StreamingPropertyValueTableData.java
+++ b/accumulo/src/main/java/org/vertexium/accumulo/StreamingPropertyValueTableData.java
@@ -63,6 +63,7 @@ public class StreamingPropertyValueTableData extends StreamingPropertyValue {
         private Span trace;
         private ScannerBase scanner;
         private Iterator<Map.Entry<Key, Value>> scannerIterator;
+        private long previousLoadedDataLength;
         private long loadedDataLength;
         private boolean closed;
 
@@ -152,7 +153,7 @@ public class StreamingPropertyValueTableData extends StreamingPropertyValue {
                     }
                     long len = Math.min(data.length, length - loadedDataLength);
                     buffer.write(data, 0, (int) len);
-                    markLoadedDataLength = loadedDataLength;
+                    previousLoadedDataLength = loadedDataLength;
                     loadedDataLength += len;
                     return true;
                 }
@@ -205,8 +206,9 @@ public class StreamingPropertyValueTableData extends StreamingPropertyValue {
 
         @Override
         public synchronized void mark(int readlimit) {
-            markRowIndex = currentDataRowIndex;
+            markRowIndex = Math.max(0, currentDataRowIndex);
             markByteOffsetInRow = currentByteOffsetInRow;
+            markLoadedDataLength = previousLoadedDataLength;
         }
 
         @Override


### PR DESCRIPTION
The `InputStream` for a `StreamingPropertyValue` was not being properly reset if `mark` was called before reading any data from the stream.