### PR TITLE
Add explicit test dependency for log4j

### DIFF
--- a/elasticsearch5/pom.xml
+++ b/elasticsearch5/pom.xml
@@ -139,6 +139,11 @@
             <version>${project.version}</version>
             <scope>test</scope>
         </dependency>
+        <dependency>
+            <groupId>log4j</groupId>
+            <artifactId>log4j</artifactId>
+            <scope>test</scope>
+        </dependency>
     </dependencies>
 
     <build>


### PR DESCRIPTION
On a brand new clone of the Vertexium repo, IntelliJ is not able to find the log4j dependency needed by  `org.vertexium.elasticsearch5.utils.ConsoleAppender`. Prior to this PR, the log4j dependency is transitively included and the Vertexium project's root pom sets the scope as runtime. For some reason, Maven and IntelliJ process this transitive runtime dependency differently. Nevertheless, since `org.vertexium.elasticsearch5.utils.ConsoleAppender` directly extends a log4j class, the log4j dependency should be called out explicitly in its module pom file. This makes IntelliJ happy too.