### PR TITLE
Indexing: Update GeoShape Extra Properties For Mutations (master)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,11 +1,12 @@
 # v4.4.1
 * Fixed: Soft Deleted Historical Property Entries not containing metadata information.
 * Fixed: Scoring strategies selecting the correct fields
+* Fixed: Indexing of GeoShape properties when the property is delete or the visibility is updated.
 
 # v4.4.0
 * Added: The ability to perform a term query by prefix using a new Compare.STARTS_WITH predicate.
 * Changed: Accumulo to lazily load metadata values
-* Changed: Metadata was changed to an interface. `new Metadata` needs to be changed to `Metadata.create` 
+* Changed: Metadata was changed to an interface. `new Metadata` needs to be changed to `Metadata.create`
 * Fixed: AccumuloGraphLogger was throwing an error when trying to log a field from a Scanner that was removed in Accumulo 1.8.0
 
 # v4.3.1
@@ -52,20 +53,20 @@
 * Changed: Disable leading wildcard support
 * Changed: Update to curator 2.12.0
 * Changed: Update to Hadoop 2.9.0
-* Changed: Update to Zookeeper 3.4.12 
+* Changed: Update to Zookeeper 3.4.12
 
 # v4.1.0
 * Added: Edge query support for in and out vertex ids
 * Changed: If fetch hints were not provided throw an exception instead of returning null
-* Changed: Elasticsearch to use BulkProcessor 
+* Changed: Elasticsearch to use BulkProcessor
 * Changed: Calling hasId multiple times on the same Query object will result in the intersection of the provided lists. Previously, the resulting list was a union of all provided inputs. This behavior is more consistent with the `AND` behavior of the other query methods.
 * Fixed: Updating metadata when metadata was not fetched in fetch hints
 
 # v4.0.0
 * Changed: FetchHints to support more filtering
 * Changed: Throw errors when calling methods without the proper fetch hints
-* Changed: Accumulo: Store metadata in an indexed list to prevent duplication in memory and over the wire 
-* Fixed: Accumulo Iterator memory leak 
+* Changed: Accumulo: Store metadata in an indexed list to prevent duplication in memory and over the wire
+* Fixed: Accumulo Iterator memory leak
 * Added: Method to Vertex to get more detailed edge summary
 * Removed: SQL
 * Removed: Blueprints and Titan support
@@ -75,7 +76,7 @@
 * Fixed: Expand SPVs when running in memory query strings
 * Fixed: Fix query search using different authorizations query string
 * Fixed: Fix indexing of geolocation properties
-* Fixed: notification to Elasticsearch when properties are added 
+* Fixed: notification to Elasticsearch when properties are added
 
 # v3.2.2
 * Fixed: Improved support for multithreaded clients with InMemoryGraph
@@ -84,12 +85,12 @@
 # v3.2.1
 * Changed: When saving an ExistingElementMutation, the Elastisearch5Index will now apply the mutations using a painless script rather than making multiple requests.
 * Changed: When using Accumulo, all threads now share a single batch writer rather than creating a new writer for every thread. This allows client programs to more effectively use multi-threading.
-* Fixed: Prevent concurrent modification exceptions when using InMemoryGraph through synchronizing the methods and also returning Collection copies. 
+* Fixed: Prevent concurrent modification exceptions when using InMemoryGraph through synchronizing the methods and also returning Collection copies.
 * Fixed: The InputStream for a StreamingPropertyValue stored in Accumulo now supports mark/reset.
 * Fixed: Elasticsearch sort throwing errors for String properties while querying across indices
 
 # v3.2.0
-* Changed: Elasticsearch _id and _type fields to be much smaller to minimize the size of the _uid field data cache 
+* Changed: Elasticsearch _id and _type fields to be much smaller to minimize the size of the _uid field data cache
 * Changed: Elasticsearch to only refresh the indices that were changed
 * Fixed: InMemory and Accumulo fix wrong vertex being returned after re-adding the same vertex with a different visibility after soft delete
 * Fixed: Find path when edge labels are deflated
@@ -103,7 +104,7 @@
 * Added: Graph.getExtendedDataInRange in order to bulk load ranges of extended data rows
 * Added: SearchIndex.addExtendedData to allow for reindexing extended data
 * Added: Elasticsearch exception if any shard failures occur on queries
