### PR TITLE
Indexing: Update GeoShape Extra Properties For Mutations (4.1.1.x)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,7 @@
 # v4.1.1.2
 * Added: Query edges with a given in or out vertex
-* Added: Elasticsearch: Return ElasticsearchEdge and ElasticsearchVertex when FetchHints.EDGE_REF and FetchHints.NONE is set for performance 
+* Added: Elasticsearch: Return ElasticsearchEdge and ElasticsearchVertex when FetchHints.EDGE_REF and FetchHints.NONE is set for performance
+* Fixed: Indexing of GeoShape properties when the property is delete or the visibility is updated.
 
 # v4.1.1.1
 * Fixed: `graph.findRelatedEdgeSummary` filtering edges that were re-added after soft delete/hidden
@@ -13,20 +14,20 @@
 * Changed: Disable leading wildcard support
 * Changed: Update to curator 2.12.0
 * Changed: Update to Hadoop 2.9.0
-* Changed: Update to Zookeeper 3.4.12 
+* Changed: Update to Zookeeper 3.4.12
 
 # v4.1.0
 * Added: Edge query support for in and out vertex ids
 * Changed: If fetch hints were not provided throw an exception instead of returning null
-* Changed: Elasticsearch to use BulkProcessor 
+* Changed: Elasticsearch to use BulkProcessor
 * Changed: Calling hasId multiple times on the same Query object will result in the intersection of the provided lists. Previously, the resulting list was a union of all provided inputs. This behavior is more consistent with the `AND` behavior of the other query methods.
 * Fixed: Updating metadata when metadata was not fetched in fetch hints
 
 # v4.0.0
 * Changed: FetchHints to support more filtering
 * Changed: Throw errors when calling methods without the proper fetch hints
-* Changed: Accumulo: Store metadata in an indexed list to prevent duplication in memory and over the wire 
-* Fixed: Accumulo Iterator memory leak 
+* Changed: Accumulo: Store metadata in an indexed list to prevent duplication in memory and over the wire
+* Fixed: Accumulo Iterator memory leak
 * Added: Method to Vertex to get more detailed edge summary
 * Removed: SQL
 * Removed: Blueprints and Titan support
@@ -36,7 +37,7 @@
 * Fixed: Expand SPVs when running in memory query strings
 * Fixed: Fix query search using different authorizations query string
 * Fixed: Fix indexing of geolocation properties
-* Fixed: notification to Elasticsearch when properties are added 
+* Fixed: notification to Elasticsearch when properties are added
 
 # v3.2.2
 * Fixed: Improved support for multithreaded clients with InMemoryGraph
@@ -45,12 +46,12 @@
 # v3.2.1
 * Changed: When saving an ExistingElementMutation, the Elastisearch5Index will now apply the mutations using a painless script rather than making multiple requests.
 * Changed: When using Accumulo, all threads now share a single batch writer rather than creating a new writer for every thread. This allows client programs to more effectively use multi-threading.
-* Fixed: Prevent concurrent modification exceptions when using InMemoryGraph through synchronizing the methods and also returning Collection copies. 
+* Fixed: Prevent concurrent modification exceptions when using InMemoryGraph through synchronizing the methods and also returning Collection copies.
 * Fixed: The InputStream for a StreamingPropertyValue stored in Accumulo now supports mark/reset.
 * Fixed: Elasticsearch sort throwing errors for String properties while querying across indices
 
 # v3.2.0
-* Changed: Elasticsearch _id and _type fields to be much smaller to minimize the size of the _uid field data cache 
+* Changed: Elasticsearch _id and _type fields to be much smaller to minimize the size of the _uid field data cache
 * Changed: Elasticsearch to only refresh the indices that were changed
 * Fixed: InMemory and Accumulo fix wrong vertex being returned after re-adding the same vertex with a different visibility after soft delete
 * Fixed: Find path when edge labels are deflated
@@ -64,7 +65,7 @@
 * Added: Graph.getExtendedDataInRange in order to bulk load ranges of extended data rows
 * Added: SearchIndex.addExtendedData to allow for reindexing extended data
 * Added: Elasticsearch exception if any shard failures occur on queries
-* Added: Elasticsearch option to force disable the use of the server side plugin 
+* Added: Elasticsearch option to force disable the use of the server side plugin
 
 # v3.1.1
 * Added: Graph.getExtendedData to get a single extended data row
@@ -73,7 +74,7 @@
 # v3.1.0
 * Changed: Set Elasticsearch scroll api query to have a size that is the same as page size
 * Changed: Properly throw NoSuchElementException from Iterables when next is called with no more elements
