### PR TITLE
Only wait for items added before flush was called to be flushed

### DIFF
--- a/elasticsearch5/search-index/src/main/java/org/vertexium/elasticsearch5/LoadAndAddDocumentMissingHelper.java
+++ b/elasticsearch5/search-index/src/main/java/org/vertexium/elasticsearch5/LoadAndAddDocumentMissingHelper.java
@@ -3,16 +3,21 @@ package org.vertexium.elasticsearch5;
 import org.vertexium.*;
 import org.vertexium.elasticsearch5.bulk.BulkItem;
 import org.vertexium.elasticsearch5.bulk.UpdateBulkItem;
+import org.vertexium.util.VertexiumLogger;
+import org.vertexium.util.VertexiumLoggerFactory;
 
 import java.util.Collections;
 
 public class LoadAndAddDocumentMissingHelper implements Elasticsearch5ExceptionHandler {
+    private static final VertexiumLogger LOGGER = VertexiumLoggerFactory.getLogger(LoadAndAddDocumentMissingHelper.class);
+
     public static void handleDocumentMissingException(
         Graph graph,
         Elasticsearch5SearchIndex elasticsearch5SearchIndex,
         BulkItem bulkItem,
         Authorizations authorizations
     ) {
+        LOGGER.info("handleDocumentMissingException (bulkItem: %s)", bulkItem);
         if (bulkItem instanceof UpdateBulkItem) {
             UpdateBulkItem updateBulkItem = (UpdateBulkItem) bulkItem;
             if (updateBulkItem.getExtendedDataRowId() != null) {

--- a/elasticsearch5/search-index/src/main/java/org/vertexium/elasticsearch5/bulk/BulkItem.java
+++ b/elasticsearch5/search-index/src/main/java/org/vertexium/elasticsearch5/bulk/BulkItem.java
@@ -9,6 +9,7 @@ public class BulkItem {
     private final ElementId elementId;
     private final int size;
     private final ActionRequest actionRequest;
+    private final long createdTime;
     private long createdOrLastTriedTime;
     private int failCount;
 
@@ -21,7 +22,7 @@ public class BulkItem {
         this.elementId = elementId;
         this.size = ElasticsearchRequestUtils.getSize(actionRequest);
         this.actionRequest = actionRequest;
-        this.createdOrLastTriedTime = System.currentTimeMillis();
+        this.createdOrLastTriedTime = this.createdTime = System.currentTimeMillis();
     }
 
     public String getIndexName() {
@@ -38,6 +39,10 @@ public class BulkItem {
 
     public ActionRequest getActionRequest() {
         return actionRequest;
+    }
+
+    public long getCreatedTime() {
+        return createdTime;
     }
 
     public long getCreatedOrLastTriedTime() {

--- a/elasticsearch5/search-index/src/main/java/org/vertexium/elasticsearch5/bulk/BulkItemFailure.java
+++ b/elasticsearch5/search-index/src/main/java/org/vertexium/elasticsearch5/bulk/BulkItemFailure.java
@@ -1,0 +1,21 @@
+package org.vertexium.elasticsearch5.bulk;
+
+import org.elasticsearch.action.bulk.BulkItemResponse;
+
+public class BulkItemFailure {
+    private final BulkItem bulkItem;
+    private final BulkItemResponse bulkItemResponse;
+
+    public BulkItemFailure(BulkItem bulkItem, BulkItemResponse bulkItemResponse) {
+        this.bulkItem = bulkItem;
+        this.bulkItemResponse = bulkItemResponse;
+    }
+
+    public BulkItem getBulkItem() {
+        return bulkItem;
+    }
+
+    public BulkItemResponse getBulkItemResponse() {
+        return bulkItemResponse;
+    }
+}

--- a/elasticsearch5/search-index/src/main/java/org/vertexium/elasticsearch5/bulk/BulkItemList.java
+++ b/elasticsearch5/search-index/src/main/java/org/vertexium/elasticsearch5/bulk/BulkItemList.java
@@ -75,7 +75,9 @@ public class BulkItemList {
         });
     }
 
-    public int size() {
-        return lock.executeInReadLock(items::size);
+    public long size(long beforeTime) {
+        return lock.executeInReadLock(() -> items.stream()
+            .filter(item -> item.getCreatedTime() <= beforeTime)
+            .count());
     }
 }

--- a/elasticsearch5/search-index/src/main/java/org/vertexium/elasticsearch5/bulk/FailureList.java
+++ b/elasticsearch5/search-index/src/main/java/org/vertexium/elasticsearch5/bulk/FailureList.java
@@ -1,0 +1,25 @@
+package org.vertexium.elasticsearch5.bulk;
+
+import java.util.concurrent.ConcurrentLinkedQueue;
+
+public class FailureList {
+    private final ConcurrentLinkedQueue<BulkItemFailure> failures = new ConcurrentLinkedQueue<>();
+
+    public void add(BulkItemFailure failure) {
+        failures.add(failure);
+    }
+
+    public void remove(BulkItemFailure failure) {
+        failures.remove(failure);
+    }
+
+    public BulkItemFailure peek() {
+        return failures.peek();
+    }
+
+    public long size(long beforeTime) {
+        return failures.stream()
+            .filter(failure -> failure.getBulkItem().getCreatedTime() <= beforeTime)
+            .count();
+    }
+}

--- a/elasticsearch5/search-index/src/main/java/org/vertexium/elasticsearch5/bulk/PendingFuturesList.java
+++ b/elasticsearch5/search-index/src/main/java/org/vertexium/elasticsearch5/bulk/PendingFuturesList.java
@@ -1,0 +1,69 @@
+package org.vertexium.elasticsearch5.bulk;
+
+import org.vertexium.VertexiumException;
+
+import java.util.List;
+import java.util.Objects;
+import java.util.concurrent.CompletableFuture;
+import java.util.concurrent.ConcurrentLinkedQueue;
+
+public class PendingFuturesList {
+    private final ConcurrentLinkedQueue<Item> pendingFutures = new ConcurrentLinkedQueue<>();
+
+    public void remove(CompletableFuture<FlushBatchResult> future) {
+        pendingFutures.remove(new Item(null, future));
+    }
+
+    public void add(List<BulkItem> batch, CompletableFuture<FlushBatchResult> future) {
+        pendingFutures.add(new Item(batch, future));
+    }
+
+    public CompletableFuture<FlushBatchResult> peek() {
+        Item result = pendingFutures.peek();
+        if (result == null) {
+            return null;
+        }
+        return result.future;
+    }
+
+    public long size(long beforeTime) {
+        return pendingFutures.stream()
+            .filter(item -> item.isBeforeTime(beforeTime))
+            .count();
+    }
+
+    private static class Item {
+        public final List<BulkItem> batch;
+        public final CompletableFuture<FlushBatchResult> future;
+
+        public Item(List<BulkItem> batch, CompletableFuture<FlushBatchResult> future) {
+            if (future == null) {
+                throw new VertexiumException("future cannot be null");
+            }
+            this.batch = batch;
+            this.future = future;
+        }
+
+        @Override
+        public boolean equals(Object o) {
+            if (this == o) {
+                return true;
+            }
+            if (o == null || getClass() != o.getClass()) {
+                return false;
+            }
+            Item item = (Item) o;
+            return Objects.equals(future, item.future);
+        }
+
+        @Override
+        public int hashCode() {
+            return Objects.hash(future);
+        }
+
+        public boolean isBeforeTime(long beforeTime) {
+            return batch.stream()
+                .anyMatch(item -> item.getCreatedTime() <= beforeTime);
+        }
+    }
+}

--- a/elasticsearch5/search-index/src/test/java/org/vertexium/elasticsearch5/TestElasticsearch5ExceptionHandler.java
+++ b/elasticsearch5/search-index/src/test/java/org/vertexium/elasticsearch5/TestElasticsearch5ExceptionHandler.java
@@ -22,7 +22,7 @@ public class TestElasticsearch5ExceptionHandler implements Elasticsearch5Excepti
         BulkItemResponse bulkItemResponse,
         AtomicBoolean retry
     ) {
-        LOGGER.warn("bulk failure on item %s: %s", bulkItem, bulkItemResponse);
+        LOGGER.warn("bulk failure on item %s: %s", bulkItem, bulkItemResponse == null ? null : bulkItemResponse.getFailure());
         if (bulkItemResponse.getFailure().getStatus() == RestStatus.NOT_FOUND) {
             LoadAndAddDocumentMissingHelper.handleDocumentMissingException(graph, elasticsearch5SearchIndex, bulkItem, authorizations);
         } else {


### PR DESCRIPTION
Before this, one thread could cause another thread to wait indefinitly as
long as new writes are coming in.