-* Added: Elasticsearch option to force disable the use of the server side plugin 
+* Added: Elasticsearch option to force disable the use of the server side plugin
 
 # v3.1.1
 * Added: Graph.getExtendedData to get a single extended data row
@@ -112,7 +113,7 @@
 # v3.1.0
 * Changed: Set Elasticsearch scroll api query to have a size that is the same as page size
 * Changed: Properly throw NoSuchElementException from Iterables when next is called with no more elements
-* Changed: If exact match is chosen for a property, full text is automatically enabled to support aggregation results 
+* Changed: If exact match is chosen for a property, full text is automatically enabled to support aggregation results
 * Added: Accumulo in table storage of streaming property value data
 * Added: Functions to delete extended data columns
 * Added: Multi-value extended data columns
@@ -131,7 +132,7 @@
 * Fixed: Fix Elasticsearch5 missing field exception when sorting on multiple indices
 
 # v3.0.3
-* Changed: Accumulo default data storage to use in table storage and not overflow to HDFS 
+* Changed: Accumulo default data storage to use in table storage and not overflow to HDFS
 * Added: Added a hasAuthorization method to the Query class to allow searches for any element that uses an authorization string or strings.
 * Added: Query extended data on an element
 * Added: EmptyResultsGraphQuery and EmptyResultsQueryResultsIterable
@@ -148,7 +149,7 @@
 * Added: Added a has method to the Query class to allow searches for a elements with a list of properties. The presence of any property in the list will cause the document to match.
 * Added: Added a has method to the Query class to allow searches for a elements without a list of properties. The absence of all properties in the list will cause the document to match.
 * Added: Implemented support all compare operators for DateOnly field types when using Elasticsearch 5.
-* Fixed: Queries with both a query string and aggregations were throwing a "not implemented" exception in the Elasticsearch 5 plugin. 
+* Fixed: Queries with both a query string and aggregations were throwing a "not implemented" exception in the Elasticsearch 5 plugin.
 
 # v3.0.1
 * Changed: Find Path to not return a path that contains one or more vertices that is can't be retrieved because of visibility restrictions
@@ -165,10 +166,10 @@
 * Changed: Removed ES 2 support and replaced it with ES 5 support
 * Changed: Removed support for NameSubstitutionStrategy from the Elasticsearch modules. NameSubstitutionStrategy is still available for Accumulo modules
 * Changed: Added property checking when using the `has` method to query the graph for a value. An exception will now be thrown if an attempt is made to either query a property that does not exist or to text query a property that isn't full text indexed
-* Note: Upgrading to this version will require re-indexing if you use NameSubstitutionStrategy or are switching to the ES 5 module. 
+* Note: Upgrading to this version will require re-indexing if you use NameSubstitutionStrategy or are switching to the ES 5 module.
 * Added: Support for extended GeoShape storage and search. Currently the new shapes are only supported by the ElasticSearch 5 module.
 * Added: GraphVisitor to visit elements, properties, extended data rows using a visitor pattern
- 
+
 # v2.6.2
 
 * Changed: remove deprecated interfaces, examples, and changed Elasticsearch deprecated methods
@@ -202,7 +203,7 @@
 
 # v2.5.5
 
-* Changed: Removed timestamp from streaming property value row key. 
+* Changed: Removed timestamp from streaming property value row key.
 
 # v2.5.4
 
@@ -292,7 +293,7 @@
 # v2.4.0
 
 * ACCUMULO: iterator locations in accumulo config are now stored per table name
-* Elasticsearch: fix: sort by strings with tokens should not effect sort order 
+* Elasticsearch: fix: sort by strings with tokens should not effect sort order
 * SQL: Switch to HikariCP connection pool
 
 # v2.3.1

--- a/core/src/main/java/org/vertexium/query/Compare.java
+++ b/core/src/main/java/org/vertexium/query/Compare.java
@@ -161,6 +161,10 @@ public enum Compare implements Predicate {
                 return 1;
             }
         }
+        if (first instanceof GeoShape && second instanceof String) {
+            String description = ((GeoShape) first).getDescription();
+            return description == null ? -1 : description.toLowerCase().compareTo((String) second);
+        }
         if (first instanceof Comparable) {
             return ((Comparable) first).compareTo(second);
         }

