### PR TITLE
rewrite how the BulkUpdateQueue waits for futures to prevent dead locks, excess waiting, etc

### DIFF
--- a/elasticsearch5/search-index/src/main/java/org/vertexium/elasticsearch5/bulk/BulkUpdateService.java
+++ b/elasticsearch5/search-index/src/main/java/org/vertexium/elasticsearch5/bulk/BulkUpdateService.java
@@ -92,8 +92,7 @@ public class BulkUpdateService {
         bulkUpdateQueue.add(new DeleteBulkItem(elementId, docId, deleteRequest));
     }
 
-    CompletableFuture<FlushBatchResult> submitBatch(List<BulkItem> batch) {
-        CompletableFuture<FlushBatchResult> future = new CompletableFuture<>();
+    CompletableFuture<FlushBatchResult> submitBatch(CompletableFuture<FlushBatchResult> future, List<BulkItem> batch) {
         this.threadPool.submit(() -> {
             try {
                 BulkRequest bulkRequest = flushObjectToBulkRequest(batch);

--- a/elasticsearch5/search-index/src/main/java/org/vertexium/elasticsearch5/bulk/PendingFuturesList.java
+++ b/elasticsearch5/search-index/src/main/java/org/vertexium/elasticsearch5/bulk/PendingFuturesList.java
@@ -12,10 +12,16 @@ public class PendingFuturesList {
 
     public void remove(CompletableFuture<FlushBatchResult> future) {
         pendingFutures.remove(new Item(null, future));
+        synchronized (this) {
+            notifyAll();
+        }
     }
 
     public void add(List<BulkItem> batch, CompletableFuture<FlushBatchResult> future) {
         pendingFutures.add(new Item(batch, future));
+        synchronized (this) {
+            notifyAll();
+        }
     }
 
     public CompletableFuture<FlushBatchResult> peek() {


### PR DESCRIPTION
I ran into a problem using the new bulk update where it was either dead locking or running into timing issues. Hopefully this simplifies things and solves the issue.