### PR TITLE
 Upgrade Elasticsearch version to 5.6.10 and Accumulo to 1.9.2

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,8 @@
-# v4.1.4
+# v4.2.0
 * Added: Elasticsearch handler for missing documents
 * Added: Query edges with a given in or out vertex
+* Changed: Elasticsearch version to 5.6.10
+* Changed: Accumulo version to 1.9.2
 
 # v4.1.3
 * Added: Query not equals element id

--- a/accumulo/src/main/java/org/vertexium/accumulo/AccumuloGraphConfiguration.java
+++ b/accumulo/src/main/java/org/vertexium/accumulo/AccumuloGraphConfiguration.java
@@ -118,7 +118,7 @@ public class AccumuloGraphConfiguration extends GraphConfiguration {
 
     @SuppressWarnings("unchecked")
     public ClientConfiguration getClientConfiguration() {
-        ClientConfiguration config = new ClientConfiguration(new ArrayList<>())
+        ClientConfiguration config = ClientConfiguration.create()
                 .withInstance(this.getAccumuloInstanceName())
                 .withZkHosts(this.getZookeeperServers());
         for (Map.Entry<String, String> entry : getClientConfigurationProperties().entrySet()) {

--- a/accumulo/src/main/java/org/vertexium/accumulo/mapreduce/AccumuloElementInputFormatBase.java
+++ b/accumulo/src/main/java/org/vertexium/accumulo/mapreduce/AccumuloElementInputFormatBase.java
@@ -37,7 +37,7 @@ public abstract class AccumuloElementInputFormatBase<TValue extends Element> ext
     public static void setInputInfo(Job job, String instanceName, String zooKeepers, String principal, AuthenticationToken token, String[] authorizations, String tableName) throws AccumuloSecurityException {
         AccumuloRowInputFormat.setInputTableName(job, tableName);
         AccumuloRowInputFormat.setConnectorInfo(job, principal, token);
-        ClientConfiguration clientConfig = new ClientConfiguration()
+        ClientConfiguration clientConfig = ClientConfiguration.create()
                 .withInstance(instanceName)
                 .withZkHosts(zooKeepers);
         AccumuloRowInputFormat.setZooKeeperInstance(job, clientConfig);

--- a/accumulo/src/main/java/org/vertexium/accumulo/mapreduce/AccumuloElementOutputFormat.java
+++ b/accumulo/src/main/java/org/vertexium/accumulo/mapreduce/AccumuloElementOutputFormat.java
@@ -15,7 +15,7 @@ public class AccumuloElementOutputFormat extends OutputFormat<Text, Mutation> {
 
     public static void setOutputInfo(Job job, String instanceName, String zooKeepers, String principal, AuthenticationToken token) throws AccumuloSecurityException {
         AccumuloOutputFormat.setConnectorInfo(job, principal, token);
-        ClientConfiguration clientConfig = new ClientConfiguration()
+        ClientConfiguration clientConfig = ClientConfiguration.create()
                 .withInstance(instanceName)
                 .withZkHosts(zooKeepers);
         AccumuloOutputFormat.setZooKeeperInstance(job, clientConfig);

--- a/elasticsearch5-plugin/src/main/assemblies/plugin-descriptor.properties
+++ b/elasticsearch5-plugin/src/main/assemblies/plugin-descriptor.properties
@@ -2,5 +2,5 @@ description=Vertexium
 version=master
 classname=org.vertexium.elasticsearch5.plugin.VertexiumElasticsearchPlugin
 java.version=1.8
-elasticsearch.version=5.5.3
+elasticsearch.version=5.6.10
 name=vertexium

--- a/elasticsearch5-plugin/src/main/java/org/vertexium/elasticsearch5/plugin/VertexiumQueryStringQueryBuilder.java
+++ b/elasticsearch5-plugin/src/main/java/org/vertexium/elasticsearch5/plugin/VertexiumQueryStringQueryBuilder.java
@@ -103,7 +103,7 @@ public class VertexiumQueryStringQueryBuilder extends QueryStringQueryBuilder {
             }
 
             return FieldNameToVisibilityMap.createFromVertexiumMetadata(results);
-        } catch (IOException ex) {
+        } catch (Exception ex) {
             throw new RuntimeException("Could not get mappings", ex);
         }
     }

--- a/pom.xml
+++ b/pom.xml
@@ -90,16 +90,13 @@
         <jts.version>1.13</jts.version>
         <spatial4j.version>0.6</spatial4j.version>
 
-        <!-- used by: elasticsearch-* -->
-        <elasticsearch.version>1.7.5</elasticsearch.version>
-
         <!-- used by: elasticsearch5* -->
-        <elasticsearch5.version>5.5.3</elasticsearch5.version>
-        <elasticsearch-cluster-runner.version>5.5.3.0</elasticsearch-cluster-runner.version>
+        <elasticsearch5.version>5.6.10</elasticsearch5.version>
+        <elasticsearch-cluster-runner.version>5.6.9.0</elasticsearch-cluster-runner.version>
         <log4j2.version>2.9.0</log4j2.version> <!-- used during testing to run the embedded ES server -->
 
         <!-- used by: accumulo* -->
-        <accumulo.version>1.7.2</accumulo.version>
+        <accumulo.version>1.9.2</accumulo.version>
         <zookeeper.version>3.4.12</zookeeper.version>
         <curator.version>2.12.0</curator.version>
         <hadoop.version>2.9.0</hadoop.version>


### PR DESCRIPTION

Wanted Accumulo 1.9 to get faster performance https://accumulo.apache.org/release/accumulo-1.9.0/#performance-improvements

According to `GraphTestBase#benchmark` running Accumulo

Before...

```
2018-08-01 11:39:21.913/EDT INFO  [vertexium.test.GraphTestBase] add vertices in 0.934s
2018-08-01 11:39:22.784/EDT INFO  [vertexium.test.GraphTestBase] add edges in 0.871s
2018-08-01 11:39:43.282/EDT INFO  [vertexium.test.GraphTestBase] find vertices by id in 20.498s
```

After...

```
2018-08-01 10:25:33.749/EDT INFO  [vertexium.test.GraphTestBase] add vertices in 1.074s
2018-08-01 10:25:34.841/EDT INFO  [vertexium.test.GraphTestBase] add edges in 1.092s
2018-08-01 10:25:50.887/EDT INFO  [vertexium.test.GraphTestBase] find vertices by id in 16.045s
```

So it looks like writes were slightly slower but reads were quite a bit faster.