--- a/elasticsearch5/src/main/java/org/vertexium/elasticsearch5/Elasticsearch5SearchIndex.java
+++ b/elasticsearch5/src/main/java/org/vertexium/elasticsearch5/Elasticsearch5SearchIndex.java
@@ -466,8 +466,19 @@ public class Elasticsearch5SearchIndex implements SearchIndex, SearchIndexWithVe
 
     private <TElement extends Element> List<String> getFieldsToRemove(Graph graph, ExistingElementMutation<TElement> mutation) {
         List<String> fieldsToRemove = new ArrayList<>();
-        mutation.getPropertyDeletes().forEach(p ->
-                fieldsToRemove.add(addVisibilityToPropertyName(graph, p.getName(), p.getVisibility())));
+        mutation.getPropertyDeletes().forEach(p -> {
+            String propertyName = addVisibilityToPropertyName(graph, p.getName(), p.getVisibility());
+            fieldsToRemove.add(propertyName);
+
+            PropertyDefinition propertyDefinition = getPropertyDefinition(graph, p.getName());
+            if (GeoShape.class.isAssignableFrom(propertyDefinition.getDataType())) {
+                fieldsToRemove.add(propertyName + GEO_PROPERTY_NAME_SUFFIX);
+
+                if (GeoPoint.class.isAssignableFrom(propertyDefinition.getDataType())) {
+                    fieldsToRemove.add(propertyName + GEO_POINT_PROPERTY_NAME_SUFFIX);
+                }
+            }
+        });
         mutation.getPropertySoftDeletes().forEach(p ->
                 fieldsToRemove.add(addVisibilityToPropertyName(graph, p.getName(), p.getVisibility())));
         return fieldsToRemove;
@@ -482,6 +493,15 @@ public class Elasticsearch5SearchIndex implements SearchIndex, SearchIndexWithVe
                     String oldFieldName = addVisibilityToPropertyName(graph, p.getName(), p.getExistingVisibility());
                     String newFieldName = addVisibilityToPropertyName(graph, p.getName(), p.getVisibility());
                     fieldVisibilityChanges.put(oldFieldName, newFieldName);
+
+                    PropertyDefinition propertyDefinition = getPropertyDefinition(graph, p.getName());
+                    if (GeoShape.class.isAssignableFrom(propertyDefinition.getDataType())) {
+                        fieldVisibilityChanges.put(oldFieldName + GEO_PROPERTY_NAME_SUFFIX, newFieldName + GEO_PROPERTY_NAME_SUFFIX);
+
+                        if (GeoPoint.class.isAssignableFrom(propertyDefinition.getDataType())) {
+                            fieldVisibilityChanges.put(oldFieldName + GEO_POINT_PROPERTY_NAME_SUFFIX, newFieldName + GEO_POINT_PROPERTY_NAME_SUFFIX);
+                        }
+                    }
                 });
 
         if (mutation.getNewElementVisibility() != null) {
@@ -1034,7 +1054,9 @@ public class Elasticsearch5SearchIndex implements SearchIndex, SearchIndexWithVe
             convertGeoShape(propertiesMap, propertyName, (GeoShape) propertyValue);
             if (propertyValue instanceof GeoPoint) {
                 GeoPoint geoPoint = (GeoPoint) propertyValue;
-                List<Double> coordinates = Arrays.asList(geoPoint.getLongitude(), geoPoint.getLatitude());
+                Map<String, Double> coordinates = new HashMap<>();
+                coordinates.put("lat", geoPoint.getLatitude());
+                coordinates.put("lon", geoPoint.getLongitude());
                 addPropertyValueToPropertiesMap(propertiesMap, propertyName + GEO_POINT_PROPERTY_NAME_SUFFIX, coordinates);
             }
             return;

--- a/inmemory/src/main/java/org/vertexium/inmemory/InMemoryEdge.java
+++ b/inmemory/src/main/java/org/vertexium/inmemory/InMemoryEdge.java
@@ -6,8 +6,6 @@ import org.vertexium.inmemory.mutations.EdgeSetupMutation;
 import org.vertexium.mutation.ExistingEdgeMutation;
 import org.vertexium.search.IndexHint;
 
-import java.util.EnumSet;
-
 public class InMemoryEdge extends InMemoryElement<InMemoryEdge> implements Edge {
     private final EdgeSetupMutation edgeSetupMutation;
 
@@ -90,18 +88,10 @@ public class InMemoryEdge extends InMemoryElement<InMemoryEdge> implements Edge 
             @Override
             public Edge save(Authorizations authorizations) {
                 IndexHint indexHint = getIndexHint();
-                Visibility oldVisibility = InMemoryEdge.this.getVisibility();
                 saveExistingElementMutation(this, indexHint, authorizations);
                 Edge edge = getElement();
                 if (indexHint != IndexHint.DO_NOT_INDEX) {
-                    saveMutationToSearchIndex(
-                            edge,
-                            oldVisibility,
-                            getNewElementVisibility(),
-                            getAlterPropertyVisibilities(),
-                            getExtendedData(),
-                            authorizations
-                    );
+                    getGraph().getSearchIndex().updateElement(getGraph(), this, authorizations);
                 }
                 return edge;
             }

--- a/inmemory/src/main/java/org/vertexium/inmemory/InMemoryElement.java
+++ b/inmemory/src/main/java/org/vertexium/inmemory/InMemoryElement.java
@@ -1,14 +1,11 @@
 package org.vertexium.inmemory;
 
 import com.google.common.collect.ImmutableSet;
-import com.google.common.collect.Lists;
 import org.vertexium.*;
 import org.vertexium.mutation.*;
 import org.vertexium.query.ExtendedDataQueryableIterable;
 import org.vertexium.query.QueryableIterable;
 import org.vertexium.search.IndexHint;
-
-import java.util.List;
 
 public abstract class InMemoryElement<TElement extends InMemoryElement> extends ElementBase {
     private final String id;
@@ -305,36 +302,6 @@ public abstract class InMemoryElement<TElement extends InMemoryElement> extends 
             return getId() + ":[" + edge.getVertexId(Direction.OUT) + "-" + edge.getLabel() + "->" + edge.getVertexId(Direction.IN) + "]";
         }
         return getId();
-    }
-
-
-    protected void saveMutationToSearchIndex(
-            Element element,
-            Visibility oldVisibility,
-            Visibility newVisibility,
-            List<AlterPropertyVisibility> alterPropertyVisibilities,
-            Iterable<ExtendedDataMutation> extendedDatas,
-            Authorizations authorizations
-    ) {
-        if (alterPropertyVisibilities != null && alterPropertyVisibilities.size() > 0) {
-            // Bulk delete
-            List<PropertyDescriptor> propertyList = Lists.newArrayList();
-            alterPropertyVisibilities.forEach(p -> propertyList.add(PropertyDescriptor.from(p.getKey(), p.getName(), p.getExistingVisibility())));
-            getGraph().getSearchIndex().deleteProperties(
-                    getGraph(),
-                    element,
-                    propertyList,
-                    authorizations
-            );
-
-            getGraph().getSearchIndex().flush(getGraph());
-        }
-        if (newVisibility != null) {
-            getGraph().getSearchIndex().alterElementVisibility(getGraph(), element, oldVisibility, newVisibility, authorizations);
-        } else {
-            getGraph().getSearchIndex().addElement(getGraph(), element, authorizations);
-            getGraph().getSearchIndex().addElementExtendedData(getGraph(), element, extendedDatas, authorizations);
-        }
     }
 
     public boolean canRead(Authorizations authorizations) {

--- a/inmemory/src/main/java/org/vertexium/inmemory/InMemoryVertex.java
+++ b/inmemory/src/main/java/org/vertexium/inmemory/InMemoryVertex.java
@@ -338,18 +338,10 @@ public class InMemoryVertex extends InMemoryElement<InMemoryVertex> implements V
             @Override
             public Vertex save(Authorizations authorizations) {
                 IndexHint indexHint = getIndexHint();
-                Visibility oldElementVisibility = InMemoryVertex.this.getVisibility();
                 saveExistingElementMutation(this, indexHint, authorizations);
                 Vertex vertex = getElement();
                 if (indexHint != IndexHint.DO_NOT_INDEX) {
-                    saveMutationToSearchIndex(
-                            vertex,
-                            oldElementVisibility,
-                            getNewElementVisibility(),
-                            getAlterPropertyVisibilities(),
-                            getExtendedData(),
-                            authorizations
-                    );
+                    getGraph().getSearchIndex().updateElement(getGraph(), this, authorizations);
                 }
                 return vertex;
             }


### PR DESCRIPTION
For an existing element, when a GeoShape property is deleted or the property visibility is changed the extra `_g` and `_gp` properties must also be handled properly.