### PR TITLE
Changed: Improve Accumulo iterator memory by not converting values to strings and then back again

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,4 +1,5 @@
 # v4.5.1
+* Changed: Improve Accumulo iterator memory by not converting values to strings and then back again
 * Removed: Ability to run embedded Elasticsearch
 
 # v4.5.0

--- a/accumulo-iterators/src/main/java/org/vertexium/accumulo/iterator/KeyValue.java
+++ b/accumulo-iterators/src/main/java/org/vertexium/accumulo/iterator/KeyValue.java
@@ -1,0 +1,66 @@
+package org.vertexium.accumulo.iterator;
+
+import org.apache.accumulo.core.data.ArrayByteSequence;
+import org.apache.accumulo.core.data.ByteSequence;
+import org.apache.accumulo.core.data.Key;
+import org.apache.accumulo.core.data.Value;
+import org.apache.hadoop.io.Text;
+import org.vertexium.accumulo.iterator.util.ByteSequenceUtils;
+
+public class KeyValue {
+    private ByteSequence columnFamilyData;
+    private ByteSequence columnQualifierData;
+    private Key key;
+    private Value value;
+
+    public void set(Key key, Value value) {
+        this.key = key;
+        this.value = value;
+        this.columnFamilyData = key.getColumnFamilyData();
+        this.columnQualifierData = key.getColumnQualifierData();
+    }
+
+    public Text takeRow() {
+        return key.getRow();
+    }
+
+    public boolean columnFamilyEquals(byte[] bytes) {
+        return ByteSequenceUtils.equals(columnFamilyData, bytes);
+    }
+
+    public boolean columnQualifierEquals(byte[] bytes) {
+        return ByteSequenceUtils.equals(columnQualifierData, bytes);
+    }
+
+    public Text takeColumnQualifier() {
+        return key.getColumnQualifier();
+    }
+
+    public Text takeColumnVisibility() {
+        return key.getColumnVisibility();
+    }
+
+    public long getTimestamp() {
+        return key.getTimestamp();
+    }
+
+    public Value peekValue() {
+        return value;
+    }
+
+    public Value takeValue() {
+        return new Value(value);
+    }
+
+    public ByteSequence takeColumnQualifierByteSequence() {
+        return new ArrayByteSequence(takeColumnQualifier().getBytes());
+    }
+
+    public ByteSequence takeColumnVisibilityByteSequence() {
+        return new ArrayByteSequence(takeColumnVisibility().getBytes());
+    }
+
+    public ByteSequence peekColumnVisibilityByteSequence() {
+        return key.getColumnVisibilityData();
+    }
+}

--- a/accumulo-iterators/src/main/java/org/vertexium/accumulo/iterator/model/HiddenProperty.java
+++ b/accumulo-iterators/src/main/java/org/vertexium/accumulo/iterator/model/HiddenProperty.java
@@ -1,27 +1,29 @@
 package org.vertexium.accumulo.iterator.model;
 
