### PR TITLE
bump version to 4.6.1-SNAPSHOT

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -11,4 +11,4 @@ env:
 branches:
   only:
     - master
-    - 2.5.x
+    - 4.6.x

--- a/accumulo-iterators/pom.xml
+++ b/accumulo-iterators/pom.xml
@@ -3,7 +3,7 @@
     <parent>
         <artifactId>vertexium-root</artifactId>
         <groupId>org.vertexium</groupId>
-        <version>4.6.0</version>
+        <version>4.6.1-SNAPSHOT</version>
     </parent>
     <modelVersion>4.0.0</modelVersion>
 

--- a/accumulo-migrations/pom.xml
+++ b/accumulo-migrations/pom.xml
@@ -3,7 +3,7 @@
     <parent>
         <artifactId>vertexium-root</artifactId>
         <groupId>org.vertexium</groupId>
-        <version>4.6.0</version>
+        <version>4.6.1-SNAPSHOT</version>
     </parent>
     <modelVersion>4.0.0</modelVersion>
 

--- a/accumulo/pom.xml
+++ b/accumulo/pom.xml
@@ -3,7 +3,7 @@
     <parent>
         <artifactId>vertexium-root</artifactId>
         <groupId>org.vertexium</groupId>
-        <version>4.6.0</version>
+        <version>4.6.1-SNAPSHOT</version>
     </parent>
     <modelVersion>4.0.0</modelVersion>
 

--- a/cli/pom.xml
+++ b/cli/pom.xml
@@ -3,7 +3,7 @@
     <parent>
         <artifactId>vertexium-root</artifactId>
         <groupId>org.vertexium</groupId>
-        <version>4.6.0</version>
+        <version>4.6.1-SNAPSHOT</version>
     </parent>
     <modelVersion>4.0.0</modelVersion>
 

--- a/core/pom.xml
+++ b/core/pom.xml
@@ -3,7 +3,7 @@
     <parent>
         <artifactId>vertexium-root</artifactId>
         <groupId>org.vertexium</groupId>
-        <version>4.6.0</version>
+        <version>4.6.1-SNAPSHOT</version>
     </parent>
     <modelVersion>4.0.0</modelVersion>
 

--- a/cypher/pom.xml
+++ b/cypher/pom.xml
@@ -3,7 +3,7 @@
     <parent>
         <artifactId>vertexium-root</artifactId>
         <groupId>org.vertexium</groupId>
-        <version>4.6.0</version>
+        <version>4.6.1-SNAPSHOT</version>
     </parent>
     <modelVersion>4.0.0</modelVersion>
 

--- a/elasticsearch5-plugin/pom.xml
+++ b/elasticsearch5-plugin/pom.xml
@@ -3,7 +3,7 @@
     <parent>
         <artifactId>vertexium-root</artifactId>
         <groupId>org.vertexium</groupId>
-        <version>4.6.0</version>
+        <version>4.6.1-SNAPSHOT</version>
     </parent>
     <modelVersion>4.0.0</modelVersion>
 

--- a/elasticsearch5/pom.xml
+++ b/elasticsearch5/pom.xml
@@ -3,7 +3,7 @@
     <parent>
         <artifactId>vertexium-root</artifactId>
         <groupId>org.vertexium</groupId>
-        <version>4.6.0</version>
+        <version>4.6.1-SNAPSHOT</version>
     </parent>
     <modelVersion>4.0.0</modelVersion>
 

--- a/inmemory/pom.xml
+++ b/inmemory/pom.xml
@@ -3,7 +3,7 @@
     <parent>
         <artifactId>vertexium-root</artifactId>
         <groupId>org.vertexium</groupId>
-        <version>4.6.0</version>
+        <version>4.6.1-SNAPSHOT</version>
     </parent>
     <modelVersion>4.0.0</modelVersion>
 

--- a/kryo-serializer/pom.xml
+++ b/kryo-serializer/pom.xml
@@ -3,7 +3,7 @@
     <parent>
         <artifactId>vertexium-root</artifactId>
         <groupId>org.vertexium</groupId>
