### PR TITLE
Fix __elementType Visibility on Extended Data

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,6 @@
 # v4.5.0
 * Fixed: If you had access an element but none of the extended data columns you could still match on the extended data row using a query with no filters. This would result in the row being counted in `totalHits`, but it could not be retrieved from Accumulo. NOTE: This change requires that all extended data values are re-indexed in ElasticSearch.
+* Fixed: If the visibility of an element changes, Vertexium will now re-index all associated extended data to ensure that they can be found according to the new visibility.
 
 # v4.4.2
 * Fixed: `EdgeInfo.getDirection` was reversed when loaded from InMemoryVertex.

--- a/accumulo/src/main/java/org/vertexium/accumulo/AccumuloElement.java
+++ b/accumulo/src/main/java/org/vertexium/accumulo/AccumuloElement.java
@@ -384,6 +384,10 @@ public abstract class AccumuloElement extends ElementBase implements Serializabl
 
     @Override
     public ImmutableSet<String> getExtendedDataTableNames() {
+        if (!getFetchHints().isIncludeExtendedDataTableNames()) {
+            throw new VertexiumMissingFetchHintException(getFetchHints(), "includeExtendedDataTableNames");
+        }
+
         return extendedDataTableNames;
     }
 

--- a/elasticsearch5/src/main/java/org/vertexium/elasticsearch5/Elasticsearch5SearchIndex.java
+++ b/elasticsearch5/src/main/java/org/vertexium/elasticsearch5/Elasticsearch5SearchIndex.java
@@ -455,19 +455,18 @@ public class Elasticsearch5SearchIndex implements SearchIndex, SearchIndexWithVe
             getIndexRefreshTracker().pushChange(indexInfo.getIndexName());
             addActionRequestBuilderForFlush(element, updateRequestBuilder);
 
-            ImmutableSet<String> extendedDataTableNames = mutation.getElement().getExtendedDataTableNames();
-            if (mutation.getNewElementVisibility() != null &&
-                    extendedDataTableNames != null &&
-                    !extendedDataTableNames.isEmpty()
-            ) {
-                extendedDataTableNames.forEach(tableName ->
-                        alterExtendedDataElementTypeVisibility(
-                                graph,
-                                element,
-                                element.getExtendedData(tableName),
-                                mutation.getOldElementVisibility(),
-                                mutation.getNewElementVisibility()
-                        ));
+            if (mutation.getNewElementVisibility() != null && element.getFetchHints().isIncludeExtendedDataTableNames()) {
+                ImmutableSet<String> extendedDataTableNames = element.getExtendedDataTableNames();
+                if (extendedDataTableNames != null && !extendedDataTableNames.isEmpty()) {
+                    extendedDataTableNames.forEach(tableName ->
+                            alterExtendedDataElementTypeVisibility(
+                                    graph,
+                                    element,
+                                    element.getExtendedData(tableName),
+                                    mutation.getOldElementVisibility(),
+                                    mutation.getNewElementVisibility()
+                            ));
+                }
             }
 
             if (getConfig().isAutoFlush()) {

--- a/elasticsearch5/src/main/resources/org/vertexium/elasticsearch5/add-fields-to-extended-data.painless
+++ b/elasticsearch5/src/main/resources/org/vertexium/elasticsearch5/add-fields-to-extended-data.painless
@@ -1,6 +1,0 @@
-for (fieldToSet in params.fieldsToSet.entrySet()) {
-  ctx._source[fieldToSet.getKey()] = fieldToSet.getValue();
-}
-
-/* see helper-functions.painless for definition of getFieldVisibilities() */
-ctx._source['__extendedDataColumnVisibilities'] = getFieldVisibilities(ctx._source).toArray();

--- a/elasticsearch5/src/main/resources/org/vertexium/elasticsearch5/update-fields-on-document.painless
+++ b/elasticsearch5/src/main/resources/org/vertexium/elasticsearch5/update-fields-on-document.painless
@@ -7,3 +7,8 @@ for (fieldToRename in params.fieldsToRename.entrySet()) {
 for (fieldToSet in params.fieldsToSet.entrySet()) {
     ctx._source[fieldToSet.getKey()] = fieldToSet.getValue();
 }
+
+if (ctx._source['__elementType'] == 'vertexextdata' || ctx._source['__elementType'] == 'edgeextdata') {
+    /* see helper-functions.painless for definition of getFieldVisibilities() */
+    ctx._source['__extendedDataColumnVisibilities'] = getFieldVisibilities(ctx._source).toArray();
+}

--- a/inmemory/src/main/java/org/vertexium/inmemory/InMemoryElement.java
+++ b/inmemory/src/main/java/org/vertexium/inmemory/InMemoryElement.java
@@ -300,6 +300,10 @@ public abstract class InMemoryElement<TElement extends InMemoryElement> extends 
 
     @Override
     public ImmutableSet<String> getExtendedDataTableNames() {
+        if (!getFetchHints().isIncludeExtendedDataTableNames()) {
+            throw new VertexiumMissingFetchHintException(getFetchHints(), "includeExtendedDataTableNames");
+        }
+
         return graph.getExtendedDataTableNames(ElementType.getTypeFromElement(this), id, authorizations);
     }
 


### PR DESCRIPTION
When the visibility changes on an element, also update the visibility of the `__elementType` field on all associated extended data.