-* Changed: If exact match is chosen for a property, full text is automatically enabled to support aggregation results 
+* Changed: If exact match is chosen for a property, full text is automatically enabled to support aggregation results
 * Added: Accumulo in table storage of streaming property value data
 * Added: Functions to delete extended data columns
 * Added: Multi-value extended data columns
@@ -92,7 +93,7 @@
 * Fixed: Fix Elasticsearch5 missing field exception when sorting on multiple indices
 
 # v3.0.3
-* Changed: Accumulo default data storage to use in table storage and not overflow to HDFS 
+* Changed: Accumulo default data storage to use in table storage and not overflow to HDFS
 * Added: Added a hasAuthorization method to the Query class to allow searches for any element that uses an authorization string or strings.
 * Added: Query extended data on an element
 * Added: EmptyResultsGraphQuery and EmptyResultsQueryResultsIterable
@@ -109,7 +110,7 @@
 * Added: Added a has method to the Query class to allow searches for a elements with a list of properties. The presence of any property in the list will cause the document to match.
 * Added: Added a has method to the Query class to allow searches for a elements without a list of properties. The absence of all properties in the list will cause the document to match.
 * Added: Implemented support all compare operators for DateOnly field types when using Elasticsearch 5.
-* Fixed: Queries with both a query string and aggregations were throwing a "not implemented" exception in the Elasticsearch 5 plugin. 
+* Fixed: Queries with both a query string and aggregations were throwing a "not implemented" exception in the Elasticsearch 5 plugin.
 
 # v3.0.1
 * Changed: Find Path to not return a path that contains one or more vertices that is can't be retrieved because of visibility restrictions
@@ -126,10 +127,10 @@
 * Changed: Removed ES 2 support and replaced it with ES 5 support
 * Changed: Removed support for NameSubstitutionStrategy from the Elasticsearch modules. NameSubstitutionStrategy is still available for Accumulo modules
 * Changed: Added property checking when using the `has` method to query the graph for a value. An exception will now be thrown if an attempt is made to either query a property that does not exist or to text query a property that isn't full text indexed
-* Note: Upgrading to this version will require re-indexing if you use NameSubstitutionStrategy or are switching to the ES 5 module. 
+* Note: Upgrading to this version will require re-indexing if you use NameSubstitutionStrategy or are switching to the ES 5 module.
 * Added: Support for extended GeoShape storage and search. Currently the new shapes are only supported by the ElasticSearch 5 module.
 * Added: GraphVisitor to visit elements, properties, extended data rows using a visitor pattern
- 
+
 # v2.6.2
 
 * Changed: remove deprecated interfaces, examples, and changed Elasticsearch deprecated methods
@@ -163,7 +164,7 @@
 
 # v2.5.5
 
-* Changed: Removed timestamp from streaming property value row key. 
+* Changed: Removed timestamp from streaming property value row key.
 
 # v2.5.4
 
@@ -253,7 +254,7 @@
 # v2.4.0
 
 * ACCUMULO: iterator locations in accumulo config are now stored per table name
-* Elasticsearch: fix: sort by strings with tokens should not effect sort order 
+* Elasticsearch: fix: sort by strings with tokens should not effect sort order
 * SQL: Switch to HikariCP connection pool
 
 # v2.3.1

--- a/core/src/main/java/org/vertexium/query/Compare.java
+++ b/core/src/main/java/org/vertexium/query/Compare.java
@@ -5,6 +5,7 @@ import org.vertexium.Property;
 import org.vertexium.PropertyDefinition;
 import org.vertexium.TextIndexHint;
 import org.vertexium.property.StreamingPropertyValue;
+import org.vertexium.type.GeoShape;
 
 import java.util.Collection;
 import java.util.Date;
@@ -148,6 +149,10 @@ public enum Compare implements Predicate {
             } catch (NumberFormatException ex) {
                 return 1;
             }
