### PR TITLE
Fix Extended Data Query with no Access to Columns

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,5 @@
-# v4.4.2
-* Fixed: If you had access an element but none of the extended data columns you could still match on the extended data row using a query with no filters. This would result in the row being counted in `totalHits`, but it could not be retrieved from Accumulo.
+# v4.5.0
+* Fixed: If you had access an element but none of the extended data columns you could still match on the extended data row using a query with no filters. This would result in the row being counted in `totalHits`, but it could not be retrieved from Accumulo. NOTE: This change requires that all extended data values are re-indexed in ElasticSearch.
 
 # v4.4.2
 * Fixed: `EdgeInfo.getDirection` was reversed when loaded from InMemoryVertex.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,4 +1,7 @@
 # v4.4.2
+* Fixed: If you had access an element but none of the extended data columns you could still match on the extended data row using a query with no filters. This would result in the row being counted in `totalHits`, but it could not be retrieved from Accumulo.
+
+# v4.4.2
 * Fixed: `EdgeInfo.getDirection` was reversed when loaded from InMemoryVertex.
 * Changed: Elasticsearch: index on reads instead of indexing on writes.
 * Changed: Elasticsearch: optimize adding properties to vertices/edges with lots of properties
@@ -45,7 +48,7 @@
 * Changed: Deprecated Elasticsearch global scoring strategy  
 
 # v4.1.1.5
-* Changed: Elasticsearch: Parse histogram aggregation interval to Double since decimal intervals are supported 
+* Changed: Elasticsearch: Parse histogram aggregation interval to Double since decimal intervals are supported
 
 # v4.1.1.4
 * Fixed: Elasticsearch: NPE in InfiniteScrollIterable if no matching property name has been found when applying filters

--- a/accumulo-iterators/pom.xml
+++ b/accumulo-iterators/pom.xml
@@ -3,7 +3,7 @@
     <parent>
         <artifactId>vertexium-root</artifactId>
         <groupId>org.vertexium</groupId>
-        <version>4.4.3-SNAPSHOT</version>
+        <version>4.5.0-SNAPSHOT</version>
     </parent>
     <modelVersion>4.0.0</modelVersion>
 

--- a/accumulo-migrations/pom.xml
+++ b/accumulo-migrations/pom.xml
@@ -3,7 +3,7 @@
     <parent>
         <artifactId>vertexium-root</artifactId>
         <groupId>org.vertexium</groupId>
-        <version>4.4.3-SNAPSHOT</version>
+        <version>4.5.0-SNAPSHOT</version>
     </parent>
     <modelVersion>4.0.0</modelVersion>
 

--- a/accumulo/pom.xml
+++ b/accumulo/pom.xml
@@ -3,7 +3,7 @@
     <parent>
         <artifactId>vertexium-root</artifactId>
         <groupId>org.vertexium</groupId>
-        <version>4.4.3-SNAPSHOT</version>
+        <version>4.5.0-SNAPSHOT</version>
     </parent>
     <modelVersion>4.0.0</modelVersion>
 

--- a/cli/pom.xml
+++ b/cli/pom.xml
@@ -3,7 +3,7 @@
     <parent>
         <artifactId>vertexium-root</artifactId>
         <groupId>org.vertexium</groupId>
-        <version>4.4.3-SNAPSHOT</version>
+        <version>4.5.0-SNAPSHOT</version>
     </parent>
     <modelVersion>4.0.0</modelVersion>
 

--- a/core/pom.xml
+++ b/core/pom.xml
@@ -3,7 +3,7 @@
     <parent>
         <artifactId>vertexium-root</artifactId>
         <groupId>org.vertexium</groupId>
-        <version>4.4.3-SNAPSHOT</version>
+        <version>4.5.0-SNAPSHOT</version>
     </parent>
     <modelVersion>4.0.0</modelVersion>
 

--- a/cypher/pom.xml
+++ b/cypher/pom.xml
@@ -3,7 +3,7 @@
     <parent>
         <artifactId>vertexium-root</artifactId>
         <groupId>org.vertexium</groupId>
