### PR TITLE
Accumulo use a thread pool when doing batch scans

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,6 @@
+# v4.6.0
+* Changed: Accumulo use a thread pool when doing batch scans 
+
 # v4.5.2
 * Fixed: Accumulo delete extended data not removing rows 
 * Changed: Elasticsearch to not use locks when flushing it's internal queue

--- a/accumulo/src/main/java/org/vertexium/accumulo/AccumuloGraph.java
+++ b/accumulo/src/main/java/org/vertexium/accumulo/AccumuloGraph.java
@@ -40,6 +40,7 @@ import org.vertexium.accumulo.iterator.util.ByteSequenceUtils;
 import org.vertexium.accumulo.keys.KeyHelper;
 import org.vertexium.accumulo.util.RangeUtils;
 import org.vertexium.accumulo.util.StreamingPropertyValueStorageStrategy;
+import org.vertexium.accumulo.util.VisalloTabletServerBatchReader;
 import org.vertexium.event.*;
 import org.vertexium.mutation.*;
 import org.vertexium.property.MutableProperty;
@@ -1800,9 +1801,13 @@ public class AccumuloGraph extends GraphBaseWithSearchIndex implements Traceable
         Collection<org.apache.accumulo.core.data.Range> ranges,
         org.apache.accumulo.core.security.Authorizations accumuloAuthorizations
     ) throws TableNotFoundException {
-        ScannerBase scanner;
-        scanner = connector.createBatchScanner(tableName, accumuloAuthorizations, numberOfQueryThreads);
-        ((BatchScanner) scanner).setRanges(ranges);
+        VisalloTabletServerBatchReader scanner = new VisalloTabletServerBatchReader(
+            connector,
+            tableName,
+            accumuloAuthorizations,
+            numberOfQueryThreads
+        );
+        scanner.setRanges(ranges);
         return scanner;
     }
 

--- a/accumulo/src/main/java/org/vertexium/accumulo/util/ConnectorUtils.java
+++ b/accumulo/src/main/java/org/vertexium/accumulo/util/ConnectorUtils.java
@@ -1,0 +1,23 @@
+package org.vertexium.accumulo.util;
+
+import org.apache.accumulo.core.client.Connector;
+import org.apache.accumulo.core.client.impl.ClientContext;
+import org.apache.accumulo.core.client.impl.ConnectorImpl;
+import org.vertexium.VertexiumException;
+
+import java.lang.reflect.Field;
+
+public class ConnectorUtils {
+    public static ClientContext getContext(Connector connector) {
+        if (!(connector instanceof ConnectorImpl)) {
+            throw new VertexiumException("Invalid connector type. Expected " + ConnectorImpl.class.getName() + " found " + connector.getClass().getName());
+        }
+        try {
+            Field f = ConnectorImpl.class.getDeclaredField("context");
+            f.setAccessible(true);
+            return (ClientContext) f.get(connector);
+        } catch (Exception e) {
+            throw new VertexiumException("Could not get context field", e);
+        }
+    }
+}

