### PR TITLE
Pass Table Name to AccumuloGraphLogger for a Scanner

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,6 @@
 # v4.3.2
 * Added: The ability to perform a term query by prefix using a new Compare.STARTS_WITH predicate. 
+* Fixed: AccumuloGraphLogger was throwing an error when trying to log a field from a Scanner that was removed in Accumulo 1.8.0
 
 # v4.3.1
 * Fixed: Serialization of StreamingPropertyValueRef

--- a/accumulo/src/main/java/org/vertexium/accumulo/AccumuloGraph.java
+++ b/accumulo/src/main/java/org/vertexium/accumulo/AccumuloGraph.java
@@ -1674,7 +1674,7 @@ public class AccumuloGraph extends GraphBaseWithSearchIndex implements Traceable
             }
 
             applyFetchHints(scanner, fetchHints, elementType);
-            GRAPH_LOGGER.logStartIterator(scanner);
+            GRAPH_LOGGER.logStartIterator(tableName, scanner);
             return scanner;
         } catch (TableNotFoundException e) {
             throw new VertexiumException(e);
@@ -2454,7 +2454,7 @@ public class AccumuloGraph extends GraphBaseWithSearchIndex implements Traceable
             protected Iterator<Map.Entry<Key, Value>> createIterator() {
                 try {
                     scanner = createScanner(getMetadataTableName(), range, METADATA_AUTHORIZATIONS);
-                    GRAPH_LOGGER.logStartIterator(scanner);
+                    GRAPH_LOGGER.logStartIterator(getMetadataTableName(), scanner);
 
                     IteratorSetting versioningIteratorSettings = new IteratorSetting(
                             90,
@@ -2562,7 +2562,7 @@ public class AccumuloGraph extends GraphBaseWithSearchIndex implements Traceable
             );
             scanner.addScanIterator(rowIteratorSettings);
 
-            GRAPH_LOGGER.logStartIterator(scanner);
+            GRAPH_LOGGER.logStartIterator(tableName, scanner);
             return scanner;
         } catch (TableNotFoundException e) {
             throw new VertexiumException(e);
@@ -2842,7 +2842,7 @@ public class AccumuloGraph extends GraphBaseWithSearchIndex implements Traceable
                 );
                 scanner.addScanIterator(countingIterator);
 
-                GRAPH_LOGGER.logStartIterator(scanner);
+                GRAPH_LOGGER.logStartIterator(tableName, scanner);
 
                 long count = 0;
                 for (Map.Entry<Key, Value> entry : scanner) {

--- a/accumulo/src/main/java/org/vertexium/accumulo/AccumuloGraphLogger.java
+++ b/accumulo/src/main/java/org/vertexium/accumulo/AccumuloGraphLogger.java
@@ -21,7 +21,7 @@ public class AccumuloGraphLogger {
         this.queryLogger = queryLogger;
     }
 
-    public void logStartIterator(ScannerBase scanner) {
+    public void logStartIterator(String table, ScannerBase scanner) {
         if (!queryLogger.isTraceEnabled()) {
             return;
         }
@@ -29,20 +29,6 @@ public class AccumuloGraphLogger {
         SortedSet<Column> fetchedColumns = null;
         if (scanner instanceof ScannerOptions) {
             fetchedColumns = ((ScannerOptions) scanner).getFetchedColumns();
-        }
-
-        String table = null;
-        try {
-            Field tableField = scanner.getClass().getDeclaredField("table");
-            tableField.setAccessible(true);
-            Object tableObj = tableField.get(scanner);
-            if (tableObj instanceof String) {
-                table = (String) tableObj;
-            } else {
-                table = tableObj.toString();
-            }
-        } catch (Exception e) {
-            queryLogger.trace("Could not get table name from scanner", e);
         }
 
         if (scanner instanceof BatchScanner) {

--- a/accumulo/src/main/java/org/vertexium/accumulo/StreamingPropertyValueTable.java
+++ b/accumulo/src/main/java/org/vertexium/accumulo/StreamingPropertyValueTable.java
@@ -86,7 +86,7 @@ public class StreamingPropertyValueTable extends StreamingPropertyValue {
                 scanner.addScanIterator(iteratorSetting);
             }
 
-            GRAPH_LOGGER.logStartIterator(scanner);
+            GRAPH_LOGGER.logStartIterator(graph.getDataTableName(), scanner);
             Span trace = Trace.start("streamingPropertyValueTableData");
             trace.data("dataRowKeyCount", Integer.toString(1));
             try {

--- a/accumulo/src/main/java/org/vertexium/accumulo/StreamingPropertyValueTableData.java
+++ b/accumulo/src/main/java/org/vertexium/accumulo/StreamingPropertyValueTableData.java
@@ -198,7 +198,7 @@ public class StreamingPropertyValueTableData extends StreamingPropertyValue {
             TimestampFilter.setEnd(iteratorSetting, timestamp, true);
             scanner.addScanIterator(iteratorSetting);
 
-            graph.getGraphLogger().logStartIterator(scanner);
+            graph.getGraphLogger().logStartIterator(graph.getDataTableName(), scanner);
             trace = Trace.start("streamingPropertyValueTableData");
             trace.data("dataRowKeyCount", Integer.toString(1));
             return scanner;

--- a/accumulo/src/main/java/org/vertexium/accumulo/util/OverflowIntoHdfsStreamingPropertyValueStorageStrategy.java
+++ b/accumulo/src/main/java/org/vertexium/accumulo/util/OverflowIntoHdfsStreamingPropertyValueStorageStrategy.java
@@ -127,7 +127,7 @@ public class OverflowIntoHdfsStreamingPropertyValueStorageStrategy implements St
             final long timerStartTime = System.currentTimeMillis();
             ScannerBase scanner = graph.createBatchScanner(graph.getDataTableName(), ranges, new org.apache.accumulo.core.security.Authorizations());
 
-            graph.getGraphLogger().logStartIterator(scanner);
+            graph.getGraphLogger().logStartIterator(graph.getDataTableName(), scanner);
             Span trace = Trace.start("streamingPropertyValueTableData");
             trace.data("dataRowKeyCount", Integer.toString(dataRowKeys.size()));
             try {


### PR DESCRIPTION
Fixed: AccumuloGraphLogger was throwing an error when trying to log a field from a Scanner that was removed in [Accumulo 1.8.0](https://github.com/apache/accumulo/commit/a14bc292d2271a4d369d2b3f04cd49e6efc36280#diff-01878db554932cd0ddae68c59402ce76L45)