-        <version>4.4.3-SNAPSHOT</version>
+        <version>4.5.0-SNAPSHOT</version>
     </parent>
     <modelVersion>4.0.0</modelVersion>
 

--- a/elasticsearch5-plugin/pom.xml
+++ b/elasticsearch5-plugin/pom.xml
@@ -3,7 +3,7 @@
     <parent>
         <artifactId>vertexium-root</artifactId>
         <groupId>org.vertexium</groupId>
-        <version>4.4.3-SNAPSHOT</version>
+        <version>4.5.0-SNAPSHOT</version>
     </parent>
     <modelVersion>4.0.0</modelVersion>
 

--- a/elasticsearch5/pom.xml
+++ b/elasticsearch5/pom.xml
@@ -3,7 +3,7 @@
     <parent>
         <artifactId>vertexium-root</artifactId>
         <groupId>org.vertexium</groupId>
-        <version>4.4.3-SNAPSHOT</version>
+        <version>4.5.0-SNAPSHOT</version>
     </parent>
     <modelVersion>4.0.0</modelVersion>
 

--- a/elasticsearch5/src/main/java/org/vertexium/elasticsearch5/Elasticsearch5SearchIndex.java
+++ b/elasticsearch5/src/main/java/org/vertexium/elasticsearch5/Elasticsearch5SearchIndex.java
@@ -22,12 +22,14 @@ import org.elasticsearch.client.Client;
 import org.elasticsearch.client.transport.TransportClient;
 import org.elasticsearch.cluster.health.ClusterHealthStatus;
 import org.elasticsearch.cluster.metadata.MappingMetaData;
+import org.elasticsearch.common.bytes.BytesArray;
 import org.elasticsearch.common.collect.ImmutableOpenMap;
 import org.elasticsearch.common.geo.builders.CircleBuilder;
 import org.elasticsearch.common.settings.Settings;
 import org.elasticsearch.common.transport.InetSocketTransportAddress;
 import org.elasticsearch.common.xcontent.XContentBuilder;
 import org.elasticsearch.common.xcontent.XContentFactory;
+import org.elasticsearch.common.xcontent.XContentType;
 import org.elasticsearch.index.query.BoolQueryBuilder;
 import org.elasticsearch.index.query.QueryBuilder;
 import org.elasticsearch.index.query.QueryBuilders;
@@ -94,6 +96,7 @@ public class Elasticsearch5SearchIndex implements SearchIndex, SearchIndexWithVe
     public static final String EDGE_LABEL_FIELD_NAME = "__edgeLabel";
     public static final String EXTENDED_DATA_TABLE_NAME_FIELD_NAME = "__extendedDataTableName";
     public static final String EXTENDED_DATA_TABLE_ROW_ID_FIELD_NAME = "__extendedDataRowId";
+    public static final String EXTENDED_DATA_TABLE_COLUMN_VISIBILITIES_FIELD_NAME = "__extendedDataColumnVisibilities";
     public static final String EXACT_MATCH_FIELD_NAME = "exact";
     public static final String EXACT_MATCH_PROPERTY_NAME_SUFFIX = "." + EXACT_MATCH_FIELD_NAME;
     public static final String GEO_PROPERTY_NAME_SUFFIX = "_g";
@@ -137,6 +140,26 @@ public class Elasticsearch5SearchIndex implements SearchIndex, SearchIndexWithVe
         this.logRequestSizeLimit = this.config.getLogRequestSizeLimit();
         this.exceptionHandler = this.config.getExceptionHandler(graph);
         this.flushObjectQueue = new FlushObjectQueue(this);