--- a/accumulo/src/main/java/org/vertexium/accumulo/util/VisalloTabletServerBatchReader.java
+++ b/accumulo/src/main/java/org/vertexium/accumulo/util/VisalloTabletServerBatchReader.java
@@ -1,0 +1,93 @@
+package org.vertexium.accumulo.util;
+
+import org.apache.accumulo.core.client.BatchScanner;
+import org.apache.accumulo.core.client.Connector;
+import org.apache.accumulo.core.client.TableNotFoundException;
+import org.apache.accumulo.core.client.impl.ClientContext;
+import org.apache.accumulo.core.client.impl.ScannerOptions;
+import org.apache.accumulo.core.client.impl.Tables;
+import org.apache.accumulo.core.client.impl.TabletServerBatchReaderIterator;
+import org.apache.accumulo.core.data.Key;
+import org.apache.accumulo.core.data.Range;
+import org.apache.accumulo.core.data.Value;
+import org.apache.accumulo.core.security.Authorizations;
+import org.apache.accumulo.core.util.NamingThreadFactory;
+
+import java.util.ArrayList;
+import java.util.Collection;
+import java.util.Iterator;
+import java.util.Map;
+import java.util.concurrent.ExecutorService;
+import java.util.concurrent.SynchronousQueue;
+import java.util.concurrent.ThreadPoolExecutor;
+import java.util.concurrent.TimeUnit;
+
+import static com.google.common.base.Preconditions.checkArgument;
+
+// Based on org.apache.accumulo.core.client.impl.TabletServerBatchReader
+public class VisalloTabletServerBatchReader extends ScannerOptions implements BatchScanner {
+    private final String tableId;
+    private final int numThreads;
+    private final ClientContext context;
+    private final Authorizations authorizations;
+    private ArrayList<Range> ranges;
+
+    private static final ExecutorService queryThreadPool = new ThreadPoolExecutor(
+        0,
+        Integer.MAX_VALUE,
+        30L,
+        TimeUnit.SECONDS,
+        new SynchronousQueue<>(),
+        new NamingThreadFactory("Accumulo batch scanner read ahead thread")
+    );
+
+    public VisalloTabletServerBatchReader(
+        Connector connector,
+        String tableName,
+        Authorizations authorizations,
+        int numQueryThreads
+    ) throws TableNotFoundException {
+        ClientContext context = ConnectorUtils.getContext(connector);
+        String tableId = Tables.getTableId(connector.getInstance(), tableName);
+
+        checkArgument(context != null, "context is null");
+        checkArgument(tableId != null, "tableId is null");
+        checkArgument(authorizations != null, "authorizations is null");
+        this.context = context;
+        this.authorizations = authorizations;
+        this.tableId = tableId;
+        this.numThreads = numQueryThreads;
+        this.ranges = null;
+    }
+
+    @Override
+    public Authorizations getAuthorizations() {
+        return authorizations;
+    }
+
+    @Override
+    public void setRanges(Collection<Range> ranges) {
+        if (ranges == null || ranges.size() == 0) {
+            throw new IllegalArgumentException("ranges must be non null and contain at least 1 range");
+        }
+        this.ranges = new ArrayList<>(ranges);
+    }
+
+    @Override
+    public Iterator<Map.Entry<Key, Value>> iterator() {
+        if (ranges == null) {
+            throw new IllegalStateException("ranges not set");
+        }
+
+        return new TabletServerBatchReaderIterator(
+            context,
+            tableId,
+            authorizations,
+            ranges,
+            numThreads,
+            queryThreadPool,
+            this,
+            timeOut
+        );
+    }
+}

--- a/test/src/main/java/org/vertexium/test/GraphTestBase.java
+++ b/test/src/main/java/org/vertexium/test/GraphTestBase.java
@@ -8834,6 +8834,7 @@ public abstract class GraphTestBase {
         benchmarkAddVertices(vertexCount);
         benchmarkAddEdges(random, vertexCount, edgeCount);
         benchmarkFindVerticesById(random, vertexCount, findVerticesByIdCount);
+        benchmarkFindConnectedVertices();
     }
 
     @Test
@@ -9009,6 +9010,17 @@ public abstract class GraphTestBase {
         graph.flush();
         double endTime = System.currentTimeMillis();
         LOGGER.info("find vertices by id in %.3fs", (endTime - startTime) / 1000);
+    }
+
+    private void benchmarkFindConnectedVertices() {
+        double startTime = System.currentTimeMillis();
+        for (Vertex vertex : graph.getVertices(AUTHORIZATIONS_ALL)) {
+            for (Vertex connectedVertex : vertex.getVertices(Direction.BOTH, AUTHORIZATIONS_ALL)) {
+                connectedVertex.getId();
+            }
+        }
+        double endTime = System.currentTimeMillis();
+        LOGGER.info("find connected vertices in %.3fs", (endTime - startTime) / 1000);
     }
 
     private boolean benchmarkEnabled() {


### PR DESCRIPTION
Benchmark https://github.com/visallo/vertexium/compare/fast-batch-reader?expand=1#diff-7de8e1270d184f1d847439d3722b3a36R9015

Before change: 36.852s
After change: 24.665s

This change also alleviates the strict need to close the iterator.