### PR TITLE
Changed: Elasticsearch to use BulkProcessor

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,4 +1,5 @@
 # v4.0.1
+* Changed: Elasticsearch to use BulkProcessor 
 * Added: Edge query support for in and out vertex ids
 
 # v4.0.0

--- a/elasticsearch5/src/main/java/org/vertexium/elasticsearch5/utils/DefaultBulkProcessorListener.java
+++ b/elasticsearch5/src/main/java/org/vertexium/elasticsearch5/utils/DefaultBulkProcessorListener.java
@@ -1,0 +1,22 @@
+package org.vertexium.elasticsearch5.utils;
+
+import org.elasticsearch.action.bulk.BulkProcessor;
+import org.elasticsearch.action.bulk.BulkRequest;
+import org.elasticsearch.action.bulk.BulkResponse;
+
+public abstract class DefaultBulkProcessorListener implements BulkProcessor.Listener {
+    @Override
+    public void beforeBulk(long executionId, BulkRequest request) {
+
+    }
+
+    @Override
+    public void afterBulk(long executionId, BulkRequest request, BulkResponse response) {
+
+    }
+
+    @Override
+    public void afterBulk(long executionId, BulkRequest request, Throwable failure) {
+
+    }
+}

--- a/test/src/main/java/org/vertexium/test/GraphTestBase.java
+++ b/test/src/main/java/org/vertexium/test/GraphTestBase.java
@@ -1250,9 +1250,13 @@ public abstract class GraphTestBase {
 
             Iterable<ExtendedDataRow> extendedData = graph.getExtendedData(ElementType.VERTEX, "v1", "table1", AUTHORIZATIONS_A);
             searchIndex.addExtendedData(graph, extendedData, AUTHORIZATIONS_A);
+            graph.flush();
         }
 
-        QueryResultsIterable<ExtendedDataRow> rows = graph.query(AUTHORIZATIONS_A)
+        QueryResultsIterable<ExtendedDataRow> rows = graph.query(AUTHORIZATIONS_A).extendedDataRows();
+        assertResultsCount(2, 2, rows);
+
+        rows = graph.query(AUTHORIZATIONS_A)
                 .has("name", "value1")
                 .extendedDataRows();
         assertResultsCount(1, 1, rows);


### PR DESCRIPTION
The default for the builder is to queue up to 1000 actions and 5MB and to have 1 in-flight request at a time so I think that should work as good defaults.