+
+        storePainlessScript("addFieldsToExtendedDataScript", getClass().getResourceAsStream("add-fields-to-extended-data.painless"), true);
+        storePainlessScript("deleteFieldsFromDocumentScript", getClass().getResourceAsStream("remove-fields-from-document.painless"), true);
+        storePainlessScript("updateFieldsOnDocumentScript", getClass().getResourceAsStream("update-fields-on-document.painless"), false);
+    }
+
+    private void storePainlessScript(String scriptId, InputStream scriptSource, boolean includeHelpers) {
+        try {
+            String source = IOUtils.toString(scriptSource);
+            if (includeHelpers) {
+                source = IOUtils.toString(getClass().getResourceAsStream("helper-functions.painless")) + " " + source;
+            }
+            source = source.replaceAll("\\r?\\n", " ");
+            client.admin().cluster().preparePutStoredScript()
+                    .setId(scriptId)
+                    .setContent(new BytesArray("{\"script\": {\"lang\": \"painless\", \"source\": \"" + source + "\"}}"), XContentType.JSON)
+                    .get();
+        } catch (Exception ex) {
+            throw new VertexiumException("Could not load painless script: " + scriptId, ex);
+        }
     }
 
     public PropertyNameVisibilitiesStore getPropertyNameVisibilitiesStore() {
@@ -742,35 +765,42 @@ public class Elasticsearch5SearchIndex implements SearchIndex, SearchIndexWithVe
     ) {
         try {
             IndexInfo indexInfo = addExtendedDataColumnsToIndex(graph, element, tableName, rowId, columns);
-            XContentBuilder source = buildJsonContentFromExtendedDataMutations(graph, element, tableName, rowId, columns, authorizations).endObject();
-
-            if (MUTATION_LOGGER.isTraceEnabled()) {
-                MUTATION_LOGGER.trace("addElementExtendedData json: %s:%s:%s: %s", element.getId(), tableName, rowId, source.string());
-            }
-
             String extendedDataDocId = getIdStrategy().createExtendedDataDocId(element, tableName, rowId);
             getIndexRefreshTracker().pushChange(indexInfo.getIndexName());
+
+            Map<String, Object> fieldsToSet =
+                    getExtendedDataColumnsAsFields(graph, columns).entrySet().stream()
+                            .collect(Collectors.toMap(e -> replaceFieldnameDots(e.getKey()), Map.Entry::getValue));
+
+            XContentBuilder source = buildJsonContentForExtendedDataUpsert(graph, element, tableName, rowId);
+            if (MUTATION_LOGGER.isTraceEnabled()) {
+                String fieldsDebug = Joiner.on(", ").withKeyValueSeparator(": ").join(fieldsToSet);
+                MUTATION_LOGGER.trace("addElementExtendedData json: %s:%s:%s: %s {%s}", element.getId(), tableName, rowId, source.string(), fieldsDebug);
+            }
+
             return getClient()
                     .prepareUpdate(indexInfo.getIndexName(), getIdStrategy().getType(), extendedDataDocId)
-                    .setDocAsUpsert(true)
-                    .setDoc(source)
+                    .setScriptedUpsert(true)
+                    .setUpsert(source)
+                    .setScript(new Script(
+                            ScriptType.STORED,
+                            "painless",
+                            "addFieldsToExtendedDataScript",
+                            ImmutableMap.of("fieldsToSet", fieldsToSet)))
                     .setRetryOnConflict(MAX_RETRIES);
         } catch (IOException e) {
             throw new VertexiumException("Could not add element extended data", e);
         }
     }
 
-    private XContentBuilder buildJsonContentFromExtendedDataMutations(
+    private XContentBuilder buildJsonContentForExtendedDataUpsert(
             Graph graph,
             Element element,
             String tableName,
-            String rowId,
-            List<ExtendedDataMutation> columns,
-            Authorizations authorizations
+            String rowId
     ) throws IOException {
         XContentBuilder jsonBuilder;
-        jsonBuilder = XContentFactory.jsonBuilder()
-                .startObject();
+        jsonBuilder = XContentFactory.jsonBuilder().startObject();
 
         String elementTypeString = ElasticsearchDocumentType.getExtendedDataDocumentTypeFromElement(element).getKey();
         jsonBuilder.field(ELEMENT_ID_FIELD_NAME, element.getId());
@@ -786,8 +816,7 @@ public class Elasticsearch5SearchIndex implements SearchIndex, SearchIndexWithVe
             jsonBuilder.field(EDGE_LABEL_FIELD_NAME, edge.getLabel());
         }
 
-        Map<String, Object> fields = getExtendedDataColumnsAsFields(graph, columns);
-        addFieldsMap(jsonBuilder, fields);
+        jsonBuilder.endObject();
 
         return jsonBuilder;
     }
