### PR TITLE
Elasticsearch: optimize adding properties to vertices/edges with lots of properties

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,6 @@
 # v4.4.2
 * Fixed: `EdgeInfo.getDirection` was reversed when loaded from InMemoryVertex.
+* Changed: Elasticsearch: optimize adding properties to vertices/edges with lots of properties
 
 # v4.4.1
 * Fixed: Soft Deleted Historical Property Entries not containing metadata information.

--- a/elasticsearch5/src/main/java/org/vertexium/elasticsearch5/Elasticsearch5SearchIndex.java
+++ b/elasticsearch5/src/main/java/org/vertexium/elasticsearch5/Elasticsearch5SearchIndex.java
@@ -2136,9 +2136,14 @@ public class Elasticsearch5SearchIndex implements SearchIndex, SearchIndexWithVe
         }
 
         if (existingValue instanceof List) {
-            ArrayList newList = new ArrayList<>((List) existingValue);
-            newList.add(valueForIndex);
-            propertiesMap.put(propertyName, newList);
+            try {
+                ((List) existingValue).add(valueForIndex);
+            } catch (Exception ex) {
+                LOGGER.error("could not add to existing list, this could cause performance issues", ex);
+                ArrayList newList = new ArrayList<>((List) existingValue);
+                newList.add(valueForIndex);
+                propertiesMap.put(propertyName, newList);
+            }
             return;
         }
 


### PR DESCRIPTION
If an element has many properties recreating a new list for every new property is expensive.
This will try and add to the existing list unless it is readonly.