-import org.apache.hadoop.io.Text;
+import org.apache.accumulo.core.data.ByteSequence;
+
+import java.util.Objects;
 
 public class HiddenProperty {
-    private final String key;
-    private final String name;
-    private final String visibility;
-    private final Text hiddenVisibility;
+    private final ByteSequence key;
+    private final ByteSequence name;
+    private final ByteSequence visibility;
+    private final ByteSequence hiddenVisibility;
 
-    public HiddenProperty(String key, String name, String visibility, Text hiddenVisibility) {
+    public HiddenProperty(ByteSequence key, ByteSequence name, ByteSequence visibility, ByteSequence hiddenVisibility) {
         this.key = key;
         this.name = name;
         this.visibility = visibility;
         this.hiddenVisibility = hiddenVisibility;
     }
 
-    public boolean matches(String propertyKey, String propertyName, String visibility) {
+    public boolean matches(ByteSequence propertyKey, ByteSequence propertyName, ByteSequence visibility) {
         return propertyKey.equals(this.key)
                 && propertyName.equals(this.name)
                 && visibility.equals(this.visibility);
     }
 
-    public Text getHiddenVisibility() {
+    public ByteSequence getHiddenVisibility() {
         return hiddenVisibility;
     }
 
@@ -36,13 +38,13 @@ public class HiddenProperty {
 
         HiddenProperty that = (HiddenProperty) o;
 
-        if (key != null ? !key.equals(that.key) : that.key != null) {
+        if (!Objects.equals(key, that.key)) {
             return false;
         }
-        if (name != null ? !name.equals(that.name) : that.name != null) {
+        if (!Objects.equals(name, that.name)) {
             return false;
         }
-        if (visibility != null ? !visibility.equals(that.visibility) : that.visibility != null) {
+        if (!Objects.equals(visibility, that.visibility)) {
             return false;
         }
 

--- a/accumulo-iterators/src/main/java/org/vertexium/accumulo/iterator/model/IteratorFetchHints.java
+++ b/accumulo-iterators/src/main/java/org/vertexium/accumulo/iterator/model/IteratorFetchHints.java
@@ -1,5 +1,8 @@
 package org.vertexium.accumulo.iterator.model;
 
+import org.apache.accumulo.core.data.ByteSequence;
+import org.vertexium.accumulo.iterator.util.ByteSequenceUtils;
+
 import java.io.Serializable;
 import java.util.Set;
 import java.util.stream.Collectors;
@@ -7,9 +10,9 @@ import java.util.stream.Collectors;
 public class IteratorFetchHints implements Serializable {
     private static final long serialVersionUID = -6302969731435846529L;
     private final boolean includeAllProperties;
-    private final Set<String> propertyNamesToInclude;
+    private final Set<ByteSequence> propertyNamesToInclude;
     private final boolean includeAllPropertyMetadata;
-    private final Set<String> metadataKeysToInclude;
+    private final Set<ByteSequence> metadataKeysToInclude;
     private final boolean includeHidden;
     private final boolean includeAllEdgeRefs;
     private final boolean includeOutEdgeRefs;
@@ -34,9 +37,9 @@ public class IteratorFetchHints implements Serializable {
 
     public IteratorFetchHints(
             boolean includeAllProperties,
-            Set<String> propertyNamesToInclude,
+            Set<ByteSequence> propertyNamesToInclude,
             boolean includeAllPropertyMetadata,
-            Set<String> metadataKeysToInclude,
+            Set<ByteSequence> metadataKeysToInclude,
             boolean includeHidden,
             boolean includeAllEdgeRefs,
             boolean includeOutEdgeRefs,
@@ -62,7 +65,7 @@ public class IteratorFetchHints implements Serializable {
         return includeAllProperties;
     }
 
-    public Set<String> getPropertyNamesToInclude() {
+    public Set<ByteSequence> getPropertyNamesToInclude() {
         return propertyNamesToInclude;
     }
 
@@ -70,7 +73,7 @@ public class IteratorFetchHints implements Serializable {
         return includeAllPropertyMetadata;
     }
 
-    public Set<String> getMetadataKeysToInclude() {
+    public Set<ByteSequence> getMetadataKeysToInclude() {
         return metadataKeysToInclude;
     }
 
@@ -106,9 +109,9 @@ public class IteratorFetchHints implements Serializable {
     public String toString() {
         return "IteratorFetchHints{" +
                 "includeAllProperties=" + includeAllProperties +
-                ", propertyNamesToInclude=" + setToString(propertyNamesToInclude) +
+                ", propertyNamesToInclude=" + setOfByteSequencesToString(propertyNamesToInclude) +
                 ", includeAllPropertyMetadata=" + includeAllPropertyMetadata +
-                ", metadataKeysToInclude=" + setToString(metadataKeysToInclude) +
+                ", metadataKeysToInclude=" + setOfByteSequencesToString(metadataKeysToInclude) +
                 ", includeHidden=" + includeHidden +
                 ", includeAllEdgeRefs=" + includeAllEdgeRefs +
                 ", includeOutEdgeRefs=" + includeOutEdgeRefs +
@@ -119,10 +122,19 @@ public class IteratorFetchHints implements Serializable {
                 '}';
     }
 
+    private String setOfByteSequencesToString(Set<ByteSequence> set) {
+        if (set == null) {
+            return "";
+        }
+        return set.stream()
+                .map(ByteSequenceUtils::toString)
+                .collect(Collectors.joining(","));
+    }
+
     private String setToString(Set<String> set) {
         if (set == null) {
             return "";
         }
-        return set.stream().collect(Collectors.joining(","));
+        return String.join(",", set);
     }
 }

--- a/accumulo-iterators/src/main/java/org/vertexium/accumulo/iterator/model/IteratorMetadataEntry.java
+++ b/accumulo-iterators/src/main/java/org/vertexium/accumulo/iterator/model/IteratorMetadataEntry.java
@@ -1,14 +1,16 @@
 package org.vertexium.accumulo.iterator.model;
 
+import org.apache.accumulo.core.data.ByteSequence;
+
 import java.util.Arrays;
 import java.util.Objects;
 
 public class IteratorMetadataEntry {
-    public final String metadataKey;
-    public final String metadataVisibility;
+    public final ByteSequence metadataKey;
+    public final ByteSequence metadataVisibility;
     public final byte[] value;
 
-    public IteratorMetadataEntry(String metadataKey, String metadataVisibility, byte[] value) {
+    public IteratorMetadataEntry(ByteSequence metadataKey, ByteSequence metadataVisibility, byte[] value) {
         this.metadataKey = metadataKey;
         this.metadataVisibility = metadataVisibility;
         this.value = value;

--- a/accumulo-iterators/src/main/java/org/vertexium/accumulo/iterator/model/KeyBaseByteSequence.java
+++ b/accumulo-iterators/src/main/java/org/vertexium/accumulo/iterator/model/KeyBaseByteSequence.java
@@ -1,0 +1,59 @@
+package org.vertexium.accumulo.iterator.model;
+
+import org.apache.accumulo.core.data.ArrayByteSequence;
+import org.apache.accumulo.core.data.ByteSequence;
+import org.vertexium.accumulo.iterator.util.ByteSequenceUtils;
+
+import java.nio.ByteBuffer;
+
+import static org.vertexium.accumulo.iterator.util.ByteSequenceUtils.indexOf;
+import static org.vertexium.accumulo.iterator.util.ByteSequenceUtils.subSequence;
+
+public abstract class KeyBaseByteSequence {
+    public static final byte VALUE_SEPARATOR = 0x1f;
+
+    public static ByteSequence[] splitOnValueSeparator(ByteSequence bytes, int partCount) {
+        ByteSequence[] results = new ByteSequence[partCount];
+        int last = 0;
+        int i = indexOf(bytes, VALUE_SEPARATOR);
+        int partIndex = 0;
+        while (true) {
+            if (i > 0) {
+                results[partIndex++] = subSequence(bytes, last, i);
+                if (partIndex >= partCount) {
+                    throw new VertexiumAccumuloIteratorException("Invalid number of parts for '" + bytes + "'. Expected " + partCount + " found " + partIndex);
+                }
+                last = i + 1;
+                i = indexOf(bytes, VALUE_SEPARATOR, last);
+            } else {
+                results[partIndex++] = subSequence(bytes, last);
+                break;
+            }
+        }
+        if (partIndex != partCount) {
+            throw new VertexiumAccumuloIteratorException("Invalid number of parts for '" + bytes + "'. Expected " + partCount + " found " + partIndex);
+        }
+        return results;
+    }
+
+    public static void assertNoValueSeparator(ByteSequence bytes) {
+        if (indexOf(bytes, VALUE_SEPARATOR) >= 0) {
+            throw new VertexiumInvalidKeyException("String cannot contain '" + VALUE_SEPARATOR + "' (0x1f): " + bytes);
+        }
+    }
+
+    public static ByteSequence getDiscriminator(ByteSequence propertyName, ByteSequence propertyKey, ByteSequence visibilityString, long timestamp) {
+        assertNoValueSeparator(propertyName);
+        assertNoValueSeparator(propertyKey);
+        assertNoValueSeparator(visibilityString);
+        int length = propertyName.length() + propertyKey.length() + visibilityString.length() + 8;
+        byte[] bytes = new byte[length];
+        ByteBuffer bb = ByteBuffer.wrap(bytes);
+        ByteSequenceUtils.putIntoByteBuffer(propertyName, bb);
+        ByteSequenceUtils.putIntoByteBuffer(propertyKey, bb);
+        ByteSequenceUtils.putIntoByteBuffer(visibilityString, bb);
+        bb.putLong(timestamp);
+        return new ArrayByteSequence(bytes);
+    }
+}
+

--- a/accumulo-iterators/src/main/java/org/vertexium/accumulo/iterator/model/Property.java
+++ b/accumulo-iterators/src/main/java/org/vertexium/accumulo/iterator/model/Property.java
@@ -1,26 +1,26 @@
 package org.vertexium.accumulo.iterator.model;
 
-import org.apache.hadoop.io.Text;
+import org.apache.accumulo.core.data.ByteSequence;
 
 import java.util.List;
 import java.util.Set;
 
 public class Property {
-    public final String key;
-    public final String name;
+    public final ByteSequence key;
+    public final ByteSequence name;
     public final byte[] value;
-    public final Set<Text> hiddenVisibilities;
-    public final String visibility;
+    public final Set<ByteSequence> hiddenVisibilities;
+    public final ByteSequence visibility;
     public final long timestamp;
     public final List<Integer> metadata;
 
     public Property(
-            String propertyKey,
-            String propertyName,
+            ByteSequence propertyKey,
+            ByteSequence propertyName,
             byte[] propertyValue,
-            String propertyVisibility,
+            ByteSequence propertyVisibility,
             long propertyTimestamp,
-            Set<Text> propertyHiddenVisibilities,
+            Set<ByteSequence> propertyHiddenVisibilities,
             List<Integer> metadata
     ) {
         this.key = propertyKey;

--- a/accumulo-iterators/src/main/java/org/vertexium/accumulo/iterator/model/PropertyColumnQualifier.java
+++ b/accumulo-iterators/src/main/java/org/vertexium/accumulo/iterator/model/PropertyColumnQualifier.java
@@ -7,10 +7,6 @@ public class PropertyColumnQualifier extends KeyBase {
     public static final int PART_INDEX_PROPERTY_KEY = 1;
     private final String[] parts;
 
-    public PropertyColumnQualifier(Text columnQualifier) {
-        this.parts = splitOnValueSeparator(columnQualifier.toString(), 2);
-    }
-
     public PropertyColumnQualifier(String propertyName, String propertyKey) {
         this.parts = new String[]{
                 propertyName,

--- a/accumulo-iterators/src/main/java/org/vertexium/accumulo/iterator/model/PropertyColumnQualifierByteSequence.java
+++ b/accumulo-iterators/src/main/java/org/vertexium/accumulo/iterator/model/PropertyColumnQualifierByteSequence.java
@@ -1,0 +1,25 @@
+package org.vertexium.accumulo.iterator.model;
+
+import org.apache.accumulo.core.data.ByteSequence;
+
+public class PropertyColumnQualifierByteSequence extends KeyBaseByteSequence {
+    public static final int PART_INDEX_PROPERTY_NAME = 0;
+    public static final int PART_INDEX_PROPERTY_KEY = 1;
+    private final ByteSequence[] parts;
+
+    public PropertyColumnQualifierByteSequence(ByteSequence columnQualifier) {
+        this.parts = splitOnValueSeparator(columnQualifier, 2);
+    }
+
+    public ByteSequence getPropertyName() {
+        return parts[PART_INDEX_PROPERTY_NAME];
+    }
+
+    public ByteSequence getPropertyKey() {
+        return parts[PART_INDEX_PROPERTY_KEY];
+    }
+
+    public ByteSequence getDiscriminator(ByteSequence columnVisibility, long timestamp) {
+        return getDiscriminator(getPropertyName(), getPropertyKey(), columnVisibility, timestamp);
+    }
+}

--- a/accumulo-iterators/src/main/java/org/vertexium/accumulo/iterator/model/PropertyHiddenColumnQualifierByteSequence.java
+++ b/accumulo-iterators/src/main/java/org/vertexium/accumulo/iterator/model/PropertyHiddenColumnQualifierByteSequence.java
@@ -1,24 +1,26 @@
 package org.vertexium.accumulo.iterator.model;
 
-public class PropertyHiddenColumnQualifier extends KeyBase {
+import org.apache.accumulo.core.data.ByteSequence;
+
+public class PropertyHiddenColumnQualifierByteSequence extends KeyBaseByteSequence {
     private static final int PART_INDEX_PROPERTY_NAME = 0;
     private static final int PART_INDEX_PROPERTY_KEY = 1;
     private static final int PART_INDEX_PROPERTY_VISIBILITY = 2;
-    private final String[] parts;
+    private final ByteSequence[] parts;
 
-    public PropertyHiddenColumnQualifier(String columnQualifier) {
+    public PropertyHiddenColumnQualifierByteSequence(ByteSequence columnQualifier) {
         parts = splitOnValueSeparator(columnQualifier, 3);
     }
 
-    public String getPropertyName() {
+    public ByteSequence getPropertyName() {
         return parts[PART_INDEX_PROPERTY_NAME];
     }
 
-    public String getPropertyKey() {
+    public ByteSequence getPropertyKey() {
         return parts[PART_INDEX_PROPERTY_KEY];
     }
 
-    public String getPropertyVisibilityString() {
+    public ByteSequence getPropertyVisibilityString() {
         return parts[PART_INDEX_PROPERTY_VISIBILITY];
     }
 }

--- a/accumulo-iterators/src/main/java/org/vertexium/accumulo/iterator/model/PropertyMetadataColumnQualifier.java
+++ b/accumulo-iterators/src/main/java/org/vertexium/accumulo/iterator/model/PropertyMetadataColumnQualifier.java
@@ -1,17 +1,11 @@
 package org.vertexium.accumulo.iterator.model;
 
-import org.apache.hadoop.io.Text;
-
 public class PropertyMetadataColumnQualifier extends KeyBase {
     public static final int PART_INDEX_PROPERTY_NAME = 0;
     public static final int PART_INDEX_PROPERTY_KEY = 1;
     public static final int PART_INDEX_PROPERTY_VISIBILITY = 2;
     public static final int PART_INDEX_METADATA_KEY = 3;
     private final String[] parts;
-
-    public PropertyMetadataColumnQualifier(Text columnQualifier) {
-        this.parts = splitOnValueSeparator(columnQualifier.toString(), 4);
-    }
 
     public PropertyMetadataColumnQualifier(String propertyName, String propertyKey, String visibilityString, String metadataKey) {
         parts = new String[]{

--- a/accumulo-iterators/src/main/java/org/vertexium/accumulo/iterator/model/PropertyMetadataColumnQualifierByteSequence.java
+++ b/accumulo-iterators/src/main/java/org/vertexium/accumulo/iterator/model/PropertyMetadataColumnQualifierByteSequence.java
@@ -1,0 +1,35 @@
+package org.vertexium.accumulo.iterator.model;
+
+import org.apache.accumulo.core.data.ByteSequence;
+
+public class PropertyMetadataColumnQualifierByteSequence extends KeyBaseByteSequence {
+    public static final int PART_INDEX_PROPERTY_NAME = 0;
+    public static final int PART_INDEX_PROPERTY_KEY = 1;
+    public static final int PART_INDEX_PROPERTY_VISIBILITY = 2;
+    public static final int PART_INDEX_METADATA_KEY = 3;
+    private final ByteSequence[] parts;
+
+    public PropertyMetadataColumnQualifierByteSequence(ByteSequence columnQualifier) {
+        this.parts = splitOnValueSeparator(columnQualifier, 4);
+    }
+
+    public ByteSequence getPropertyName() {
+        return parts[PART_INDEX_PROPERTY_NAME];
+    }
+
+    public ByteSequence getPropertyKey() {
+        return parts[PART_INDEX_PROPERTY_KEY];
+    }
+
+    public ByteSequence getPropertyVisibilityString() {
+        return parts[PART_INDEX_PROPERTY_VISIBILITY];
+    }
+
+    public ByteSequence getMetadataKey() {
+        return parts[PART_INDEX_METADATA_KEY];
+    }
+
+    public ByteSequence getPropertyDiscriminator(long propertyTimestamp) {
+        return getDiscriminator(getPropertyName(), getPropertyKey(), getPropertyVisibilityString(), propertyTimestamp);
+    }
+}

--- a/accumulo-iterators/src/main/java/org/vertexium/accumulo/iterator/model/SoftDeletedProperty.java
+++ b/accumulo-iterators/src/main/java/org/vertexium/accumulo/iterator/model/SoftDeletedProperty.java
@@ -1,14 +1,16 @@
 package org.vertexium.accumulo.iterator.model;
 
-import org.apache.hadoop.io.Text;
+import org.apache.accumulo.core.data.ByteSequence;
+
+import java.util.Objects;
 
 public class SoftDeletedProperty {
-    private final String propertyKey;
-    private final String propertyName;
+    private final ByteSequence propertyKey;
+    private final ByteSequence propertyName;
     private final long timestamp;
-    private final Text visibility;
+    private final ByteSequence visibility;
 
-    public SoftDeletedProperty(String propertyKey, String propertyName, long timestamp, Text visibility) {
+    public SoftDeletedProperty(ByteSequence propertyKey, ByteSequence propertyName, long timestamp, ByteSequence visibility) {
         this.propertyKey = propertyKey;
         this.propertyName = propertyName;
         this.timestamp = timestamp;
@@ -30,13 +32,13 @@ public class SoftDeletedProperty {
 
         SoftDeletedProperty that = (SoftDeletedProperty) o;
 
-        if (propertyKey != null ? !propertyKey.equals(that.propertyKey) : that.propertyKey != null) {
+        if (!Objects.equals(propertyKey, that.propertyKey)) {
             return false;
         }
-        if (propertyName != null ? !propertyName.equals(that.propertyName) : that.propertyName != null) {
+        if (!Objects.equals(propertyName, that.propertyName)) {
             return false;
         }
-        if (visibility != null ? !visibility.equals(that.visibility) : that.visibility != null) {
+        if (!Objects.equals(visibility, that.visibility)) {
             return false;
         }
 
@@ -51,7 +53,7 @@ public class SoftDeletedProperty {
         return result;
     }
 
-    public boolean matches(String propertyKey, String propertyName, Text visibility) {
+    public boolean matches(ByteSequence propertyKey, ByteSequence propertyName, ByteSequence visibility) {
         return propertyKey.equals(this.propertyKey)
                 && propertyName.equals(this.propertyName)
                 && visibility.equals(this.visibility);

--- a/accumulo-iterators/src/main/java/org/vertexium/accumulo/iterator/util/ByteSequenceUtils.java
+++ b/accumulo-iterators/src/main/java/org/vertexium/accumulo/iterator/util/ByteSequenceUtils.java
@@ -1,0 +1,64 @@
+package org.vertexium.accumulo.iterator.util;
+
+import org.apache.accumulo.core.data.ByteSequence;
+
+import java.nio.ByteBuffer;
+import java.nio.charset.StandardCharsets;
+import java.util.Arrays;
+
+public class ByteSequenceUtils {
+    public static boolean equals(ByteSequence byteSequence, byte[] bytes) {
+        if (byteSequence.length() != bytes.length) {
+            return false;
+        }
+        if (byteSequence.isBackedByArray() && byteSequence.offset() == 0) {
+            return Arrays.equals(bytes, byteSequence.getBackingArray());
+        }
+
+        for (int i = 0; i < bytes.length; i++) {
+            if (bytes[i] != byteSequence.byteAt(i)) {
+                return false;
+            }
+        }
+        return true;
+    }
+
+    public static String toString(ByteSequence byteSequence) {
+        return new String(
+                byteSequence.getBackingArray(),
+                byteSequence.offset(),
+                byteSequence.length(),
+                StandardCharsets.UTF_8
+        );
+    }
+
+    public static int indexOf(ByteSequence bytes, byte b) {
+        return indexOf(bytes, b, 0);
+    }
+
+    public static int indexOf(ByteSequence bytes, byte b, int startIndex) {
+        // TODO utf-8 encoding issues?
+        for (int i = startIndex; i < bytes.length(); i++) {
+            if (bytes.byteAt(i) == b) {
+                return i;
+            }
+        }
+        return -1;
+    }
+
+    public static ByteSequence subSequence(ByteSequence bytes, int startIndex) {
+        return subSequence(bytes, startIndex, bytes.length());
+    }
+
+    public static ByteSequence subSequence(ByteSequence bytes, int startIndex, int endIndex) {
+        return bytes.subSequence(startIndex, endIndex);
+    }
+
+    public static void putIntoByteBuffer(ByteSequence bytes, ByteBuffer bb) {
+        bb.put(bytes.getBackingArray(), bytes.offset(), bytes.length());
+    }
+
+    public static byte[] getBytes(ByteSequence byteSequence) {
+        return byteSequence.toArray();
+    }
+}

--- a/accumulo-iterators/src/main/java/org/vertexium/accumulo/iterator/util/DataOutputStreamUtils.java
+++ b/accumulo-iterators/src/main/java/org/vertexium/accumulo/iterator/util/DataOutputStreamUtils.java
@@ -1,5 +1,6 @@
 package org.vertexium.accumulo.iterator.util;
 
+import org.apache.accumulo.core.data.ByteSequence;
 import org.apache.hadoop.io.Text;
 import org.vertexium.accumulo.iterator.model.EdgeInfo;
 import org.vertexium.accumulo.iterator.model.EdgesWithEdgeInfo;
@@ -26,6 +27,17 @@ public class DataOutputStreamUtils {
         }
     }
 
+    public static void encodeByteSequenceList(DataOutputStream out, Collection<ByteSequence> byteSequences) throws IOException {
+        if (byteSequences == null) {
+            out.writeInt(-1);
+            return;
+        }
+        out.writeInt(byteSequences.size());
+        for (ByteSequence byteSequence : byteSequences) {
+            encodeByteSequence(out, byteSequence);
+        }
+    }
+
     public static void encodeStringSet(DataOutputStream out, Set<String> set) throws IOException {
         if (set == null) {
             out.writeInt(-1);
@@ -44,6 +56,15 @@ public class DataOutputStreamUtils {
         }
         out.writeInt(text.getLength());
         out.write(text.getBytes(), 0, text.getLength());
+    }
+
+    public static void encodeByteSequence(DataOutputStream out, ByteSequence byteSequence) throws IOException {
+        if (byteSequence == null) {
+            out.writeInt(-1);
+            return;
+        }
+        out.writeInt(byteSequence.length());
+        out.write(byteSequence.getBackingArray(), byteSequence.offset(), byteSequence.length());
     }
 
     public static void encodeByteArray(DataOutputStream out, byte[] bytes) throws IOException {
@@ -83,8 +104,8 @@ public class DataOutputStreamUtils {
         }
         out.writeInt(metadataEntries.size());
         for (IteratorMetadataEntry metadataEntry : metadataEntries) {
-            encodeString(out, metadataEntry.metadataKey);
-            encodeString(out, metadataEntry.metadataVisibility);
+            encodeByteSequence(out, metadataEntry.metadataKey);
+            encodeByteSequence(out, metadataEntry.metadataVisibility);
             out.writeInt(metadataEntry.value.length);
             out.write(metadataEntry.value);
         }

--- a/accumulo/src/main/java/org/vertexium/accumulo/mapreduce/AccumuloElementInputFormatBase.java
+++ b/accumulo/src/main/java/org/vertexium/accumulo/mapreduce/AccumuloElementInputFormatBase.java
@@ -8,6 +8,7 @@ import org.apache.accumulo.core.client.ClientConfiguration;
 import org.apache.accumulo.core.client.mapreduce.AccumuloInputFormat;
 import org.apache.accumulo.core.client.mapreduce.AccumuloRowInputFormat;
 import org.apache.accumulo.core.client.security.tokens.AuthenticationToken;
+import org.apache.accumulo.core.data.ByteSequence;
 import org.apache.accumulo.core.data.Key;
 import org.apache.accumulo.core.data.Value;
 import org.apache.accumulo.core.util.Pair;
@@ -20,6 +21,7 @@ import org.vertexium.accumulo.AccumuloGraph;
 import org.vertexium.accumulo.LazyMutableProperty;
 import org.vertexium.accumulo.iterator.model.ElementData;
 import org.vertexium.accumulo.iterator.model.IteratorFetchHints;
+import org.vertexium.accumulo.iterator.util.ByteSequenceUtils;
 import org.vertexium.util.MapUtils;
 
 import javax.annotation.Nullable;
@@ -117,15 +119,17 @@ public abstract class AccumuloElementInputFormatBase<TValue extends Element> ext
     private static Property makePropertyFromIteratorProperty(AccumuloGraph graph, org.vertexium.accumulo.iterator.model.Property property) {
         Set<Visibility> hiddenVisibilities = null;
         if (property.hiddenVisibilities != null) {
-            hiddenVisibilities = Sets.newHashSet(Iterables.transform(property.hiddenVisibilities, new Function<Text, Visibility>() {
+            hiddenVisibilities = Sets.newHashSet(Iterables.transform(property.hiddenVisibilities, new Function<ByteSequence, Visibility>() {
                 @Nullable
                 @Override
-                public Visibility apply(Text visibilityText) {
-                    return AccumuloGraph.accumuloVisibilityToVisibility(AccumuloGraph.visibilityToAccumuloVisibility(visibilityText.toString()));
+                public Visibility apply(ByteSequence visibilityText) {
+                    return AccumuloGraph.accumuloVisibilityToVisibility(AccumuloGraph.visibilityToAccumuloVisibility(ByteSequenceUtils.toString(visibilityText)));
                 }
             }));
         }
-        Visibility visibility = AccumuloGraph.accumuloVisibilityToVisibility(AccumuloGraph.visibilityToAccumuloVisibility(property.visibility));
+        Visibility visibility = AccumuloGraph.accumuloVisibilityToVisibility(
+                AccumuloGraph.visibilityToAccumuloVisibility(property.visibility)
+        );
         return new LazyMutableProperty(
                 graph,
                 graph.getVertexiumSerializer(),

--- a/test/src/main/java/org/vertexium/test/GraphTestBase.java
+++ b/test/src/main/java/org/vertexium/test/GraphTestBase.java
@@ -808,6 +808,7 @@ public abstract class GraphTestBase {
         graph.softDeleteVertex("v1", AUTHORIZATIONS_A);
         graph.flush();
         assertEquals(1, count(graph.getVertices(AUTHORIZATIONS_A)));
+        assertEquals(0, count(graph.getEdges(AUTHORIZATIONS_A)));
         assertEquals(0, count(graph.query(AUTHORIZATIONS_A).has("name1", "value1").vertices()));
 
         v2 = graph.getVertex("v2", AUTHORIZATIONS_A);
@@ -9044,7 +9045,7 @@ public abstract class GraphTestBase {
             }
         }
 
-        Metadata metadata =  Metadata.create();
+        Metadata metadata = Metadata.create();
         metadata.add("metadata1", "metadata1Value", VISIBILITY_A);
         Vertex v2 = graph.prepareVertex("v2", VISIBILITY_A)
                 .setProperty("prop1_A", "value1", metadata, VISIBILITY_A)


### PR DESCRIPTION
Unit tests pass and based on testing helps by speeding up the iterator by 75% in highly constrained memory environments.