### PR TITLE
Reload Elasticsearch IndexInfo Cache when Property Definitions Change (3.2)

### DIFF
--- a/accumulo/src/main/java/org/vertexium/accumulo/AccumuloElement.java
+++ b/accumulo/src/main/java/org/vertexium/accumulo/AccumuloElement.java
@@ -41,7 +41,7 @@ public abstract class AccumuloElement extends ElementBase implements Serializabl
     private Visibility visibility;
     private final long timestamp;
     private final EnumSet<FetchHint> fetchHints;
-    private Set<Visibility> hiddenVisibilities = new HashSet<>();
+    private final Set<Visibility> hiddenVisibilities;
 
     private final PropertyCollection properties;
     private final ImmutableSet<String> extendedDataTableNames;
@@ -70,11 +70,14 @@ public abstract class AccumuloElement extends ElementBase implements Serializabl
         this.properties = new PropertyCollection();
         this.extendedDataTableNames = extendedDataTableNames;
         this.authorizations = authorizations;
+
+        ImmutableSet.Builder<Visibility> hiddenVisibilityBuilder = new ImmutableSet.Builder<>();
         if (hiddenVisibilities != null) {
             for (Visibility v : hiddenVisibilities) {
-                this.hiddenVisibilities.add(v);
+                hiddenVisibilityBuilder.add(v);
             }
         }
+        this.hiddenVisibilities = hiddenVisibilityBuilder.build();
         updatePropertiesInternal(properties, propertyDeleteMutations, propertySoftDeleteMutations);
     }
 

--- a/accumulo/src/main/java/org/vertexium/accumulo/AccumuloGraph.java
+++ b/accumulo/src/main/java/org/vertexium/accumulo/AccumuloGraph.java
@@ -2881,6 +2881,7 @@ public class AccumuloGraph extends GraphBaseWithSearchIndex implements Traceable
                 synchronized (entries) {
                     entries.clear();
                 }
+                getSearchIndex().clearCache();
             });
             try {
                 this.treeCache.start();

--- a/core/src/main/java/org/vertexium/search/DefaultSearchIndex.java
+++ b/core/src/main/java/org/vertexium/search/DefaultSearchIndex.java
@@ -93,6 +93,11 @@ public class DefaultSearchIndex implements SearchIndex {
     }
 
     @Override
+    public void clearCache() {
+
+    }
+
+    @Override
     public void shutdown() {
 
     }

--- a/core/src/main/java/org/vertexium/search/SearchIndex.java
+++ b/core/src/main/java/org/vertexium/search/SearchIndex.java
@@ -58,6 +58,8 @@ public interface SearchIndex {
 
     void shutdown();
 
+    void clearCache();
+
     boolean isFieldBoostSupported();
 
     void truncate(Graph graph);

--- a/elasticsearch5/src/test/java/org/vertexium/elasticsearch5/Elasticsearch5SearchIndexTest.java
+++ b/elasticsearch5/src/test/java/org/vertexium/elasticsearch5/Elasticsearch5SearchIndexTest.java
@@ -78,7 +78,7 @@ public class Elasticsearch5SearchIndexTest extends GraphTestBase {
     public void testGraphQuerySortOnPropertyThatHasNoValuesInTheIndex() {
         super.testGraphQuerySortOnPropertyThatHasNoValuesInTheIndex();
 
-        getSearchIndex().clearIndexInfoCache();
+        getSearchIndex().clearCache();
 
         QueryResultsIterable<Vertex> vertices = graph.query(AUTHORIZATIONS_A).sort("age", SortDirection.ASCENDING).vertices();
         Assert.assertEquals(2, count(vertices));


### PR DESCRIPTION
When a cluster member is notified of property definition changes, we need to reload the Elasticsearch IndexInfo cache to see the new property definitions.