### PR TITLE
Disallow leading wildcards

### DIFF
--- a/elasticsearch5-plugin/src/main/java/org/vertexium/elasticsearch5/plugin/VertexiumQueryStringQueryBuilder.java
+++ b/elasticsearch5-plugin/src/main/java/org/vertexium/elasticsearch5/plugin/VertexiumQueryStringQueryBuilder.java
@@ -26,6 +26,7 @@ public class VertexiumQueryStringQueryBuilder extends QueryStringQueryBuilder {
     public VertexiumQueryStringQueryBuilder(StreamInput in) throws IOException {
         super(in);
         authorizations = in.readStringArray();
+        allowLeadingWildcard(false);
     }
 
     @Override

--- a/elasticsearch5/src/main/java/org/vertexium/elasticsearch5/ElasticsearchSearchQueryBase.java
+++ b/elasticsearch5/src/main/java/org/vertexium/elasticsearch5/ElasticsearchSearchQueryBase.java
@@ -195,6 +195,7 @@ public class ElasticsearchSearchQueryBase extends QueryBase {
             for (String field : fields) {
                 qs = qs.field(getSearchIndex().replaceFieldnameDots(field));
             }
+            qs.allowLeadingWildcard(false);
             return qs;
         }
     }

--- a/elasticsearch5/src/main/java/org/vertexium/elasticsearch5/VertexiumQueryStringQueryBuilder.java
+++ b/elasticsearch5/src/main/java/org/vertexium/elasticsearch5/VertexiumQueryStringQueryBuilder.java
@@ -19,6 +19,7 @@ public class VertexiumQueryStringQueryBuilder extends QueryStringQueryBuilder {
     private VertexiumQueryStringQueryBuilder(String queryString, Authorizations authorizations) {
         super(queryString);
         this.authorizations = authorizations;
+        allowLeadingWildcard(false);
     }
 
     public static VertexiumQueryStringQueryBuilder build(String queryString, Authorizations authorizations) {


### PR DESCRIPTION
This PR turns off default support for wildcards at the start of a query, which alleviates significant performance impacts on large indices.