+        }
+        if (first instanceof GeoShape && second instanceof String) {
+            String description = ((GeoShape) first).getDescription();
+            return description == null ? -1 : description.toLowerCase().compareTo((String) second);
         }
         if (first instanceof Comparable) {
             return ((Comparable) first).compareTo(second);

--- a/inmemory/src/main/java/org/vertexium/inmemory/InMemoryEdge.java
+++ b/inmemory/src/main/java/org/vertexium/inmemory/InMemoryEdge.java
@@ -6,8 +6,6 @@ import org.vertexium.inmemory.mutations.EdgeSetupMutation;
 import org.vertexium.mutation.ExistingEdgeMutation;
 import org.vertexium.search.IndexHint;
 
-import java.util.EnumSet;
-
 public class InMemoryEdge extends InMemoryElement<InMemoryEdge> implements Edge {
     private final EdgeSetupMutation edgeSetupMutation;
 
@@ -90,18 +88,10 @@ public class InMemoryEdge extends InMemoryElement<InMemoryEdge> implements Edge 
             @Override
             public Edge save(Authorizations authorizations) {
                 IndexHint indexHint = getIndexHint();
-                Visibility oldVisibility = InMemoryEdge.this.getVisibility();
                 saveExistingElementMutation(this, indexHint, authorizations);
                 Edge edge = getElement();
                 if (indexHint != IndexHint.DO_NOT_INDEX) {
-                    saveMutationToSearchIndex(
-                            edge,
-                            oldVisibility,
-                            getNewElementVisibility(),
-                            getAlterPropertyVisibilities(),
-                            getExtendedData(),
-                            authorizations
-                    );
+                    getGraph().getSearchIndex().updateElement(getGraph(), this, authorizations);
                 }
                 return edge;
             }

--- a/inmemory/src/main/java/org/vertexium/inmemory/InMemoryElement.java
+++ b/inmemory/src/main/java/org/vertexium/inmemory/InMemoryElement.java
@@ -1,20 +1,15 @@
 package org.vertexium.inmemory;
 
 import com.google.common.collect.ImmutableSet;
-import com.google.common.collect.Lists;
 import org.vertexium.*;
 import org.vertexium.mutation.*;
 import org.vertexium.query.ExtendedDataQueryableIterable;
 import org.vertexium.query.QueryableIterable;
 import org.vertexium.search.IndexHint;
 
-import java.util.List;
-
 public abstract class InMemoryElement<TElement extends InMemoryElement> extends ElementBase {
     private final String id;
     private final FetchHints fetchHints;
-    private Property idProperty;
-    private Property edgeLabelProperty;
     private InMemoryGraph graph;
     private InMemoryTableElement<TElement> inMemoryTableElement;
     private final Long endTime;
@@ -307,36 +302,6 @@ public abstract class InMemoryElement<TElement extends InMemoryElement> extends 
             return getId() + ":[" + edge.getVertexId(Direction.OUT) + "-" + edge.getLabel() + "->" + edge.getVertexId(Direction.IN) + "]";
         }
         return getId();
-    }
-
-
-    protected void saveMutationToSearchIndex(
-            Element element,
-            Visibility oldVisibility,
-            Visibility newVisibility,
-            List<AlterPropertyVisibility> alterPropertyVisibilities,
-            Iterable<ExtendedDataMutation> extendedDatas,
-            Authorizations authorizations
-    ) {
-        if (alterPropertyVisibilities != null && alterPropertyVisibilities.size() > 0) {
-            // Bulk delete
-            List<PropertyDescriptor> propertyList = Lists.newArrayList();
-            alterPropertyVisibilities.forEach(p -> propertyList.add(PropertyDescriptor.from(p.getKey(), p.getName(), p.getExistingVisibility())));
-            getGraph().getSearchIndex().deleteProperties(
-                    getGraph(),
-                    element,
-                    propertyList,
-                    authorizations
-            );
-
-            getGraph().getSearchIndex().flush(getGraph());
-        }
-        if (newVisibility != null) {
-            getGraph().getSearchIndex().alterElementVisibility(getGraph(), element, oldVisibility, newVisibility, authorizations);
-        } else {
-            getGraph().getSearchIndex().addElement(getGraph(), element, authorizations);
-            getGraph().getSearchIndex().addElementExtendedData(getGraph(), element, extendedDatas, authorizations);
-        }
     }
 
     public boolean canRead(Authorizations authorizations) {

--- a/inmemory/src/main/java/org/vertexium/inmemory/InMemoryVertex.java
+++ b/inmemory/src/main/java/org/vertexium/inmemory/InMemoryVertex.java
@@ -338,18 +338,10 @@ public class InMemoryVertex extends InMemoryElement<InMemoryVertex> implements V
             @Override
             public Vertex save(Authorizations authorizations) {
                 IndexHint indexHint = getIndexHint();
-                Visibility oldElementVisibility = InMemoryVertex.this.getVisibility();
                 saveExistingElementMutation(this, indexHint, authorizations);
                 Vertex vertex = getElement();
                 if (indexHint != IndexHint.DO_NOT_INDEX) {
-                    saveMutationToSearchIndex(
-                            vertex,
-                            oldElementVisibility,
-                            getNewElementVisibility(),
-                            getAlterPropertyVisibilities(),
-                            getExtendedData(),
-                            authorizations
-                    );
+                    getGraph().getSearchIndex().updateElement(getGraph(), this, authorizations);
                 }
                 return vertex;
             }

--- a/test/src/main/java/org/vertexium/test/GraphTestBase.java
+++ b/test/src/main/java/org/vertexium/test/GraphTestBase.java
@@ -5581,6 +5581,121 @@ public abstract class GraphTestBase {
     }
 
     @Test
+    public void testAlterPropertyVisibilityOfGeoLocation() {
+        graph.defineProperty("prop1").dataType(String.class).textIndexHint(TextIndexHint.ALL).define();
+        graph.defineProperty("prop2").dataType(GeoPoint.class).textIndexHint(TextIndexHint.ALL).define();
+
+        graph.prepareVertex("v1", VISIBILITY_EMPTY)
+                .addPropertyValue("key1", "prop1", "value1", VISIBILITY_A)
+                .addPropertyValue("key1", "prop2", new GeoPoint(38.9186, -77.2297, "Reston, VA"), VISIBILITY_A)
+                .save(AUTHORIZATIONS_A_AND_B);
+        graph.flush();
+
+        Vertex v1 = graph.getVertex("v1", FetchHints.ALL, AUTHORIZATIONS_A);
+        v1.prepareMutation()
+                .alterPropertyVisibility(v1.getProperty("key1", "prop1", VISIBILITY_A), VISIBILITY_EMPTY)
+                .alterPropertyVisibility(v1.getProperty("key1", "prop2", VISIBILITY_A), VISIBILITY_EMPTY)
+                .save(AUTHORIZATIONS_A_AND_B);
+        graph.flush();
+
+        QueryResultsIterable<Vertex> vertices = graph.query(AUTHORIZATIONS_EMPTY).has("prop1", "value1").vertices();
+        assertVertexIdsAnyOrder(vertices, "v1");
+        assertResultsCount(1, 1, vertices);
+
+        vertices = graph.query(AUTHORIZATIONS_EMPTY).has("prop2", "reston, va").vertices();
+        assertVertexIdsAnyOrder(vertices, "v1");
+        assertResultsCount(1, 1, vertices);
+
+        QueryResultsIterable<String> vertexIds = graph.query(AUTHORIZATIONS_EMPTY).has("prop2", GeoCompare.WITHIN, new GeoCircle(38.9186, -77.2297, 1)).vertexIds();
+        assertIdsAnyOrder(vertexIds, "v1");
+        assertResultsCount(1, 1, vertexIds);
+
+        vertices = graph.query(AUTHORIZATIONS_EMPTY).has("prop2", GeoCompare.WITHIN, new GeoCircle(38.9186, -77.2297, 1)).vertices();
+        assertVertexIdsAnyOrder(vertices, "v1");
+        assertResultsCount(1, 1, vertices);
+    }
+
+    @Test
+    public void testDeleteGeoLocationProperty() {
+        graph.defineProperty("prop1").dataType(String.class).textIndexHint(TextIndexHint.ALL).define();
+        graph.defineProperty("prop2").dataType(GeoPoint.class).textIndexHint(TextIndexHint.ALL).define();
+
+        graph.prepareVertex("v1", VISIBILITY_EMPTY)
+                .addPropertyValue("key1", "prop1", "value1", VISIBILITY_A)
+                .addPropertyValue("key1", "prop2", new GeoPoint(38.9186, -77.2297, "Reston, VA"), VISIBILITY_A)
+                .save(AUTHORIZATIONS_A_AND_B);
+        graph.flush();
+
+        Vertex v1 = graph.getVertex("v1", FetchHints.ALL, AUTHORIZATIONS_A);
+        v1.prepareMutation()
+                .deleteProperties("key1", "prop1")
+                .deleteProperties("key1", "prop2")
+                .save(AUTHORIZATIONS_A_AND_B);
+        graph.flush();
+
+        QueryResultsIterable<Vertex> vertices = graph.query(AUTHORIZATIONS_A).has("prop1", "value1").vertices();
+        assertResultsCount(0, 0, vertices);
+
+        vertices = graph.query(AUTHORIZATIONS_A).has("prop2", "reston, va").vertices();
+        assertResultsCount(0, 0, vertices);
+
+        vertices = graph.query(AUTHORIZATIONS_A).has("prop2", GeoCompare.WITHIN, new GeoCircle(38.9186, -77.2297, 1)).vertices();
+        assertResultsCount(0, 0, vertices);
+
+        QueryResultsIterable<String> vertexIds = graph.query(AUTHORIZATIONS_A).has("prop2", GeoCompare.WITHIN, new GeoCircle(38.9186, -77.2297, 1)).vertexIds();
+        assertResultsCount(0, 0, vertexIds);
+    }
+
+
+    @Test
+    public void testGeoLocationsWithDifferentKeys() {
+        graph.defineProperty("prop1").dataType(GeoPoint.class).textIndexHint(TextIndexHint.ALL).define();
+
+        graph.prepareVertex("v1", VISIBILITY_EMPTY)
+                .addPropertyValue("key1", "prop1", new GeoPoint(38.9186, -77.2297, "Reston, VA"), VISIBILITY_A)
+                .save(AUTHORIZATIONS_A_AND_B);
+        graph.flush();
+
+        QueryResultsIterable<Vertex> vertices = graph.query(AUTHORIZATIONS_A).has("prop1", GeoCompare.WITHIN, new GeoCircle(38.9186, -77.2297, 1)).vertices();
+        assertVertexIdsAnyOrder(vertices, "v1");
+        assertResultsCount(1, 1, vertices);
+
+        vertices = graph.query(AUTHORIZATIONS_A).has("prop1", "reston, va").vertices();
+        assertVertexIdsAnyOrder(vertices, "v1");
+        assertResultsCount(1, 1, vertices);
+
+        Vertex v1 = graph.getVertex("v1", FetchHints.ALL, AUTHORIZATIONS_A);
+        v1.prepareMutation()
+                .addPropertyValue("key2", "prop1", new GeoPoint(38.6270, -90.1994, "St Louis, MO"), VISIBILITY_A)
+                .save(AUTHORIZATIONS_A_AND_B);
+        graph.flush();
+
+        // NOTE: Now that the field has multiple values, WITHIN really means that all values must be within the circle
+        vertices = graph.query(AUTHORIZATIONS_A).has("prop1", GeoCompare.WITHIN, new GeoCircle(38.9186, -77.2297, 1)).vertices();
+        assertResultsCount(0, 0, vertices);
+
+        vertices = graph.query(AUTHORIZATIONS_A).has("prop1", GeoCompare.INTERSECTS, new GeoCircle(38.9186, -77.2297, 1)).vertices();
+        assertVertexIdsAnyOrder(vertices, "v1");
+        assertResultsCount(1, 1, vertices);
+
+        vertices = graph.query(AUTHORIZATIONS_A).has("prop1", "reston, va").vertices();
+        assertVertexIdsAnyOrder(vertices, "v1");
+        assertResultsCount(1, 1, vertices);
+
+        // NOTE: Now that the field has multiple values, WITHIN really means that all values must be within the circle
+        vertices = graph.query(AUTHORIZATIONS_A).has("prop1", GeoCompare.WITHIN, new GeoCircle(38.6270, -90.1994, 1)).vertices();
+        assertResultsCount(0, 0, vertices);
+
+        vertices = graph.query(AUTHORIZATIONS_A).has("prop1", GeoCompare.INTERSECTS, new GeoCircle(38.6270, -90.1994, 1)).vertices();
+        assertVertexIdsAnyOrder(vertices, "v1");
+        assertResultsCount(1, 1, vertices);
+
+        vertices = graph.query(AUTHORIZATIONS_A).has("prop1", "st louis, mo").vertices();
+        assertVertexIdsAnyOrder(vertices, "v1");
+        assertResultsCount(1, 1, vertices);
+    }
+
+    @Test
     public void testChangeVisibilityEdge() {
         Vertex v1 = graph.prepareVertex("v1", VISIBILITY_EMPTY)
                 .save(AUTHORIZATIONS_A_AND_B);
@@ -6991,7 +7106,6 @@ public abstract class GraphTestBase {
         q.addAggregation(agg);
         return q.vertices().getAggregationResult("percentiles", PercentilesResult.class);
     }
-
 
     @Test
     public void testGraphQueryWithGeohashAggregation() {


### PR DESCRIPTION
For an existing element, when a GeoShape property is deleted or the property visibility is changed the extra `_g` and `_gp` properties must also be handled properly.