### PR TITLE
add sync index

### DIFF
--- a/core/src/main/java/org/vertexium/GraphBaseWithSearchIndex.java
+++ b/core/src/main/java/org/vertexium/GraphBaseWithSearchIndex.java
@@ -259,4 +259,26 @@ public abstract class GraphBaseWithSearchIndex extends GraphBase implements Grap
     public FetchHints getDefaultFetchHints() {
         return defaultFetchHints;
     }
+
+    @Override
+    public Iterable<Edge> addEdgesAsyncIndex(Iterable<ElementBuilder<Edge>> edges, Authorizations authorizations) {
+        List<Edge> addedEdges = new ArrayList<>();
+        for (ElementBuilder<Edge> edgeBuilder : edges) {
+            edgeBuilder.setIndexHint(IndexHint.DO_NOT_INDEX);
+            addedEdges.add(edgeBuilder.save(authorizations));
+        }
+        getSearchIndex().addElements(this,addedEdges,authorizations);
+        return addedEdges;
+    }
+
+    @Override
+    public Iterable<Vertex> addVerticesAsyncIndex(Iterable<ElementBuilder<Vertex>> vertices, Authorizations authorizations) {
+        List<Vertex> addedVertices = new ArrayList<>();
+        for (ElementBuilder<Vertex> vertexBuilder : vertices) {
+            vertexBuilder.setIndexHint(IndexHint.DO_NOT_INDEX);
+            addedVertices.add(vertexBuilder.save(authorizations));
+        }
+        getSearchIndex().addElements(this,addedVertices,authorizations);
+        return addedVertices;
+    }
 }

--- a/core/src/main/java/org/vertexium/GraphWithSearchIndex.java
+++ b/core/src/main/java/org/vertexium/GraphWithSearchIndex.java
@@ -9,4 +9,8 @@ public interface GraphWithSearchIndex extends Graph {
      * This method will only flush the primary graph and not the search index
      */
     void flushGraph();
+
+    Iterable<Edge> addEdgesAsyncIndex(Iterable<ElementBuilder<Edge>> edges, Authorizations authorizations);
+
+    Iterable<Vertex> addVerticesAsyncIndex(Iterable<ElementBuilder<Vertex>> vertices, Authorizations authorizations);
 }


### PR DESCRIPTION
  When we write bulk data, if the index is written to accumulo and es one by one, we can first batch write accumulo in asynchronous synchronous es index data, which can greatly improve the efficiency of batch import data.
  After the test index synchronization speed is greatly improved compared to before