@@ -1229,6 +1258,10 @@ public class Elasticsearch5SearchIndex implements SearchIndex, SearchIndexWithVe
             results[i++] = propertyName + "_" + hash;
         }
         return results;
+    }
+
+    public Collection<String> getQueryableExtendedDataVisibilities(Graph graph, Authorizations authorizations) {
+        return propertyNameVisibilitiesStore.getHashes(graph, authorizations);
     }
 
     public Collection<String> getQueryableElementTypeVisibilityPropertyNames(Graph graph, Authorizations authorizations) {
@@ -1895,9 +1928,9 @@ public class Elasticsearch5SearchIndex implements SearchIndex, SearchIndexWithVe
                 .setId(documentId)
                 .setType(getIdStrategy().getType())
                 .setScript(new Script(
-                        ScriptType.INLINE,
+                        ScriptType.STORED,
                         "painless",
-                        "for (def fieldName : params.fieldNames) { ctx._source.remove(fieldName); }",
+                        "deleteFieldsFromDocumentScript",
                         ImmutableMap.of("fieldNames", fieldNames)
                 ))
                 .setRetryOnConflict(MAX_RETRIES);
@@ -1927,11 +1960,9 @@ public class Elasticsearch5SearchIndex implements SearchIndex, SearchIndexWithVe
                 .setId(documentId)
                 .setType(getIdStrategy().getType())
                 .setScript(new Script(
-                        ScriptType.INLINE,
+                        ScriptType.STORED,
                         "painless",
-                        "for (def fieldName : params.fieldsToRemove) { ctx._source.remove(fieldName); } " +
-                                "for (fieldToRename in params.fieldsToRename.entrySet()) { ctx._source[fieldToRename.getValue()] = ctx._source[fieldToRename.getKey()]; ctx._source.remove(fieldToRename.getKey()); } " +
-                                "for (fieldToSet in params.fieldsToSet.entrySet()) { ctx._source[fieldToSet.getKey()] = fieldToSet.getValue(); }",
+                        "updateFieldsOnDocumentScript",
                         ImmutableMap.of("fieldsToSet", fieldsToSet, "fieldsToRemove", fieldsToRemove, "fieldsToRename", fieldsToRename)
                 ))
                 .setRetryOnConflict(MAX_RETRIES);

--- a/elasticsearch5/src/main/java/org/vertexium/elasticsearch5/MetadataTablePropertyNameVisibilitiesStore.java
+++ b/elasticsearch5/src/main/java/org/vertexium/elasticsearch5/MetadataTablePropertyNameVisibilitiesStore.java
@@ -30,6 +30,18 @@ public class MetadataTablePropertyNameVisibilitiesStore extends PropertyNameVisi
         return hashes;
     }
 
