### PR TITLE
Elasticsearch: index on reads instead of indexing on writes.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,6 @@
 # v4.4.2
 * Fixed: `EdgeInfo.getDirection` was reversed when loaded from InMemoryVertex.
+* Changed: Elasticsearch: index on reads instead of indexing on writes.
 
 # v4.4.1
 * Fixed: Soft Deleted Historical Property Entries not containing metadata information.

--- a/accumulo/src/main/java/org/vertexium/accumulo/AccumuloGraph.java
+++ b/accumulo/src/main/java/org/vertexium/accumulo/AccumuloGraph.java
@@ -1072,10 +1072,10 @@ public class AccumuloGraph extends GraphBaseWithSearchIndex implements Traceable
     ) {
         try {
             Span trace = Trace.start("getExtendedData");
-            trace.data("elementType", elementType.name());
+            trace.data("elementType", elementType == null ? null : elementType.name());
             trace.data("elementId", elementId);
             trace.data("tableName", tableName);
-            org.apache.accumulo.core.data.Range range = org.apache.accumulo.core.data.Range.prefix(KeyHelper.createExtendedDataRowKey(elementType, elementId, tableName, ""));
+            org.apache.accumulo.core.data.Range range = org.apache.accumulo.core.data.Range.prefix(KeyHelper.createExtendedDataRowKey(elementType, elementId, tableName, null));
             return getExtendedDataRowsInRange(trace, Lists.newArrayList(range), FetchHints.ALL, authorizations);
         } catch (IllegalStateException ex) {
             throw new VertexiumException("Failed to get extended data: " + elementType + ":" + elementId + ":" + tableName, ex);

--- a/accumulo/src/main/java/org/vertexium/accumulo/keys/KeyHelper.java
+++ b/accumulo/src/main/java/org/vertexium/accumulo/keys/KeyHelper.java
@@ -106,8 +106,29 @@ public class KeyHelper {
     }
 
     public static Text createExtendedDataRowKey(ElementType elementType, String elementId, String tableName, String row) {
-        String elementTypePrefix = getExtendedDataRowKeyElementTypePrefix(elementType);
-        return new Text(elementTypePrefix + elementId + KeyBase.VALUE_SEPARATOR + tableName + KeyBase.VALUE_SEPARATOR + row);
+        StringBuilder sb = new StringBuilder();
+        if (elementType != null) {
+            String elementTypePrefix = getExtendedDataRowKeyElementTypePrefix(elementType);
+            sb.append(elementTypePrefix);
+            if (elementId != null) {
+                sb.append(elementId);
+                if (tableName != null) {
+                    sb.append(KeyBase.VALUE_SEPARATOR);
+                    sb.append(tableName);
+                    sb.append(KeyBase.VALUE_SEPARATOR);
+                    if (row != null) {
+                        sb.append(row);
+                    }
+                } else if (row != null) {
+                    throw new VertexiumException("Cannot create partial key with missing inner value");
+                }
+            } else if (tableName != null || row != null) {
+                throw new VertexiumException("Cannot create partial key with missing inner value");
+            }
+        } else if (elementId != null || tableName != null || row != null) {
+            throw new VertexiumException("Cannot create partial key with missing inner value");
+        }
+        return new Text(sb.toString());
     }
 
     public static Text createExtendedDataColumnQualifier(ExtendedDataMutationBase edm) {

--- a/core/src/main/java/org/vertexium/GraphBase.java
+++ b/core/src/main/java/org/vertexium/GraphBase.java
@@ -1043,13 +1043,18 @@ public abstract class GraphBase implements Graph {
             String tableName,
             Authorizations authorizations
     ) {
+        if ((elementType == null && (elementId != null || tableName != null))
+                || (elementType != null && elementId == null && tableName != null)) {
+            throw new VertexiumException("Cannot create partial key with missing inner value");
+        }
+
         return new FilterIterable<ExtendedDataRow>(getAllExtendedData(authorizations)) {
             @Override
             protected boolean isIncluded(ExtendedDataRow row) {
                 ExtendedDataRowId rowId = row.getId();
-                return (elementType != null && elementType.equals(rowId.getElementType()))
-                        && (elementId != null && elementId.equals(rowId.getElementId()))
-                        && (tableName != null && tableName.equals(rowId.getTableName()));
+                return (elementType == null || elementType.equals(rowId.getElementType()))
+                        && (elementId == null || elementId.equals(rowId.getElementId()))
+                        && (tableName == null || tableName.equals(rowId.getTableName()));
             }
         };
     }

--- a/elasticsearch5/src/main/java/org/vertexium/elasticsearch5/ElasticsearchSearchIndexConfiguration.java
+++ b/elasticsearch5/src/main/java/org/vertexium/elasticsearch5/ElasticsearchSearchIndexConfiguration.java
@@ -49,6 +49,8 @@ public class ElasticsearchSearchIndexConfiguration {
     private static final boolean FORCE_DISABLE_VERTEXIUM_PLUGIN_DEFAULT = false;
     public static final String INDEX_MAPPING_TOTAL_FIELDS_LIMIT = "indexMappingTotalFieldsLimit";
     public static final int INDEX_MAPPING_TOTAL_FIELDS_LIMIT_DEFAULT = 100000;
+    public static final String INDEX_REFRESH_INTERVAL = "indexRefreshInterval";
+    public static final Integer INDEX_REFRESH_INTERVAL_DEFAULT = null;
     public static final String PROPERTY_NAME_VISIBILITIES_STORE = "propertyNameVisibilitiesStore";
     public static final Class<? extends PropertyNameVisibilitiesStore> PROPERTY_NAME_VISIBILITIES_STORE_DEFAULT = MetadataTablePropertyNameVisibilitiesStore.class;
     public static final String EXCEPTION_HANDLER = "exceptionHandler";
@@ -127,6 +129,10 @@ public class ElasticsearchSearchIndexConfiguration {
 
     public int getIndexMappingTotalFieldsLimit() {
         return graphConfiguration.getInt(GraphConfiguration.SEARCH_INDEX_PROP_PREFIX + "." + INDEX_MAPPING_TOTAL_FIELDS_LIMIT, INDEX_MAPPING_TOTAL_FIELDS_LIMIT_DEFAULT);
+    }
+
+    public Integer getIndexRefreshInterval() {
+        return graphConfiguration.getInteger(GraphConfiguration.SEARCH_INDEX_PROP_PREFIX + "." + INDEX_REFRESH_INTERVAL, INDEX_REFRESH_INTERVAL_DEFAULT);
     }
 
     public int getTermAggregationShardSize() {

--- a/elasticsearch5/src/main/java/org/vertexium/elasticsearch5/ElasticsearchSearchQueryBase.java
+++ b/elasticsearch5/src/main/java/org/vertexium/elasticsearch5/ElasticsearchSearchQueryBase.java
@@ -161,6 +161,8 @@ public class ElasticsearchSearchQueryBase extends QueryBase {
         if (QUERY_LOGGER.isTraceEnabled()) {
             QUERY_LOGGER.trace("indicesToQuery: %s", Joiner.on(", ").join(indicesToQuery));
         }
+        getSearchIndex().getIndexRefreshTracker().refresh(client, indicesToQuery);
+
         SearchRequestBuilder searchRequestBuilder = getClient()
                 .prepareSearch(indicesToQuery)
                 .setTypes(getSearchIndex().getIdStrategy().getType())

--- a/elasticsearch5/src/main/java/org/vertexium/elasticsearch5/IndexRefreshTracker.java
+++ b/elasticsearch5/src/main/java/org/vertexium/elasticsearch5/IndexRefreshTracker.java
@@ -1,46 +1,82 @@
 package org.vertexium.elasticsearch5;
 
+import com.google.common.collect.Lists;
 import org.elasticsearch.client.Client;
 
 import java.util.HashMap;
 import java.util.Map;
+import java.util.Set;
+import java.util.concurrent.locks.Lock;
+import java.util.concurrent.locks.ReadWriteLock;
+import java.util.concurrent.locks.ReentrantReadWriteLock;
+import java.util.stream.Collectors;
 
 public class IndexRefreshTracker {
+    private final ReadWriteLock indexToMaxRefreshTimeLock = new ReentrantReadWriteLock();
     private final Map<String, Long> indexToMaxRefreshTime = new HashMap<>();
+    private final Lock readLock = indexToMaxRefreshTimeLock.readLock();
+    private final Lock writeLock = indexToMaxRefreshTimeLock.writeLock();
 
     public void pushChange(String indexName) {
-        synchronized (indexToMaxRefreshTime) {
-            indexToMaxRefreshTime.put(indexName, System.currentTimeMillis());
+        writeLock.lock();
+        try {
+            indexToMaxRefreshTime.put(indexName, getTime());
+        } finally {
+            writeLock.unlock();
         }
     }
 
     public void refresh(Client client) {
-        long time = System.currentTimeMillis();
+        long time = getTime();
 
-        String[] indexNamesNeedingRefresh = getIndexNamesNeedingRefresh(time);
-        if (indexNamesNeedingRefresh.length == 0) {
-            return;
+        Set<String> indexNamesNeedingRefresh = getIndexNamesNeedingRefresh(time);
+        if (indexNamesNeedingRefresh.size() > 0) {
+            refresh(client, indexNamesNeedingRefresh);
+            removeRefreshedIndexNames(indexNamesNeedingRefresh, time);
         }
-        client.admin().indices().prepareRefresh(indexNamesNeedingRefresh).execute().actionGet();
-        removeRefreshedIndexNames(indexNamesNeedingRefresh, time);
     }
 
-    private String[] getIndexNamesNeedingRefresh(long time) {
-        synchronized (indexToMaxRefreshTime) {
+    protected long getTime() {
+        return System.currentTimeMillis();
+    }
+
+    public void refresh(Client client, String... indexNames) {
+        long time = getTime();
+
+        Set<String> indexNamesNeedingRefresh = getIndexNamesNeedingRefresh(time);
+        indexNamesNeedingRefresh.retainAll(Lists.newArrayList(indexNames));
+        if (indexNamesNeedingRefresh.size() > 0) {
+            refresh(client, indexNamesNeedingRefresh);
+            removeRefreshedIndexNames(indexNamesNeedingRefresh, time);
+        }
+    }
+
+    protected void refresh(Client client, Set<String> indexNamesNeedingRefresh) {
+        client.admin().indices().prepareRefresh(indexNamesNeedingRefresh.toArray(new String[0])).execute().actionGet();
+    }
+
+    private Set<String> getIndexNamesNeedingRefresh(long time) {
+        readLock.lock();
+        try {
             return indexToMaxRefreshTime.entrySet().stream()
                     .filter(e -> e.getValue() <= time)
                     .map(Map.Entry::getKey)
-                    .toArray(String[]::new);
+                    .collect(Collectors.toSet());
+        } finally {
+            readLock.unlock();
         }
     }
 
-    private void removeRefreshedIndexNames(String[] indexNamesNeedingRefresh, long time) {
-        synchronized (indexToMaxRefreshTime) {
+    private void removeRefreshedIndexNames(Set<String> indexNamesNeedingRefresh, long time) {
+        writeLock.lock();
+        try {
             for (String indexName : indexNamesNeedingRefresh) {
                 if (indexToMaxRefreshTime.getOrDefault(indexName, Long.MAX_VALUE) <= time) {
                     indexToMaxRefreshTime.remove(indexName);
                 }
             }
+        } finally {
+            writeLock.unlock();
         }
     }
 }

--- a/elasticsearch5/src/test/java/org/vertexium/elasticsearch5/ElasticsearchResource.java
+++ b/elasticsearch5/src/test/java/org/vertexium/elasticsearch5/ElasticsearchResource.java
@@ -138,6 +138,7 @@ public class ElasticsearchResource extends ExternalResource {
         configMap.put(SEARCH_INDEX_PROP_PREFIX + "." + LOG_REQUEST_SIZE_LIMIT, 10000);
         configMap.put(SEARCH_INDEX_PROP_PREFIX + "." + MAX_QUERY_STRING_TERMS, 20);
         configMap.put(SEARCH_INDEX_PROP_PREFIX + "." + EXCEPTION_HANDLER, TestElasticsearch5ExceptionHandler.class.getName());
+        configMap.put(SEARCH_INDEX_PROP_PREFIX + "." + INDEX_REFRESH_INTERVAL, -1);
 
         // transport-5.3.3.jar!/org/elasticsearch/transport/client/PreBuiltTransportClient.class:61 likes to sleep on
         // connection close if default or netty4. This speeds up the test by skipping that

--- a/elasticsearch5/src/test/java/org/vertexium/elasticsearch5/IndexRefreshTrackerTest.java
+++ b/elasticsearch5/src/test/java/org/vertexium/elasticsearch5/IndexRefreshTrackerTest.java
@@ -1,0 +1,98 @@
+package org.vertexium.elasticsearch5;
+
+import com.google.common.base.Joiner;
+import com.google.common.collect.Sets;
+import org.elasticsearch.client.Client;
+import org.junit.Before;
+import org.junit.Test;
+
+import java.util.ArrayList;
+import java.util.Collections;
+import java.util.HashSet;
+import java.util.Set;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertNull;
+
+public class IndexRefreshTrackerTest {
+    private IndexRefreshTracker indexRefreshTracker;
+    private long time;
+    private Set<String> lastIndexNamesNeedingRefresh;
+
+    @Before
+    public void before() {
+        this.indexRefreshTracker = new IndexRefreshTracker() {
+            @Override
+            protected long getTime() {
+                return time;
+            }
+
+            @Override
+            protected void refresh(Client client, Set<String> indexNamesNeedingRefresh) {
+                lastIndexNamesNeedingRefresh = indexNamesNeedingRefresh;
+            }
+        };
+    }
+
+    @Test
+    public void testRefreshListOfIndexNames_noChanges() {
+        indexRefreshTracker.refresh(null, "a", "b");
+        assertNull(lastIndexNamesNeedingRefresh);
+    }
+
+    @Test
+    public void testRefreshListOfIndexNames_singleChange() {
+        time = 0;
+        indexRefreshTracker.pushChange("a");
+
+        time = 2;
+        indexRefreshTracker.refresh(null, "a", "b");
+        assertLastIndexNamesNeedingRefresh(Sets.newHashSet("a"));
+        assertLastIndexNamesNeedingRefresh(Sets.newHashSet());
+    }
+
+    @Test
+    public void testRefreshListOfIndexNames_multipleChanges() {
+        time = 1;
+        indexRefreshTracker.pushChange("a");
+        indexRefreshTracker.pushChange("b");
+
+        time = 2;
+        indexRefreshTracker.refresh(null, "a", "b");
+        assertLastIndexNamesNeedingRefresh(Sets.newHashSet("a", "b"));
+        assertLastIndexNamesNeedingRefresh(Sets.newHashSet());
+    }
+
+    @Test
+    public void testRefreshListOfIndexNames_time() {
+        time = 2;
+        indexRefreshTracker.pushChange("a");
+        indexRefreshTracker.pushChange("b");
+
+        time = 1;
+        indexRefreshTracker.refresh(null, "a", "b");
+        assertLastIndexNamesNeedingRefresh(Sets.newHashSet());
+
+        time = 3;
+        indexRefreshTracker.refresh(null, "a", "b");
+        assertLastIndexNamesNeedingRefresh(Sets.newHashSet("a", "b"));
+        assertLastIndexNamesNeedingRefresh(Sets.newHashSet());
+    }
+
+    private void assertLastIndexNamesNeedingRefresh(Set<String> expected) {
+        Set<String> found = lastIndexNamesNeedingRefresh;
+        if (found == null) {
+            found = new HashSet<>();
+        }
+        lastIndexNamesNeedingRefresh = null;
+        ArrayList<String> expectedList = new ArrayList<>(expected);
+        Collections.sort(expectedList);
+        ArrayList<String> foundList = new ArrayList<>(found);
+        Collections.sort(foundList);
+
+        assertEquals(
+                Joiner.on(", ").join(expectedList),
+                Joiner.on(", ").join(foundList)
+        );
+    }
+}

--- a/test/src/main/java/org/vertexium/test/GraphTestBase.java
+++ b/test/src/main/java/org/vertexium/test/GraphTestBase.java
@@ -7766,6 +7766,22 @@ public abstract class GraphTestBase {
         assertEquals(4, rowsList.size());
         rowsList = toList(v1.getExtendedData("table2"));
         assertEquals(1, rowsList.size());
+
+        assertEquals(5, count(graph.getExtendedData(ElementType.VERTEX, "v1", null, AUTHORIZATIONS_A)));
+        assertEquals(5, count(graph.getExtendedData(ElementType.VERTEX, null, null, AUTHORIZATIONS_A)));
+        assertEquals(5, count(graph.getExtendedData(null, null, null, AUTHORIZATIONS_A)));
+        try {
+            count(graph.getExtendedData(null, null, "table1", AUTHORIZATIONS_A));
+            fail("nulls to the left of a value is not allowed");
+        } catch (Exception ex) {
+            // expected
+        }
+        try {
+            count(graph.getExtendedData(null, "v1", null, AUTHORIZATIONS_A));
+            fail("nulls to the left of a value is not allowed");
+        } catch (Exception ex) {
+            // expected
+        }
     }
 
     @Test


### PR DESCRIPTION
This allows multiple writes to happen before a refresh is needed.