### PR TITLE
Refactor ElementId to allow Elements to comply with the interface

### DIFF
--- a/accumulo/src/main/java/org/vertexium/accumulo/AccumuloEdge.java
+++ b/accumulo/src/main/java/org/vertexium/accumulo/AccumuloEdge.java
@@ -195,9 +195,4 @@ public class AccumuloEdge extends AccumuloElement implements Edge {
             }
         };
     }
-
-    @Override
-    public ElementType getElementType() {
-        return ElementType.EDGE;
-    }
 }

--- a/accumulo/src/main/java/org/vertexium/accumulo/AccumuloElement.java
+++ b/accumulo/src/main/java/org/vertexium/accumulo/AccumuloElement.java
@@ -197,7 +197,7 @@ public abstract class AccumuloElement extends ElementBase implements Serializabl
         Authorizations authorizations
     ) {
         return getGraph().getHistoricalEvents(
-            Lists.newArrayList(new ElementId(ElementType.getTypeFromElement(this), getId())),
+            Lists.newArrayList(this),
             after,
             fetchHints,
             authorizations

--- a/accumulo/src/main/java/org/vertexium/accumulo/AccumuloGraph.java
+++ b/accumulo/src/main/java/org/vertexium/accumulo/AccumuloGraph.java
@@ -1001,7 +1001,7 @@ public class AccumuloGraph extends GraphBaseWithSearchIndex implements Traceable
                 .collect(Collectors.groupingBy(ElementId::getElementType));
             return fetchHints.applyToResults(elementIdsByType.entrySet().stream()
                 .flatMap(entry -> {
-                    Set<String> ids = entry.getValue().stream().map(ElementId::getElementId).collect(Collectors.toSet());
+                    Set<String> ids = entry.getValue().stream().map(ElementId::getId).collect(Collectors.toSet());
                     return getHistoricalEvents(entry.getKey(), ids, after, fetchHints, authorizations);
                 }), after);
         } finally {

--- a/accumulo/src/main/java/org/vertexium/accumulo/AccumuloVertex.java
+++ b/accumulo/src/main/java/org/vertexium/accumulo/AccumuloVertex.java
@@ -618,9 +618,4 @@ public class AccumuloVertex extends AccumuloElement implements Vertex {
     private Iterable<EdgeVertexPair> getEdgeVertexPairs(Iterable<EdgeInfo> edgeInfos, FetchHints fetchHints, Long endTime, Authorizations authorizations) {
         return EdgeVertexPair.getEdgeVertexPairs(getGraph(), getId(), edgeInfos, fetchHints, endTime, authorizations);
     }
-
-    @Override
-    public ElementType getElementType() {
-        return ElementType.VERTEX;
-    }
 }

--- a/core/src/main/java/org/vertexium/DefaultElementId.java
+++ b/core/src/main/java/org/vertexium/DefaultElementId.java
@@ -1,0 +1,46 @@
+package org.vertexium;
+
+import java.util.Objects;
+
+public class DefaultElementId implements ElementId {
+    private final ElementType elementType;
+    private final String id;
+
+    public DefaultElementId(ElementType elementType, String id) {
+        this.elementType = elementType;
+        this.id = id;
+    }
+
+    @Override
+    public ElementType getElementType() {
+        return elementType;
+    }
+
+    @Override
+    public String getId() {
+        return id;
+    }
+
+    @Override
+    public boolean equals(Object o) {
+        if (this == o) {
+            return true;
+        }
+        if (o == null || getClass() != o.getClass()) {
+            return false;
+        }
+        DefaultElementId that = (DefaultElementId) o;
+        return elementType == that.elementType
+            && id.equals(that.id);
+    }
+
+    @Override
+    public int hashCode() {
+        return Objects.hash(elementType, id);
+    }
+
+    @Override
+    public String toString() {
+        return String.format("ElementId{elementType=%s, id='%s'}", elementType, id);
+    }
+}

--- a/core/src/main/java/org/vertexium/DefaultElementLocation.java
+++ b/core/src/main/java/org/vertexium/DefaultElementLocation.java
@@ -1,24 +1,11 @@
 package org.vertexium;
 
-abstract class DefaultElementLocation implements ElementLocation {
-    private final ElementType elementType;
-    private final String id;
+abstract class DefaultElementLocation extends DefaultElementId implements ElementLocation {
     private final Visibility visibility;
 
     protected DefaultElementLocation(ElementType elementType, String id, Visibility visibility) {
-        this.elementType = elementType;
-        this.id = id;
+        super(elementType, id);
         this.visibility = visibility;
-    }
-
-    @Override
-    public ElementType getElementType() {
-        return elementType;
-    }
-
-    @Override
-    public String getId() {
-        return id;
     }
 
     @Override

--- a/core/src/main/java/org/vertexium/Edge.java
+++ b/core/src/main/java/org/vertexium/Edge.java
@@ -112,4 +112,9 @@ public interface Edge extends Element, EdgeElementLocation {
      * @return The mutation builder.
      */
     ExistingEdgeMutation prepareMutation();
+
+    @Override
+    default ElementType getElementType() {
+        return ElementType.EDGE;
+    }
 }

--- a/core/src/main/java/org/vertexium/EdgeInfoEdge.java
+++ b/core/src/main/java/org/vertexium/EdgeInfoEdge.java
@@ -30,11 +30,6 @@ public class EdgeInfoEdge extends ElementBase implements Edge {
     }
 
     @Override
-    public ElementType getElementType() {
-        return ElementType.EDGE;
-    }
-
-    @Override
     public String getLabel() {
         return edgeInfo.getLabel();
     }

--- a/core/src/main/java/org/vertexium/Element.java
+++ b/core/src/main/java/org/vertexium/Element.java
@@ -23,11 +23,6 @@ public interface Element extends VertexiumObject, ElementLocation {
     String ID_PROPERTY_NAME = "__ID__";
 
     /**
-     * id of the element.
-     */
-    String getId();
-
-    /**
      * the visibility of the element.
      */
     Visibility getVisibility();

--- a/core/src/main/java/org/vertexium/ElementId.java
+++ b/core/src/main/java/org/vertexium/ElementId.java
@@ -1,32 +1,25 @@
 package org.vertexium;
 
-public class ElementId {
-    private final ElementType elementType;
-    private final String elementId;
-
-    public ElementId(ElementType elementType, String elementId) {
-        this.elementType = elementType;
-        this.elementId = elementId;
+public interface ElementId {
+    static ElementId vertex(String id) {
+        return new DefaultElementId(ElementType.VERTEX, id);
     }
 
-    public static ElementId vertex(String id) {
-        return new ElementId(ElementType.VERTEX, id);
+    static ElementId edge(String id) {
+        return new DefaultElementId(ElementType.EDGE, id);
     }
 
-    public static ElementId edge(String id) {
-        return new ElementId(ElementType.EDGE, id);
+    static ElementId create(ElementType elementType, String id) {
+        return new DefaultElementId(elementType, id);
     }
 
-    public ElementType getElementType() {
-        return elementType;
-    }
+    /**
+     * the type of the element.
+     */
+    ElementType getElementType();
 
-    public String getElementId() {
-        return elementId;
-    }
-
-    @Override
-    public String toString() {
-        return String.format("ElementId{elementType=%s, elementId='%s'}", elementType, elementId);
-    }
+    /**
+     * id of the element.
+     */
+    String getId();
 }

--- a/core/src/main/java/org/vertexium/ElementLocation.java
+++ b/core/src/main/java/org/vertexium/ElementLocation.java
@@ -1,10 +1,9 @@
 package org.vertexium;
 
-public interface ElementLocation {
-    ElementType getElementType();
-
-    String getId();
-
+public interface ElementLocation extends ElementId {
+    /**
+     * the visibility of the element.
+     */
     Visibility getVisibility();
 
     static EdgeElementLocation edge(

--- a/core/src/main/java/org/vertexium/Graph.java
+++ b/core/src/main/java/org/vertexium/Graph.java
@@ -116,9 +116,9 @@ public interface Graph {
     default Element getElement(ElementId elementId, FetchHints fetchHints, Authorizations authorizations) {
         switch (elementId.getElementType()) {
             case VERTEX:
-                return getVertex(elementId.getElementId(), fetchHints, authorizations);
+                return getVertex(elementId.getId(), fetchHints, authorizations);
             case EDGE:
-                return getEdge(elementId.getElementId(), fetchHints, authorizations);
+                return getEdge(elementId.getId(), fetchHints, authorizations);
             default:
                 throw new VertexiumException("Unhandled element type: " + elementId.getElementType());
         }

--- a/core/src/main/java/org/vertexium/Vertex.java
+++ b/core/src/main/java/org/vertexium/Vertex.java
@@ -463,4 +463,9 @@ public interface Vertex extends Element {
      * @return An Iterable of edge/vertex pairs.
      */
     Iterable<EdgeVertexPair> getEdgeVertexPairs(Direction direction, String[] labels, FetchHints fetchHints, Authorizations authorizations);
+
+    @Override
+    default ElementType getElementType() {
+        return ElementType.VERTEX;
+    }
 }

--- a/elasticsearch5/src/main/java/org/vertexium/elasticsearch5/ElasticsearchEdge.java
+++ b/elasticsearch5/src/main/java/org/vertexium/elasticsearch5/ElasticsearchEdge.java
@@ -80,9 +80,4 @@ public class ElasticsearchEdge extends ElasticsearchElement implements Edge {
     public ExistingEdgeMutation prepareMutation() {
         throw new VertexiumNotSupportedException("prepareMutation is not supported");
     }
-
-    @Override
-    public ElementType getElementType() {
-        return ElementType.EDGE;
-    }
 }

--- a/elasticsearch5/src/main/java/org/vertexium/elasticsearch5/ElasticsearchVertex.java
+++ b/elasticsearch5/src/main/java/org/vertexium/elasticsearch5/ElasticsearchVertex.java
@@ -240,9 +240,4 @@ public class ElasticsearchVertex extends ElasticsearchElement implements Vertex 
     public Iterable<EdgeVertexPair> getEdgeVertexPairs(Direction direction, String[] labels, FetchHints fetchHints, Authorizations authorizations) {
         throw new VertexiumNotSupportedException("getEdgeVertexPairs is not supported on " + className);
     }
-
-    @Override
-    public ElementType getElementType() {
-        return ElementType.VERTEX;
-    }
 }

--- a/inmemory/src/main/java/org/vertexium/inmemory/InMemoryEdge.java
+++ b/inmemory/src/main/java/org/vertexium/inmemory/InMemoryEdge.java
@@ -22,11 +22,6 @@ public class InMemoryEdge extends InMemoryElement<InMemoryEdge> implements Edge 
     }
 
     @Override
-    public ElementType getElementType() {
-        return ElementType.EDGE;
-    }
-
-    @Override
     public String getLabel() {
         return getInMemoryTableElement().findLastMutation(AlterEdgeLabelMutation.class).getNewEdgeLabel();
     }

--- a/inmemory/src/main/java/org/vertexium/inmemory/InMemoryVertex.java
+++ b/inmemory/src/main/java/org/vertexium/inmemory/InMemoryVertex.java
@@ -32,11 +32,6 @@ public class InMemoryVertex extends InMemoryElement<InMemoryVertex> implements V
     }
 
     @Override
-    public ElementType getElementType() {
-        return ElementType.VERTEX;
-    }
-
-    @Override
     public Iterable<Edge> getEdges(Direction direction, Authorizations authorizations) {
         return getEdges(direction, getGraph().getDefaultFetchHints(), authorizations);
     }

--- a/test/src/main/java/org/vertexium/test/GraphTestBase.java
+++ b/test/src/main/java/org/vertexium/test/GraphTestBase.java
@@ -5748,7 +5748,6 @@ public abstract class GraphTestBase {
             .save(AUTHORIZATIONS_A_AND_B);
         graph.flush();
 
-        IncreasingTime.advanceTime(1);
         long beforeAlterTimestamp = IncreasingTime.currentTimeMillis();
 
         Vertex v1 = graph.getVertex("v1", FetchHints.ALL, AUTHORIZATIONS_A);


### PR DESCRIPTION
This allows methods to take an `ElementId` as a parameter and you could just pass the `Element` itself.

FYI makes some of my merge code easier