### PR TITLE
Move property conversion so it's called on updates

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,7 @@
 
 # v3.2.2
 * Fixed: Improved support for multithreaded clients with InMemoryGraph
+* Fixed: Fixed saving BigInteger and BigDecimal when using prepareMutation with existing element
 
 # v3.2.1
 * Changed: When saving an ExistingElementMutation, the Elastisearch5Index will now apply the mutations using a painless script rather than making multiple requests.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,7 +3,7 @@
 
 # v3.2.2
 * Fixed: Improved support for multithreaded clients with InMemoryGraph
-* Fixed: Fixed saving BigInteger and BigDecimal when using prepareMutation with existing element
+* Fixed: Saving BigInteger and BigDecimal when using prepareMutation with existing element
 
 # v3.2.1
 * Changed: When saving an ExistingElementMutation, the Elastisearch5Index will now apply the mutations using a painless script rather than making multiple requests.

--- a/elasticsearch5/src/main/java/org/vertexium/elasticsearch5/Elasticsearch5SearchIndex.java
+++ b/elasticsearch5/src/main/java/org/vertexium/elasticsearch5/Elasticsearch5SearchIndex.java
@@ -769,7 +769,7 @@ public class Elasticsearch5SearchIndex implements SearchIndex, SearchIndexWithVe
                 List list = (List) property.getValue();
                 jsonBuilder.field(propertyKey, list.toArray(new Object[list.size()]));
             } else {
-                jsonBuilder.field(propertyKey, convertValueForIndexing(property.getValue()));
+                jsonBuilder.field(propertyKey, property.getValue());
             }
         }
     }
@@ -1983,21 +1983,22 @@ public class Elasticsearch5SearchIndex implements SearchIndex, SearchIndexWithVe
     @SuppressWarnings("unchecked")
     protected void addPropertyValueToPropertiesMap(Map<String, Object> propertiesMap, String propertyName, Object propertyValue) {
         Object existingValue = propertiesMap.get(propertyName);
+        Object valueForIndex = convertValueForIndexing(propertyValue);
         if (existingValue == null) {
-            propertiesMap.put(propertyName, propertyValue);
+            propertiesMap.put(propertyName, valueForIndex);
             return;
         }
 
         if (existingValue instanceof List) {
             ArrayList newList = new ArrayList<>((List) existingValue);
-            newList.add(propertyValue);
+            newList.add(valueForIndex);
             propertiesMap.put(propertyName, newList);
             return;
         }
 
         List list = new ArrayList();
         list.add(existingValue);
-        list.add(propertyValue);
+        list.add(valueForIndex);
         propertiesMap.put(propertyName, list);
     }
 

--- a/test/src/main/java/org/vertexium/test/GraphTestBase.java
+++ b/test/src/main/java/org/vertexium/test/GraphTestBase.java
@@ -5010,6 +5010,46 @@ public abstract class GraphTestBase {
     }
 
     @Test
+    public void testValueTypesUpdatingWithMutations() throws Exception {
+        Date date = createDate(2014, 2, 24, 13, 0, 5);
+
+        graph.prepareVertex("v1", VISIBILITY_A).save(AUTHORIZATIONS_A_AND_B);
+        graph.flush();
+
+        graph.getVertex("v1", AUTHORIZATIONS_A_AND_B)
+            .prepareMutation()
+            .addPropertyValue("", "int", 5, VISIBILITY_A)
+            .addPropertyValue("", "bigInteger", BigInteger.valueOf(10), VISIBILITY_A)
+            .addPropertyValue("", "bigDecimal", BigDecimal.valueOf(1.1), VISIBILITY_A)
+            .addPropertyValue("", "double", 5.6, VISIBILITY_A)
+            .addPropertyValue("", "float", 6.4f, VISIBILITY_A)
+            .addPropertyValue("", "string", "test", VISIBILITY_A)
+            .addPropertyValue("", "byte", (byte) 5, VISIBILITY_A)
+            .addPropertyValue("", "long", (long) 5, VISIBILITY_A)
+            .addPropertyValue("", "boolean", true, VISIBILITY_A)
+            .addPropertyValue("", "geopoint", new GeoPoint(77, -33), VISIBILITY_A)
+            .addPropertyValue("", "short", (short) 5, VISIBILITY_A)
+            .addPropertyValue("", "date", date, VISIBILITY_A)
+            .save(AUTHORIZATIONS_A_AND_B);
+        graph.flush();
+
+        Assert.assertEquals(1, count(graph.query(AUTHORIZATIONS_A).has("int", 5).vertices()));
+        Assert.assertEquals(1, count(graph.query(AUTHORIZATIONS_A).has("double", 5.6).vertices()));
+        Assert.assertEquals(1, count(graph.query(AUTHORIZATIONS_A).range("float", 6.3f, 6.5f).vertices())); // can't search for 6.4f her because of float precision
+        Assert.assertEquals(1, count(graph.query(AUTHORIZATIONS_A).has("string", "test").vertices()));
+        Assert.assertEquals(1, count(graph.query(AUTHORIZATIONS_A).has("byte", 5).vertices()));
+        Assert.assertEquals(1, count(graph.query(AUTHORIZATIONS_A).has("long", 5).vertices()));
+        Assert.assertEquals(1, count(graph.query(AUTHORIZATIONS_A).has("boolean", true).vertices()));
+        Assert.assertEquals(1, count(graph.query(AUTHORIZATIONS_A).has("short", 5).vertices()));
+        Assert.assertEquals(1, count(graph.query(AUTHORIZATIONS_A).has("date", date).vertices()));
+        Assert.assertEquals(1, count(graph.query(AUTHORIZATIONS_A).has("bigInteger", BigInteger.valueOf(10)).vertices()));
+        Assert.assertEquals(1, count(graph.query(AUTHORIZATIONS_A).has("bigInteger", 10).vertices()));
+        Assert.assertEquals(1, count(graph.query(AUTHORIZATIONS_A).has("bigDecimal", BigDecimal.valueOf(1.1)).vertices()));
+        Assert.assertEquals(1, count(graph.query(AUTHORIZATIONS_A).has("bigDecimal", 1.1).vertices()));
+        Assert.assertEquals(1, count(graph.query(AUTHORIZATIONS_A).has("geopoint", GeoCompare.WITHIN, new GeoCircle(77, -33, 1)).vertices()));
+    }
+
+    @Test
     public void testChangeVisibilityVertex() {
         graph.prepareVertex("v1", VISIBILITY_A)
                 .save(AUTHORIZATIONS_A_AND_B);


### PR DESCRIPTION
If calling index.updateElement the conversion wasn't called so would fail if saving a BigDecimal or BigInteger

All tests use InMemoryElement which always calls `addElement`