-        <version>4.6.0</version>
+        <version>4.6.1-SNAPSHOT</version>
     </parent>
     <modelVersion>4.0.0</modelVersion>
 

--- a/multimodule-test/accumulo-elasticsearch5/pom.xml
+++ b/multimodule-test/accumulo-elasticsearch5/pom.xml
@@ -6,7 +6,7 @@
     <parent>
         <groupId>org.vertexium</groupId>
         <artifactId>vertexium-multimodule-test</artifactId>
-        <version>4.5.3-SNAPSHOT</version>
+        <version>4.6.1-SNAPSHOT</version>
     </parent>
 
     <artifactId>vertexium-accumulo-elasticsearch5-multimodule-test</artifactId>

--- a/multimodule-test/pom.xml
+++ b/multimodule-test/pom.xml
@@ -6,7 +6,7 @@
     <parent>
         <groupId>org.vertexium</groupId>
         <artifactId>vertexium-root</artifactId>
-        <version>4.5.3-SNAPSHOT</version>
+        <version>4.6.1-SNAPSHOT</version>
     </parent>
 
     <artifactId>vertexium-multimodule-test</artifactId>

--- a/pom.xml
+++ b/pom.xml
@@ -11,7 +11,7 @@
     <groupId>org.vertexium</groupId>
     <artifactId>vertexium-root</artifactId>
     <packaging>pom</packaging>
-    <version>4.6.0</version>
+    <version>4.6.1-SNAPSHOT</version>
     <name>Vertexium</name>
     <description>
         Vertexium is an API to manipulate graphs. Every Vertexium method requires authorizations
@@ -35,7 +35,7 @@
         <url>scm:git:git@github.com:visallo/vertexium.git</url>
         <connection>scm:git:git@github.com:visallo/vertexium.git</connection>
         <developerConnection>scm:git:git@github.com:visallo/vertexium.git</developerConnection>
-        <tag>vertexium-root-4.6.0</tag>
+        <tag>vertexium-root-4.6.1-SNAPSHOT</tag>
     </scm>
 
     <issueManagement>

--- a/security/pom.xml
+++ b/security/pom.xml
@@ -3,7 +3,7 @@
     <parent>
         <artifactId>vertexium-root</artifactId>
         <groupId>org.vertexium</groupId>
-        <version>4.6.0</version>
+        <version>4.6.1-SNAPSHOT</version>
     </parent>
     <modelVersion>4.0.0</modelVersion>
 

--- a/test/pom.xml
+++ b/test/pom.xml
@@ -3,7 +3,7 @@
     <parent>
         <artifactId>vertexium-root</artifactId>
         <groupId>org.vertexium</groupId>
-        <version>4.6.0</version>
+        <version>4.6.1-SNAPSHOT</version>
     </parent>
     <modelVersion>4.0.0</modelVersion>
 

--- a/xstream-serializer/pom.xml
+++ b/xstream-serializer/pom.xml
@@ -3,7 +3,7 @@
     <parent>
         <artifactId>vertexium-root</artifactId>
         <groupId>org.vertexium</groupId>
-        <version>4.6.0</version>
+        <version>4.6.1-SNAPSHOT</version>
     </parent>
     <modelVersion>4.0.0</modelVersion>
 


### PR DESCRIPTION
Can't release 4.6.1 due to this maven error:
```
[ERROR] Failed to execute goal org.apache.maven.plugins:maven-release-plugin:2.5.3:prepare (default-cli) on project vertexium-root: You don't have a SNAPSHOT project in the reactor projects list. -> [Help 1]
[ERROR]
[ERROR] To see the full stack trace of the errors, re-run Maven with the -e switch.
[ERROR] Re-run Maven using the -X switch to enable full debug logging.
[ERROR]
[ERROR] For more information about the errors and possible solutions, please read the following articles:
[ERROR] [Help 1] http://cwiki.apache.org/confluence/display/MAVEN/MojoFailureException
```

Bumped the pom version to `4.6.1-SNAPSHOT` and created PR to wait for travis to pass.