+    public Collection<String> getHashes(Graph graph, Authorizations authorizations) {
+        List<String> hashes = new ArrayList<>();
+        for (GraphMetadataEntry metadata : graph.getMetadataWithPrefix(HASH_TO_VISIBILITY)) {
+            Visibility visibility = getVisibility((String) metadata.getValue());
+            if (authorizations.canRead(visibility)) {
+                String hash = metadata.getKey().substring(HASH_TO_VISIBILITY.length());
+                hashes.add(hash);
+            }
+        }
+        return hashes;
+    }
+
     public Collection<String> getHashes(Graph graph, String propertyName, Authorizations authorizations) {
         List<String> results = new ArrayList<>();
         String prefix = getPropertyNameVisibilityToHashPrefix(propertyName);

--- a/elasticsearch5/src/main/java/org/vertexium/elasticsearch5/PropertyNameVisibilitiesStore.java
+++ b/elasticsearch5/src/main/java/org/vertexium/elasticsearch5/PropertyNameVisibilitiesStore.java
@@ -7,6 +7,8 @@ import org.vertexium.Visibility;
 import java.util.Collection;
 
 public abstract class PropertyNameVisibilitiesStore {
+    public abstract Collection<String> getHashes(Graph graph, Authorizations authorizations);
+
     public abstract Collection<String> getHashes(Graph graph, String propertyName, Authorizations authorizations);
 
     public abstract String getHash(Graph graph, String propertyName, Visibility visibility);

--- a/elasticsearch5/src/main/resources/org/vertexium/elasticsearch5/add-fields-to-extended-data.painless
+++ b/elasticsearch5/src/main/resources/org/vertexium/elasticsearch5/add-fields-to-extended-data.painless
@@ -1,0 +1,6 @@
+for (fieldToSet in params.fieldsToSet.entrySet()) {
+  ctx._source[fieldToSet.getKey()] = fieldToSet.getValue();
+}
+
+/* see helper-functions.painless for definition of getFieldVisibilities() */
+ctx._source['__extendedDataColumnVisibilities'] = getFieldVisibilities(ctx._source).toArray();

--- a/elasticsearch5/src/main/resources/org/vertexium/elasticsearch5/helper-functions.painless
+++ b/elasticsearch5/src/main/resources/org/vertexium/elasticsearch5/helper-functions.painless
@@ -1,0 +1,30 @@
+
+Set getFieldVisibilities(def source) {
+    Set visibilities = new HashSet();
+    for(String fn : source.keySet()) {
+        if (!fn.startsWith('__')) {
+            String key = fn;
+            int lastIndex = key.lastIndexOf('_');
+            while (lastIndex > 0) {
+                if ((key.length() - lastIndex - 1) == 32) {
+                    String hash = key.substring(lastIndex + 1);
+                    boolean validMd5 = true;
+
+                    for (int i; validMd5 && i < hash.length(); i++) {
+                        char hc = hash.charAt(i);
+                        if (!(hc >= ((char)'0') && hc <= ((char)'9')) && !(hc >= ((char)'a') && hc <= ((char)'z')) && !(hc >= ((char)'A') && hc <= ((char)'Z')) ) {
+                            validMd5 = false;
+                        }
+                    }
+                    if (validMd5) {
+                        visibilities.add(hash);
+                    }
+
+                }
+                key = key.substring(0, lastIndex);
+                lastIndex = key.lastIndexOf('_');
+            }
+        }
+    }
+    visibilities;
+}

--- a/elasticsearch5/src/main/resources/org/vertexium/elasticsearch5/remove-fields-from-document.painless
+++ b/elasticsearch5/src/main/resources/org/vertexium/elasticsearch5/remove-fields-from-document.painless
@@ -1,0 +1,7 @@
+for (def fieldName : params.fieldNames) {
+  ctx._source.remove(fieldName);
+}
+if (ctx._source.containsKey('__extendedDataColumnVisibilities')) {
+    /* see helper-functions.painless for definition of getFieldVisibilities() */
+    ctx._source['__extendedDataColumnVisibilities'] = getFieldVisibilities(ctx._source).toArray();
+}

--- a/elasticsearch5/src/main/resources/org/vertexium/elasticsearch5/update-fields-on-document.painless
+++ b/elasticsearch5/src/main/resources/org/vertexium/elasticsearch5/update-fields-on-document.painless
@@ -1,0 +1,9 @@
+for (def fieldName : params.fieldsToRemove) {
+    ctx._source.remove(fieldName);
+}
+for (fieldToRename in params.fieldsToRename.entrySet()) {
+    ctx._source[fieldToRename.getValue()] = ctx._source[fieldToRename.getKey()]; ctx._source.remove(fieldToRename.getKey());
+}
+for (fieldToSet in params.fieldsToSet.entrySet()) {
+    ctx._source[fieldToSet.getKey()] = fieldToSet.getValue();
+}

--- a/inmemory/pom.xml
+++ b/inmemory/pom.xml
@@ -3,7 +3,7 @@
     <parent>
         <artifactId>vertexium-root</artifactId>
         <groupId>org.vertexium</groupId>
-        <version>4.4.3-SNAPSHOT</version>
+        <version>4.5.0-SNAPSHOT</version>
     </parent>
     <modelVersion>4.0.0</modelVersion>
 

--- a/inmemory/src/main/java/org/vertexium/inmemory/InMemoryElement.java
+++ b/inmemory/src/main/java/org/vertexium/inmemory/InMemoryElement.java
@@ -67,32 +67,14 @@ public abstract class InMemoryElement<TElement extends InMemoryElement> extends 
         getGraph().deleteExtendedData(this, tableName, row, columnName, key, visibility, authorizations);
     }
 
-    protected void extendedData(
-            String tableName,
-            String rowId,
-            String column,
-            String key,
-            Object value,
-            long timestamp,
-            Visibility visibility,
-            Authorizations authorizations
-    ) {
+    protected void extendedData(ExtendedDataMutation extendedData, Authorizations authorizations) {
         ExtendedDataRowId extendedDataRowId = new ExtendedDataRowId(
                 ElementType.getTypeFromElement(this),
                 getId(),
-                tableName,
-                rowId
+                extendedData.getTableName(),
+                extendedData.getRow()
         );
-        getGraph().extendedData(
-                this,
-                extendedDataRowId,
-                column,
-                key,
-                value,
-                timestamp,
-                visibility,
-                authorizations
-        );
+        getGraph().extendedData(this, extendedDataRowId, extendedData, authorizations);
     }
 
     @Override
@@ -217,16 +199,7 @@ public abstract class InMemoryElement<TElement extends InMemoryElement> extends 
         }
         for (ExtendedDataMutation extendedData : extendedDatas) {
             getGraph().ensurePropertyDefined(extendedData.getColumnName(), extendedData.getValue());
-            extendedData(
-                    extendedData.getTableName(),
-                    extendedData.getRow(),
-                    extendedData.getColumnName(),
-                    extendedData.getKey(),
-                    extendedData.getValue(),
-                    extendedData.getTimestamp(),
-                    extendedData.getVisibility(),
-                    authorizations
-            );
+            extendedData(extendedData, authorizations);
         }
         for (ExtendedDataDeleteMutation extendedDataDelete : extendedDataDeletes) {
             deleteExtendedData(

--- a/inmemory/src/main/java/org/vertexium/inmemory/InMemoryGraph.java
+++ b/inmemory/src/main/java/org/vertexium/inmemory/InMemoryGraph.java
@@ -11,6 +11,7 @@ import org.vertexium.inmemory.mutations.EdgeSetupMutation;
 import org.vertexium.inmemory.mutations.ElementTimestampMutation;
 import org.vertexium.mutation.AlterPropertyVisibility;
 import org.vertexium.mutation.ExtendedDataDeleteMutation;
+import org.vertexium.mutation.ExtendedDataMutation;
 import org.vertexium.mutation.SetPropertyMetadata;
 import org.vertexium.property.StreamingPropertyValue;
 import org.vertexium.property.StreamingPropertyValueRef;
@@ -880,24 +881,21 @@ public class InMemoryGraph extends GraphBaseWithSearchIndex {
     public void extendedData(
             Element element,
             ExtendedDataRowId rowId,
-            String column,
-            String key,
-            Object value,
-            long timestamp,
-            Visibility visibility,
+            ExtendedDataMutation extendedData,
             Authorizations authorizations
     ) {
-        extendedDataTable.addData(rowId, column, key, value, timestamp, visibility);
+        extendedDataTable.addData(rowId, extendedData.getColumnName(), extendedData.getKey(), extendedData.getValue(), extendedData.getTimestamp(), extendedData.getVisibility());
+        getSearchIndex().addElementExtendedData(this, element, Collections.singleton(extendedData), authorizations);
         if (hasEventListeners()) {
             fireGraphEvent(new AddExtendedDataEvent(
                     this,
                     element,
                     rowId.getTableName(),
                     rowId.getRowId(),
-                    column,
-                    key,
-                    value,
-                    visibility
+                    extendedData.getColumnName(),
+                    extendedData.getKey(),
+                    extendedData.getValue(),
+                    extendedData.getVisibility()
             ));
         }
     }

--- a/kryo-serializer/pom.xml
+++ b/kryo-serializer/pom.xml
@@ -3,7 +3,7 @@
     <parent>
         <artifactId>vertexium-root</artifactId>
         <groupId>org.vertexium</groupId>
-        <version>4.4.3-SNAPSHOT</version>
+        <version>4.5.0-SNAPSHOT</version>
     </parent>
     <modelVersion>4.0.0</modelVersion>
 

--- a/multimodule-test/accumulo-elasticsearch5/pom.xml
+++ b/multimodule-test/accumulo-elasticsearch5/pom.xml
@@ -5,7 +5,7 @@
     <parent>
         <groupId>org.vertexium</groupId>
         <artifactId>vertexium-multimodule-test</artifactId>
-        <version>4.4.3-SNAPSHOT</version>
+        <version>4.5.0-SNAPSHOT</version>
     </parent>
 
     <artifactId>vertexium-accumulo-elasticsearch5-multimodule-test</artifactId>

--- a/multimodule-test/pom.xml
+++ b/multimodule-test/pom.xml
@@ -5,7 +5,7 @@
     <parent>
         <groupId>org.vertexium</groupId>
         <artifactId>vertexium-root</artifactId>
-        <version>4.4.3-SNAPSHOT</version>
+        <version>4.5.0-SNAPSHOT</version>
     </parent>
 
     <artifactId>vertexium-multimodule-test</artifactId>

--- a/pom.xml
+++ b/pom.xml
@@ -11,7 +11,7 @@
     <groupId>org.vertexium</groupId>
     <artifactId>vertexium-root</artifactId>
     <packaging>pom</packaging>
-    <version>4.4.3-SNAPSHOT</version>
+    <version>4.5.0-SNAPSHOT</version>
     <name>Vertexium</name>
     <description>
         Vertexium is an API to manipulate graphs. Every Vertexium method requires authorizations

--- a/security/pom.xml
+++ b/security/pom.xml
@@ -3,7 +3,7 @@
     <parent>
         <artifactId>vertexium-root</artifactId>
         <groupId>org.vertexium</groupId>
-        <version>4.4.3-SNAPSHOT</version>
+        <version>4.5.0-SNAPSHOT</version>
     </parent>
     <modelVersion>4.0.0</modelVersion>
 

--- a/test/pom.xml
+++ b/test/pom.xml
@@ -3,7 +3,7 @@
     <parent>
         <artifactId>vertexium-root</artifactId>
         <groupId>org.vertexium</groupId>
-        <version>4.4.3-SNAPSHOT</version>
+        <version>4.5.0-SNAPSHOT</version>
     </parent>
     <modelVersion>4.0.0</modelVersion>
 

--- a/xstream-serializer/pom.xml
+++ b/xstream-serializer/pom.xml
@@ -3,7 +3,7 @@
     <parent>
         <artifactId>vertexium-root</artifactId>
         <groupId>org.vertexium</groupId>
-        <version>4.4.3-SNAPSHOT</version>
+        <version>4.5.0-SNAPSHOT</version>
     </parent>
     <modelVersion>4.0.0</modelVersion>
 


### PR DESCRIPTION
Updated to make sure that you have access to at least one column for a query to match extended data. Previously, if you had access to the element but none of the extended data columns you could still match on the row using a query with no filters. This resulted in the row being counted in `totalHits` but not loaded by Accumulo, which caused errors in the paging iterables.