### PR TITLE
Deprecated: the following methods have been deprecated in favor of methods on mutations.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,13 @@
 * Fixed: Soft delete with event data cannot be un-soft deleted
 * Changed: Elasticsearch to use bulk updates
 * Changed: EdgeVertexPairs can now have null vertex ids if user can see the edge but not the vertex
+* Deprecated: the following methods have been deprecated in favor of methods on mutations.
+  - Graph.addVertex
+  - Graph.addEdge
+  - Element.deleteProperty
+  - Element.setProperty
+  - Element.markPropertyHidden
+  - Element.markPropertyVisible
 
 # v4.7.1
 * Added: Compare.RANGE to query

--- a/accumulo-migrations/src/main/java/org/vertexium/accumulo/migrations/MRMigrationBase.java
+++ b/accumulo-migrations/src/main/java/org/vertexium/accumulo/migrations/MRMigrationBase.java
@@ -20,6 +20,7 @@ import org.vertexium.util.VertexiumLoggerFactory;
 
 import java.io.IOException;
 
+@Deprecated
 public abstract class MRMigrationBase extends Configured implements Tool {
     private static final VertexiumLogger LOGGER = VertexiumLoggerFactory.getLogger(MRMigrationBase.class);
 
@@ -108,6 +109,7 @@ public abstract class MRMigrationBase extends Configured implements Tool {
     }
 
     @Override
+    @SuppressWarnings("unchecked")
     public int run(String[] args) throws Exception {
         Opts opts = createOpts();
         opts.parseArgs(getClass().getName(), args);

--- a/accumulo/src/main/java/org/vertexium/accumulo/AccumuloEdge.java
+++ b/accumulo/src/main/java/org/vertexium/accumulo/AccumuloEdge.java
@@ -20,6 +20,7 @@ import java.io.DataInputStream;
 import java.io.IOException;
 import java.util.List;
 
+@SuppressWarnings("unchecked")
 public class AccumuloEdge extends AccumuloElement implements Edge {
     public static final Text CF_SIGNAL = EdgeIterator.CF_SIGNAL;
     public static final Text CF_OUT_VERTEX = EdgeIterator.CF_OUT_VERTEX;
@@ -185,7 +186,6 @@ public class AccumuloEdge extends AccumuloElement implements Edge {
     }
 
     @Override
-    @SuppressWarnings("unchecked")
     public ExistingEdgeMutation prepareMutation() {
         return new ExistingEdgeMutation(this) {
             @Override

--- a/accumulo/src/main/java/org/vertexium/accumulo/AccumuloGraphLogger.java
+++ b/accumulo/src/main/java/org/vertexium/accumulo/AccumuloGraphLogger.java
@@ -21,6 +21,7 @@ public class AccumuloGraphLogger {
         this.queryLogger = queryLogger;
     }
 
+    @SuppressWarnings("unchecked")
     public void logStartIterator(String table, ScannerBase scanner) {
         if (!queryLogger.isTraceEnabled()) {
             return;

--- a/accumulo/src/main/java/org/vertexium/accumulo/AccumuloVertex.java
+++ b/accumulo/src/main/java/org/vertexium/accumulo/AccumuloVertex.java
@@ -27,6 +27,7 @@ import java.io.IOException;
 import java.util.*;
 import java.util.stream.Collectors;
 
+@SuppressWarnings("unchecked")
 public class AccumuloVertex extends AccumuloElement implements Vertex {
     public static final Text CF_SIGNAL = VertexIterator.CF_SIGNAL;
     public static final Text CF_OUT_EDGE = VertexIterator.CF_OUT_EDGE;
@@ -368,7 +369,10 @@ public class AccumuloVertex extends AccumuloElement implements Vertex {
                 }
                 throw new VertexiumException("Cannot get edge info");
             case BOTH:
-                return new JoinIterable<>(getEdgeInfos(Direction.IN), getEdgeInfos(Direction.OUT));
+                return new JoinIterable<Map.Entry<Text, org.vertexium.accumulo.iterator.model.EdgeInfo>>(
+                    getEdgeInfos(Direction.IN),
+                    getEdgeInfos(Direction.OUT)
+                );
             default:
                 throw new VertexiumException("Unexpected direction: " + direction);
         }
@@ -396,7 +400,7 @@ public class AccumuloVertex extends AccumuloElement implements Vertex {
             case OUT:
                 return filterEdgeInfosByLabel(accumuloEdgeInfosToEdgeInfos(getEdgeInfos(direction), Direction.OUT), labels);
             case BOTH:
-                return new JoinIterable<>(getEdgeInfos(Direction.IN, labels, authorizations), getEdgeInfos(Direction.OUT, labels, authorizations));
+                return new JoinIterable<EdgeInfo>(getEdgeInfos(Direction.IN, labels, authorizations), getEdgeInfos(Direction.OUT, labels, authorizations));
             default:
                 throw new VertexiumException("Unexpected direction: " + direction);
         }
@@ -506,7 +510,7 @@ public class AccumuloVertex extends AccumuloElement implements Vertex {
             case BOTH:
                 Iterable<String> inVertexIds = getVertexIds(Direction.IN, labels, authorizations);
                 Iterable<String> outVertexIds = getVertexIds(Direction.OUT, labels, authorizations);
-                return new JoinIterable<>(inVertexIds, outVertexIds);
+                return new JoinIterable<String>(inVertexIds, outVertexIds);
             case IN:
                 if (this.inEdges instanceof EdgesWithEdgeInfo) {
                     return new GetVertexIdsIterable(((EdgesWithEdgeInfo) this.inEdges).getEdgeInfos(), labels);
@@ -565,7 +569,6 @@ public class AccumuloVertex extends AccumuloElement implements Vertex {
     }
 
     @Override
-    @SuppressWarnings("unchecked")
     public ExistingElementMutation<Vertex> prepareMutation() {
         return new ExistingElementMutationImpl<Vertex>(this) {
             @Override

--- a/accumulo/src/main/java/org/vertexium/accumulo/LazyMutableProperty.java
+++ b/accumulo/src/main/java/org/vertexium/accumulo/LazyMutableProperty.java
@@ -106,6 +106,7 @@ public class LazyMutableProperty extends MutableProperty {
     }
 
     @Override
+    @SuppressWarnings("unchecked")
     public Object getValue() {
         if (cachedPropertyValue == null) {
             if (propertyValue == null || propertyValue.length == 0) {
@@ -113,7 +114,6 @@ public class LazyMutableProperty extends MutableProperty {
             }
             cachedPropertyValue = this.vertexiumSerializer.bytesToObject(propertyValue);
             if (cachedPropertyValue instanceof StreamingPropertyValueRef) {
-                //noinspection unchecked
                 cachedPropertyValue = ((StreamingPropertyValueRef) cachedPropertyValue).toStreamingPropertyValue(this.graph, getTimestamp());
             }
         }

--- a/accumulo/src/main/java/org/vertexium/accumulo/mapreduce/AccumuloEdgeInputFormat.java
+++ b/accumulo/src/main/java/org/vertexium/accumulo/mapreduce/AccumuloEdgeInputFormat.java
@@ -22,6 +22,7 @@ import javax.annotation.Nullable;
 import java.util.Map;
 import java.util.stream.Collectors;
 
+@Deprecated
 public class AccumuloEdgeInputFormat extends AccumuloElementInputFormatBase<Edge> {
     private static EdgeIterator edgeIterator;
 

--- a/accumulo/src/main/java/org/vertexium/accumulo/mapreduce/AccumuloElementInputFormatBase.java
+++ b/accumulo/src/main/java/org/vertexium/accumulo/mapreduce/AccumuloElementInputFormatBase.java
@@ -28,6 +28,7 @@ import javax.annotation.Nullable;
 import java.io.IOException;
 import java.util.*;
 
+@Deprecated
 public abstract class AccumuloElementInputFormatBase<TValue extends Element> extends InputFormat<Text, TValue> {
     private final AccumuloRowInputFormat accumuloInputFormat;
 
@@ -68,6 +69,7 @@ public abstract class AccumuloElementInputFormatBase<TValue extends Element> ext
             public Authorizations authorizations;
 
             @Override
+            @SuppressWarnings("unchecked")
             public void initialize(InputSplit inputSplit, TaskAttemptContext ctx) throws IOException, InterruptedException {
                 reader.initialize(inputSplit, ctx);
 

--- a/accumulo/src/main/java/org/vertexium/accumulo/mapreduce/AccumuloElementOutputFormat.java
+++ b/accumulo/src/main/java/org/vertexium/accumulo/mapreduce/AccumuloElementOutputFormat.java
@@ -10,6 +10,7 @@ import org.apache.hadoop.mapreduce.*;
 
 import java.io.IOException;
 
+@Deprecated
 public class AccumuloElementOutputFormat extends OutputFormat<Text, Mutation> {
     private AccumuloOutputFormat accumuloOutputFormat = new AccumuloOutputFormat();
 

--- a/accumulo/src/main/java/org/vertexium/accumulo/mapreduce/AccumuloMutationElementMapper.java
+++ b/accumulo/src/main/java/org/vertexium/accumulo/mapreduce/AccumuloMutationElementMapper.java
@@ -5,6 +5,7 @@ import org.apache.hadoop.io.Text;
 
 import java.io.IOException;
 
+@Deprecated
 public abstract class AccumuloMutationElementMapper<KEYIN, VALUEIN> extends ElementMapper<KEYIN, VALUEIN, Text, Mutation> {
     @Override
     protected void saveDataMutation(Context context, Text dataTableName, Mutation m) throws IOException, InterruptedException {

--- a/accumulo/src/main/java/org/vertexium/accumulo/mapreduce/AccumuloVertexInputFormat.java
+++ b/accumulo/src/main/java/org/vertexium/accumulo/mapreduce/AccumuloVertexInputFormat.java
@@ -23,6 +23,7 @@ import java.util.Iterator;
 import java.util.Map;
 import java.util.stream.Collectors;
 
+@Deprecated
 public class AccumuloVertexInputFormat extends AccumuloElementInputFormatBase<Vertex> {
     private static VertexIterator vertexIterator;
 

--- a/accumulo/src/main/java/org/vertexium/accumulo/mapreduce/ElementMapper.java
+++ b/accumulo/src/main/java/org/vertexium/accumulo/mapreduce/ElementMapper.java
@@ -12,6 +12,7 @@ import org.vertexium.util.IncreasingTime;
 
 import java.io.IOException;
 
+@Deprecated
 public abstract class ElementMapper<KEYIN, VALUEIN, KEYOUT, VALUEOUT> extends Mapper<KEYIN, VALUEIN, KEYOUT, VALUEOUT> {
     public static final String GRAPH_CONFIG_PREFIX = "graphConfigPrefix";
     private ElementMutationBuilder elementMutationBuilder;

--- a/accumulo/src/main/java/org/vertexium/accumulo/mapreduce/ElementMapperGraph.java
+++ b/accumulo/src/main/java/org/vertexium/accumulo/mapreduce/ElementMapperGraph.java
@@ -7,6 +7,7 @@ import org.vertexium.metric.NullMetricRegistry;
 import org.vertexium.query.GraphQuery;
 import org.vertexium.query.MultiVertexQuery;
 
+@Deprecated
 public class ElementMapperGraph extends GraphBase {
     private static final boolean STRICT_TYPING = false;
     private ElementMapper elementMapper;

--- a/accumulo/src/main/java/org/vertexium/accumulo/mapreduce/VertexiumMRUtils.java
+++ b/accumulo/src/main/java/org/vertexium/accumulo/mapreduce/VertexiumMRUtils.java
@@ -5,9 +5,11 @@ import org.apache.hadoop.conf.Configuration;
 import java.util.HashMap;
 import java.util.Map;
 
+@Deprecated
 public class VertexiumMRUtils {
     public static final String CONFIG_AUTHORIZATIONS = "authorizations";
 
+    @SuppressWarnings("unchecked")
     public static Map toMap(Configuration configuration) {
         Map map = new HashMap();
         for (Map.Entry<String, String> entry : configuration) {

--- a/accumulo/src/main/java/org/vertexium/accumulo/util/HistoricalEventsIteratorConverter.java
+++ b/accumulo/src/main/java/org/vertexium/accumulo/util/HistoricalEventsIteratorConverter.java
@@ -392,6 +392,7 @@ public class HistoricalEventsIteratorConverter {
         return results;
     }
 
+    @SuppressWarnings("unchecked")
     private static Object valueToObject(
         AccumuloGraph graph,
         ElementType elementType,
@@ -404,7 +405,6 @@ public class HistoricalEventsIteratorConverter {
         }
         Object propertyValue = graph.getVertexiumSerializer().bytesToObject(elementType, elementId, value.get());
         if (propertyValue instanceof StreamingPropertyValueRef) {
-            //noinspection unchecked
             propertyValue = ((StreamingPropertyValueRef) propertyValue).toStreamingPropertyValue(graph, timestamp);
         }
         return propertyValue;

--- a/accumulo/src/test/java/org/vertexium/accumulo/AccumuloGraphConfigurationTest.java
+++ b/accumulo/src/test/java/org/vertexium/accumulo/AccumuloGraphConfigurationTest.java
@@ -15,8 +15,8 @@ import static org.hamcrest.MatcherAssert.assertThat;
 
 @RunWith(JUnit4.class)
 public class AccumuloGraphConfigurationTest {
-
     @Test
+    @SuppressWarnings("unchecked")
     public void testBatchWriterConfigUsesDefaultWithNoParameters() {
         Map configMap = Maps.newHashMap();
         AccumuloGraphConfiguration accumuloGraphConfiguration = new AccumuloGraphConfiguration(configMap);
@@ -29,6 +29,7 @@ public class AccumuloGraphConfigurationTest {
     }
 
     @Test
+    @SuppressWarnings("unchecked")
     public void testBatchWriterConfigIsSetToValuesWithParameters() {
         int numThreads = 2;
         long timeout = 3;

--- a/accumulo/src/test/java/org/vertexium/accumulo/AccumuloGraphTestBase.java
+++ b/accumulo/src/test/java/org/vertexium/accumulo/AccumuloGraphTestBase.java
@@ -72,6 +72,7 @@ public abstract class AccumuloGraphTestBase extends GraphTestBase {
     }
 
     @Test
+    @SuppressWarnings("unchecked")
     public void testDefinePropertiesMultipleGraphs() {
         Graph graph1 = graph;
         Graph graph2 = AccumuloGraph.create(new AccumuloGraphConfiguration(getAccumuloResource().createConfig()));
@@ -112,14 +113,19 @@ public abstract class AccumuloGraphTestBase extends GraphTestBase {
 
     @Test
     public void testStoringEmptyMetadata() {
-        Vertex v1 = graph.addVertex("v1", VISIBILITY_EMPTY, AUTHORIZATIONS_EMPTY);
+        Vertex v1 = graph.prepareVertex("v1", VISIBILITY_EMPTY).save(AUTHORIZATIONS_EMPTY);
         Metadata metadata = Metadata.create();
-        v1.addPropertyValue("prop1", "prop1", "val1", metadata, VISIBILITY_EMPTY, AUTHORIZATIONS_A_AND_B);
+        v1.prepareMutation()
+            .addPropertyValue("prop1", "prop1", "val1", metadata, VISIBILITY_EMPTY)
+            .save(AUTHORIZATIONS_A_AND_B);
 
-        Vertex v2 = graph.addVertex("v2", VISIBILITY_EMPTY, AUTHORIZATIONS_EMPTY);
+        Vertex v2 = graph.prepareVertex("v2", VISIBILITY_EMPTY)
+            .save(AUTHORIZATIONS_EMPTY);
         metadata = Metadata.create();
         metadata.add("meta1", "metavalue1", VISIBILITY_EMPTY);
-        v2.addPropertyValue("prop1", "prop1", "val1", metadata, VISIBILITY_EMPTY, AUTHORIZATIONS_A_AND_B);
+        v2.prepareMutation()
+            .addPropertyValue("prop1", "prop1", "val1", metadata, VISIBILITY_EMPTY)
+            .save(AUTHORIZATIONS_A_AND_B);
         graph.flush();
 
         v1 = graph.getVertex("v1", FetchHints.ALL, AUTHORIZATIONS_EMPTY);
@@ -442,8 +448,9 @@ public abstract class AccumuloGraphTestBase extends GraphTestBase {
 
         addLegacySPVData(vertexId, timestamp - 100, propertyKey, propertyName, propertyValue1);
         StreamingPropertyValue newSpv = StreamingPropertyValue.create(propertyValue2);
-        getGraph().getVertex("v1", AUTHORIZATIONS_EMPTY)
-            .addPropertyValue(propertyKey, propertyName, newSpv, VISIBILITY_EMPTY, AUTHORIZATIONS_EMPTY);
+        getGraph().getVertex("v1", AUTHORIZATIONS_EMPTY).prepareMutation()
+            .addPropertyValue(propertyKey, propertyName, newSpv, VISIBILITY_EMPTY)
+            .save(AUTHORIZATIONS_EMPTY);
 
         getGraph().flush();
 
@@ -496,7 +503,7 @@ public abstract class AccumuloGraphTestBase extends GraphTestBase {
 
     /**
      * Add this into the watch window to print the vertices table in time sorted order
-     *
+     * <p>
      * ((AccumuloGraphTest)this).printVerticesTable(AUTHORIZATIONS_ALL)
      */
     public void printVerticesTable(Authorizations authorizations) {

--- a/accumulo/src/test/java/org/vertexium/accumulo/AccumuloResource.java
+++ b/accumulo/src/test/java/org/vertexium/accumulo/AccumuloResource.java
@@ -1,7 +1,5 @@
 package org.vertexium.accumulo;
 
-import org.apache.accumulo.core.client.AccumuloException;
-import org.apache.accumulo.core.client.AccumuloSecurityException;
 import org.apache.accumulo.core.client.Connector;
 import org.apache.accumulo.core.security.Authorizations;
 import org.apache.accumulo.minicluster.MiniAccumuloCluster;
@@ -126,7 +124,8 @@ public class AccumuloResource extends ExternalResource {
         return configMap;
     }
 
-    public Connector createConnector() throws AccumuloSecurityException, AccumuloException {
+    @SuppressWarnings("unchecked")
+    public Connector createConnector() {
         return new AccumuloGraphConfiguration(createConfig()).createConnector();
     }
 

--- a/cli/src/main/java/org/vertexium/cli/model/LazyProperty.java
+++ b/cli/src/main/java/org/vertexium/cli/model/LazyProperty.java
@@ -108,7 +108,9 @@ public abstract class LazyProperty extends ModelBase {
     }
 
     public void delete() {
-        getE().deleteProperty(getKey(), getName(), getVisibility(), getAuthorizations());
+        getE().prepareMutation()
+            .deleteProperty(getKey(), getName(), getVisibility())
+            .save(getAuthorizations());
         getGraph().flush();
     }
 }

--- a/core/src/main/java/org/vertexium/Edge.java
+++ b/core/src/main/java/org/vertexium/Edge.java
@@ -7,6 +7,7 @@ import java.util.ArrayList;
 import java.util.List;
 import java.util.Map;
 
+@SuppressWarnings("unchecked")
 public interface Edge extends Element, EdgeElementLocation {
     /**
      * Meta property name used for queries, sorting, and aggregations
@@ -111,6 +112,7 @@ public interface Edge extends Element, EdgeElementLocation {
      *
      * @return The mutation builder.
      */
+    @Override
     ExistingEdgeMutation prepareMutation();
 
     @Override

--- a/core/src/main/java/org/vertexium/EdgeInfoEdge.java
+++ b/core/src/main/java/org/vertexium/EdgeInfoEdge.java
@@ -8,6 +8,7 @@ import org.vertexium.query.QueryableIterable;
 
 import java.util.stream.Stream;
 
+@SuppressWarnings("unchecked")
 public class EdgeInfoEdge extends ElementBase implements Edge {
     private final Graph graph;
     private final String sourceVertexId;
@@ -82,11 +83,13 @@ public class EdgeInfoEdge extends ElementBase implements Edge {
     }
 
     @Override
+    @Deprecated
     public void deleteProperty(String key, String name, Visibility visibility, Authorizations authorizations) {
         getEdge().deleteProperty(key, name, visibility, authorizations);
     }
 
     @Override
+    @Deprecated
     public void softDeleteProperty(String key, String name, Visibility visibility, Object eventData, Authorizations authorizations) {
         getEdge().softDeleteProperty(key, name, visibility, eventData, authorizations);
     }
@@ -102,11 +105,13 @@ public class EdgeInfoEdge extends ElementBase implements Edge {
     }
 
     @Override
+    @Deprecated
     public void markPropertyHidden(Property property, Long timestamp, Visibility visibility, Object data, Authorizations authorizations) {
         getEdge().markPropertyHidden(property, timestamp, visibility, data, authorizations);
     }
 
     @Override
+    @Deprecated
     public void markPropertyVisible(Property property, Long timestamp, Visibility visibility, Object eventData, Authorizations authorizations) {
         getEdge().markPropertyVisible(property, timestamp, visibility, eventData, authorizations);
     }

--- a/core/src/main/java/org/vertexium/Element.java
+++ b/core/src/main/java/org/vertexium/Element.java
@@ -145,7 +145,9 @@ public interface Element extends VertexiumObject, ElementLocation {
      * this method.
      *
      * @param property The property to delete.
+     * @deprecated Use {@link org.vertexium.mutation.ElementMutation#deleteProperty(Property)}
      */
+    @Deprecated
     default void deleteProperty(Property property, Authorizations authorizations) {
         deleteProperty(property.getKey(), property.getName(), property.getVisibility(), authorizations);
     }
@@ -156,7 +158,9 @@ public interface Element extends VertexiumObject, ElementLocation {
      *
      * @param key  The property key.
      * @param name The property name.
+     * @deprecated Use {@link org.vertexium.mutation.ExistingElementMutation#deleteProperties(String, String)}
      */
+    @Deprecated
     default void deleteProperty(String key, String name, Authorizations authorizations) {
         deleteProperty(key, name, null, authorizations);
     }
@@ -168,15 +172,21 @@ public interface Element extends VertexiumObject, ElementLocation {
      * @param key        The property key.
      * @param name       The property name.
      * @param visibility The property visibility.
+     * @deprecated Use {@link org.vertexium.mutation.ElementMutation#deleteProperty(String, String, Visibility)}
      */
-    void deleteProperty(String key, String name, Visibility visibility, Authorizations authorizations);
+    @Deprecated
+    default void deleteProperty(String key, String name, Visibility visibility, Authorizations authorizations) {
+        prepareMutation().deleteProperty(key, name, visibility).save(authorizations);
+    }
 
     /**
      * Permanently deletes all properties with the given name that you have access to. Only properties which you have
      * access to will be deleted.
      *
      * @param name The name of the property to delete.
+     * @deprecated Use {@link org.vertexium.mutation.ExistingElementMutation#deleteProperties(String)}
      */
+    @Deprecated
     default void deleteProperties(String name, Authorizations authorizations) {
         for (Property p : getProperties(name)) {
             deleteProperty(p.getKey(), p.getName(), p.getVisibility(), authorizations);
@@ -189,7 +199,9 @@ public interface Element extends VertexiumObject, ElementLocation {
      *
      * @param key  The property key.
      * @param name The property name.
+     * @deprecated Use {@link org.vertexium.mutation.ExistingElementMutation#softDeleteProperties(String, String)}
      */
+    @Deprecated
     default void softDeleteProperty(String key, String name, Authorizations authorizations) {
         softDeleteProperty(key, name, null, authorizations);
     }
@@ -201,7 +213,9 @@ public interface Element extends VertexiumObject, ElementLocation {
      * @param key       The property key.
      * @param name      The property name.
      * @param eventData Data to store with the soft delete
+     * @deprecated Use {@link org.vertexium.mutation.ExistingElementMutation#softDeleteProperties(String, String, Object)}
      */
+    @Deprecated
     default void softDeleteProperty(String key, String name, Object eventData, Authorizations authorizations) {
         softDeleteProperty(key, name, null, eventData, authorizations);
     }
@@ -213,7 +227,9 @@ public interface Element extends VertexiumObject, ElementLocation {
      * @param key        The property key.
      * @param name       The property name.
      * @param visibility The visibility string of the property to soft delete.
+     * @deprecated Use {@link org.vertexium.mutation.ElementMutation#softDeleteProperty(String, String, Visibility)}
      */
+    @Deprecated
     default void softDeleteProperty(String key, String name, Visibility visibility, Authorizations authorizations) {
         softDeleteProperty(key, name, visibility, null, authorizations);
     }
@@ -226,7 +242,9 @@ public interface Element extends VertexiumObject, ElementLocation {
      * @param name       The property name.
      * @param visibility The visibility string of the property to soft delete.
      * @param eventData  Data to store with the soft delete
+     * @deprecated Use {@link org.vertexium.mutation.ElementMutation#softDeleteProperty(String, String, Visibility, Object)}
      */
+    @Deprecated
     void softDeleteProperty(String key, String name, Visibility visibility, Object eventData, Authorizations authorizations);
 
     /**
@@ -234,7 +252,9 @@ public interface Element extends VertexiumObject, ElementLocation {
      * access to will be soft deleted.
      *
      * @param name The name of the property to delete.
+     * @deprecated Use {@link org.vertexium.mutation.ExistingElementMutation#softDeleteProperties(String)}
      */
+    @Deprecated
     default void softDeleteProperties(String name, Authorizations authorizations) {
         softDeleteProperties(name, null, authorizations);
     }
@@ -245,7 +265,9 @@ public interface Element extends VertexiumObject, ElementLocation {
      *
      * @param name      The name of the property to delete.
      * @param eventData Data to store with the soft delete
+     * @deprecated Use {@link org.vertexium.mutation.ExistingElementMutation#softDeleteProperties(String, Object)}
      */
+    @Deprecated
     default void softDeleteProperties(String name, Object eventData, Authorizations authorizations) {
         for (Property property : getProperties(name)) {
             softDeleteProperty(property.getKey(), property.getName(), property.getVisibility(), eventData, authorizations);
@@ -264,7 +286,9 @@ public interface Element extends VertexiumObject, ElementLocation {
      * @param name       The name of the property.
      * @param value      The value of the property.
      * @param visibility The visibility to give this property.
+     * @deprecated Use {@link org.vertexium.mutation.ElementMutation#addPropertyValue(String, String, Object, Visibility)}
      */
+    @Deprecated
     default void addPropertyValue(String key, String name, Object value, Visibility visibility, Authorizations authorizations) {
         prepareMutation().addPropertyValue(key, name, value, visibility).save(authorizations);
     }
@@ -277,7 +301,9 @@ public interface Element extends VertexiumObject, ElementLocation {
      * @param value      The value of the property.
      * @param metadata   The metadata to assign to this property.
      * @param visibility The visibility to give this property.
+     * @deprecated Use {@link org.vertexium.mutation.ElementMutation#addPropertyValue(String, String, Object, Metadata, Visibility)}
      */
+    @Deprecated
     default void addPropertyValue(String key, String name, Object value, Metadata metadata, Visibility visibility, Authorizations authorizations) {
         prepareMutation().addPropertyValue(key, name, value, metadata, visibility).save(authorizations);
     }
@@ -291,7 +317,9 @@ public interface Element extends VertexiumObject, ElementLocation {
      * @param name       The name of the property.
      * @param value      The value of the property.
      * @param visibility The visibility to give this property.
+     * @deprecated Use {@link org.vertexium.mutation.ElementMutation#setProperty(String, Object, Visibility)}
      */
+    @Deprecated
     default void setProperty(String name, Object value, Visibility visibility, Authorizations authorizations) {
         prepareMutation().setProperty(name, value, visibility).save(authorizations);
     }
@@ -306,7 +334,9 @@ public interface Element extends VertexiumObject, ElementLocation {
      * @param value      The value of the property.
      * @param metadata   The metadata to assign to this property.
      * @param visibility The visibility to give this property.
+     * @deprecated Use {@link org.vertexium.mutation.ElementMutation#setProperty(String, Object, Metadata, Visibility)}
      */
+    @Deprecated
     default void setProperty(String name, Object value, Metadata metadata, Visibility visibility, Authorizations authorizations) {
         prepareMutation().setProperty(name, value, metadata, visibility).save(authorizations);
     }
@@ -326,7 +356,9 @@ public interface Element extends VertexiumObject, ElementLocation {
      *                           This visibility can be a superset of the property visibility to mark
      *                           it as hidden for only a subset of authorizations.
      * @param authorizations     The authorizations used.
+     * @deprecated Use {@link org.vertexium.mutation.ElementMutation#markPropertyHidden(String, String, Visibility, Visibility)}
      */
+    @Deprecated
     default void markPropertyHidden(String key, String name, Visibility propertyVisibility, Visibility visibility, Authorizations authorizations) {
         markPropertyHidden(key, name, propertyVisibility, null, visibility, null, authorizations);
     }
@@ -342,7 +374,9 @@ public interface Element extends VertexiumObject, ElementLocation {
      *                           it as hidden for only a subset of authorizations.
      * @param eventData          Data to store with the hidden
      * @param authorizations     The authorizations used.
+     * @deprecated Use {@link org.vertexium.mutation.ElementMutation#markPropertyHidden(String, String, Visibility, Visibility, Object)}
      */
+    @Deprecated
     default void markPropertyHidden(String key, String name, Visibility propertyVisibility, Visibility visibility, Object eventData, Authorizations authorizations) {
         markPropertyHidden(key, name, propertyVisibility, null, visibility, eventData, authorizations);
     }
@@ -358,7 +392,9 @@ public interface Element extends VertexiumObject, ElementLocation {
      *                           This visibility can be a superset of the property visibility to mark
      *                           it as hidden for only a subset of authorizations.
      * @param authorizations     The authorizations used.
+     * @deprecated Use {@link org.vertexium.mutation.ElementMutation#markPropertyHidden(String, String, Visibility, Long, Visibility)}
      */
+    @Deprecated
     default void markPropertyHidden(
         String key,
         String name,
@@ -382,7 +418,9 @@ public interface Element extends VertexiumObject, ElementLocation {
      *                           it as hidden for only a subset of authorizations.
      * @param eventData          Data to store with the hidden
      * @param authorizations     The authorizations used.
+     * @deprecated Use {@link org.vertexium.mutation.ElementMutation#markPropertyHidden(String, String, Visibility, Long, Visibility, Object)}
      */
+    @Deprecated
     default void markPropertyHidden(
         String key,
         String name,
@@ -410,7 +448,9 @@ public interface Element extends VertexiumObject, ElementLocation {
      *                       This visibility can be a superset of the property visibility to mark
      *                       it as hidden for only a subset of authorizations.
      * @param authorizations The authorizations used.
+     * @deprecated Use {@link org.vertexium.mutation.ElementMutation#markPropertyHidden(Property, Visibility)}
      */
+    @Deprecated
     default void markPropertyHidden(Property property, Visibility visibility, Authorizations authorizations) {
         markPropertyHidden(property, null, visibility, null, authorizations);
     }
@@ -424,7 +464,9 @@ public interface Element extends VertexiumObject, ElementLocation {
      *                       it as hidden for only a subset of authorizations.
      * @param eventData      Data to store with the hidden
      * @param authorizations The authorizations used.
+     * @deprecated Use {@link org.vertexium.mutation.ElementMutation#markPropertyHidden(Property, Visibility, Object)}
      */
+    @Deprecated
     default void markPropertyHidden(Property property, Visibility visibility, Object eventData, Authorizations authorizations) {
         markPropertyHidden(property, null, visibility, eventData, authorizations);
     }
@@ -438,7 +480,9 @@ public interface Element extends VertexiumObject, ElementLocation {
      *                       This visibility can be a superset of the property visibility to mark
      *                       it as hidden for only a subset of authorizations.
      * @param authorizations The authorizations used.
+     * @deprecated Use {@link org.vertexium.mutation.ElementMutation#markPropertyHidden(Property, Long, Visibility)}
      */
+    @Deprecated
     default void markPropertyHidden(Property property, Long timestamp, Visibility visibility, Authorizations authorizations) {
         markPropertyHidden(property, timestamp, visibility, null, authorizations);
     }
@@ -452,7 +496,9 @@ public interface Element extends VertexiumObject, ElementLocation {
      *                       This visibility can be a superset of the property visibility to mark
      *                       it as hidden for only a subset of authorizations.
      * @param authorizations The authorizations used.
+     * @deprecated Use {@link org.vertexium.mutation.ElementMutation#markPropertyHidden(Property, Long, Visibility, Object)}
      */
+    @Deprecated
     void markPropertyHidden(Property property, Long timestamp, Visibility visibility, Object data, Authorizations authorizations);
 
     /**
@@ -463,7 +509,9 @@ public interface Element extends VertexiumObject, ElementLocation {
      * @param propertyVisibility The visibility of the property.
      * @param visibility         The visibility string under which this property is now visible.
      * @param authorizations     The authorizations used.
+     * @deprecated Use {@link org.vertexium.mutation.ElementMutation#markPropertyVisible(String, String, Visibility, Visibility)}
      */
+    @Deprecated
     default void markPropertyVisible(String key, String name, Visibility propertyVisibility, Visibility visibility, Authorizations authorizations) {
         markPropertyVisible(key, name, propertyVisibility, null, visibility, null, authorizations);
     }
@@ -477,7 +525,9 @@ public interface Element extends VertexiumObject, ElementLocation {
      * @param visibility         The visibility string under which this property is now visible.
      * @param eventData          Data to store with the visible
      * @param authorizations     The authorizations used.
+     * @deprecated Use {@link org.vertexium.mutation.ElementMutation#markPropertyVisible(String, String, Visibility, Visibility, Object)}
      */
+    @Deprecated
     default void markPropertyVisible(String key, String name, Visibility propertyVisibility, Visibility visibility, Object eventData, Authorizations authorizations) {
         markPropertyVisible(key, name, propertyVisibility, null, visibility, eventData, authorizations);
     }
@@ -491,7 +541,9 @@ public interface Element extends VertexiumObject, ElementLocation {
      * @param timestamp          The timestamp.
      * @param visibility         The visibility string under which this property is now visible.
      * @param authorizations     The authorizations used.
+     * @deprecated Use {@link org.vertexium.mutation.ElementMutation#markPropertyVisible(String, String, Visibility, Long, Visibility)}
      */
+    @Deprecated
     default void markPropertyVisible(
         String key,
         String name,
@@ -513,7 +565,9 @@ public interface Element extends VertexiumObject, ElementLocation {
      * @param visibility         The visibility string under which this property is now visible.
      * @param eventData          Data to store with the visible
      * @param authorizations     The authorizations used.
+     * @deprecated Use {@link org.vertexium.mutation.ElementMutation#markPropertyVisible(String, String, Visibility, Long, Visibility, Object)}
      */
+    @Deprecated
     default void markPropertyVisible(
         String key,
         String name,
@@ -539,7 +593,9 @@ public interface Element extends VertexiumObject, ElementLocation {
      * @param property       The property.
      * @param visibility     The visibility string under which this property is now visible.
      * @param authorizations The authorizations used.
+     * @deprecated Use {@link org.vertexium.mutation.ElementMutation#markPropertyVisible(Property, Visibility)}
      */
+    @Deprecated
     default void markPropertyVisible(Property property, Visibility visibility, Authorizations authorizations) {
         markPropertyVisible(property, null, visibility, null, authorizations);
     }
@@ -551,7 +607,9 @@ public interface Element extends VertexiumObject, ElementLocation {
      * @param visibility     The visibility string under which this property is now visible.
      * @param eventData      Data to store with the visible
      * @param authorizations The authorizations used.
+     * @deprecated Use {@link org.vertexium.mutation.ElementMutation#markPropertyVisible(Property, Visibility, Object)}
      */
+    @Deprecated
     default void markPropertyVisible(Property property, Visibility visibility, Object eventData, Authorizations authorizations) {
         markPropertyVisible(property, null, visibility, eventData, authorizations);
     }
@@ -563,7 +621,9 @@ public interface Element extends VertexiumObject, ElementLocation {
      * @param timestamp      The timestamp.
      * @param visibility     The visibility string under which this property is now visible.
      * @param authorizations The authorizations used.
+     * @deprecated Use {@link org.vertexium.mutation.ElementMutation#markPropertyVisible(Property, Long, Visibility)}
      */
+    @Deprecated
     default void markPropertyVisible(Property property, Long timestamp, Visibility visibility, Authorizations authorizations) {
         markPropertyVisible(property, timestamp, visibility, null, authorizations);
     }
@@ -576,8 +636,12 @@ public interface Element extends VertexiumObject, ElementLocation {
      * @param visibility     The visibility string under which this property is now visible.
      * @param eventData      Data to store with the visible
      * @param authorizations The authorizations used.
+     * @deprecated Use {@link org.vertexium.mutation.ElementMutation#markPropertyVisible(Property, Long, Visibility, Object)}
      */
-    void markPropertyVisible(Property property, Long timestamp, Visibility visibility, Object eventData, Authorizations authorizations);
+    @Deprecated
+    default void markPropertyVisible(Property property, Long timestamp, Visibility visibility, Object eventData, Authorizations authorizations) {
+        prepareMutation().markPropertyVisible(property, timestamp, visibility, eventData).save(authorizations);
+    }
 
     /**
      * Given the supplied authorizations is this element hidden?

--- a/core/src/main/java/org/vertexium/ElementBuilder.java
+++ b/core/src/main/java/org/vertexium/ElementBuilder.java
@@ -23,6 +23,8 @@ public abstract class ElementBuilder<T extends Element> implements ElementMutati
     private final List<AdditionalVisibilityDeleteMutation> additionalVisibilityDeletes = new ArrayList<>();
     private final List<AdditionalExtendedDataVisibilityAddMutation> additionalExtendedDataVisibilities = new ArrayList<>();
     private final List<AdditionalExtendedDataVisibilityDeleteMutation> additionalExtendedDataVisibilityDeletes = new ArrayList<>();
+    private final List<MarkPropertyHiddenMutation> markPropertyHiddenMutations = new ArrayList<>();
+    private final List<MarkPropertyVisibleMutation> markPropertyVisibleMutations = new ArrayList<>();
     private final ElementType elementType;
     private final String elementId;
     private final Visibility elementVisibility;
@@ -257,6 +259,32 @@ public abstract class ElementBuilder<T extends Element> implements ElementMutati
         return this;
     }
 
+    @Override
+    public ElementMutation<T> markPropertyHidden(
+        String key,
+        String name,
+        Visibility propertyVisibility,
+        Long timestamp,
+        Visibility visibility,
+        Object eventData
+    ) {
+        markPropertyHiddenMutations.add(new MarkPropertyHiddenMutation(key, name, propertyVisibility, timestamp, visibility, eventData));
+        return this;
+    }
+
+    @Override
+    public ElementMutation<T> markPropertyVisible(
+        String key,
+        String name,
+        Visibility propertyVisibility,
+        Long timestamp,
+        Visibility visibility,
+        Object eventData
+    ) {
+        markPropertyVisibleMutations.add(new MarkPropertyVisibleMutation(key, name, propertyVisibility, timestamp, visibility, eventData));
+        return this;
+    }
+
     /**
      * saves the element to the graph.
      *
@@ -309,6 +337,16 @@ public abstract class ElementBuilder<T extends Element> implements ElementMutati
         return additionalExtendedDataVisibilityDeletes;
     }
 
+    @Override
+    public List<MarkPropertyHiddenMutation> getMarkPropertyHiddenMutations() {
+        return markPropertyHiddenMutations;
+    }
+
+    @Override
+    public List<MarkPropertyVisibleMutation> getMarkPropertyVisibleMutations() {
+        return markPropertyVisibleMutations;
+    }
+
     public Set<String> getAdditionalVisibilitiesAsStringSet() {
         Set<String> results = getAdditionalVisibilities().stream()
             .map(AdditionalVisibilityAddMutation::getAdditionalVisibility)
@@ -357,6 +395,14 @@ public abstract class ElementBuilder<T extends Element> implements ElementMutati
         }
 
         if (extendedDataDeletes.size() > 0) {
+            return true;
+        }
+
+        if (markPropertyHiddenMutations.size() > 0) {
+            return true;
+        }
+
+        if (markPropertyVisibleMutations.size() > 0) {
             return true;
         }
 

--- a/core/src/main/java/org/vertexium/Graph.java
+++ b/core/src/main/java/org/vertexium/Graph.java
@@ -27,8 +27,12 @@ public interface Graph {
      * @param visibility     The visibility to assign to the new vertex.
      * @param authorizations The authorizations required to add and retrieve the new vertex.
      * @return The newly added vertex.
+     * @deprecated Use {@link #prepareVertex(Visibility)}
      */
-    Vertex addVertex(Visibility visibility, Authorizations authorizations);
+    @Deprecated
+    default Vertex addVertex(Visibility visibility, Authorizations authorizations) {
+        return prepareVertex(visibility).save(authorizations);
+    }
 
     /**
      * Adds a vertex to the graph.
@@ -37,8 +41,12 @@ public interface Graph {
      * @param visibility     The visibility to assign to the new vertex.
      * @param authorizations The authorizations required to add and retrieve the new vertex.
      * @return The newly added vertex.
+     * * @deprecated Use {@link #prepareVertex(String, Visibility)}
      */
-    Vertex addVertex(String vertexId, Visibility visibility, Authorizations authorizations);
+    @Deprecated
+    default Vertex addVertex(String vertexId, Visibility visibility, Authorizations authorizations) {
+        return prepareVertex(vertexId, visibility).save(authorizations);
+    }
 
     /**
      * Adds the vertices to the graph.
@@ -186,7 +194,7 @@ public interface Graph {
             return getVertices(vertexIds, fetchHints, authorizations);
         }
 
-        return new JoinIterable<>(
+        return new JoinIterable<Element>(
             getVertices(vertexIds, fetchHints, authorizations),
             getEdges(edgeIds, fetchHints, authorizations)
         );
@@ -524,8 +532,12 @@ public interface Graph {
      * @param visibility     The visibility to assign to the new edge.
      * @param authorizations The authorizations required to add and retrieve the new edge.
      * @return The newly created edge.
+     * @deprecated Use {@link #prepareEdge(Vertex, Vertex, String, Visibility)}
      */
-    Edge addEdge(Vertex outVertex, Vertex inVertex, String label, Visibility visibility, Authorizations authorizations);
+    @Deprecated
+    default Edge addEdge(Vertex outVertex, Vertex inVertex, String label, Visibility visibility, Authorizations authorizations) {
+        return prepareEdge(outVertex, inVertex, label, visibility).save(authorizations);
+    }
 
     /**
      * Adds an edge between two vertices.
@@ -537,8 +549,12 @@ public interface Graph {
      * @param visibility     The visibility to assign to the new edge.
      * @param authorizations The authorizations required to add and retrieve the new edge.
      * @return The newly created edge.
+     * @deprecated Use {@link #prepareEdge(String, Vertex, Vertex, String, Visibility)}
      */
-    Edge addEdge(String edgeId, Vertex outVertex, Vertex inVertex, String label, Visibility visibility, Authorizations authorizations);
+    @Deprecated
+    default Edge addEdge(String edgeId, Vertex outVertex, Vertex inVertex, String label, Visibility visibility, Authorizations authorizations) {
+        return prepareEdge(edgeId, outVertex, inVertex, label, visibility).save(authorizations);
+    }
 
     /**
      * Adds an edge between two vertices.
@@ -549,8 +565,12 @@ public interface Graph {
      * @param visibility     The visibility to assign to the new edge.
      * @param authorizations The authorizations required to add and retrieve the new edge.
      * @return The newly created edge.
+     * @deprecated Use {@link #prepareEdge(String, String, String, Visibility)}
      */
-    Edge addEdge(String outVertexId, String inVertexId, String label, Visibility visibility, Authorizations authorizations);
+    @Deprecated
+    default Edge addEdge(String outVertexId, String inVertexId, String label, Visibility visibility, Authorizations authorizations) {
+        return prepareEdge(outVertexId, inVertexId, label, visibility).save(authorizations);
+    }
 
     /**
      * Adds an edge between two vertices.
@@ -562,8 +582,12 @@ public interface Graph {
      * @param visibility     The visibility to assign to the new edge.
      * @param authorizations The authorizations required to add and retrieve the new edge.
      * @return The newly created edge.
+     * @deprecated Use {@link #prepareEdge(String, String, String, String, Visibility)}
      */
-    Edge addEdge(String edgeId, String outVertexId, String inVertexId, String label, Visibility visibility, Authorizations authorizations);
+    @Deprecated
+    default Edge addEdge(String edgeId, String outVertexId, String inVertexId, String label, Visibility visibility, Authorizations authorizations) {
+        return prepareEdge(edgeId, outVertexId, inVertexId, label, visibility).save(authorizations);
+    }
 
     /**
      * Prepare an edge to be added to the graph. This method provides a way to build up an edge with it's properties to be inserted
@@ -1538,21 +1562,25 @@ public interface Graph {
     /**
      * Visits all elements on the graph
      */
+    @Deprecated
     void visitElements(GraphVisitor graphVisitor, Authorizations authorizations);
 
     /**
      * Visits all vertices on the graph
      */
+    @Deprecated
     void visitVertices(GraphVisitor graphVisitor, Authorizations authorizations);
 
     /**
      * Visits all edges on the graph
      */
+    @Deprecated
     void visitEdges(GraphVisitor graphVisitor, Authorizations authorizations);
 
     /**
      * Visits elements using the supplied elements and visitor
      */
+    @Deprecated
     void visit(Iterable<? extends Element> elements, GraphVisitor visitor);
 
     /**

--- a/core/src/main/java/org/vertexium/GraphBase.java
+++ b/core/src/main/java/org/vertexium/GraphBase.java
@@ -48,16 +48,6 @@ public abstract class GraphBase implements Graph {
     }
 
     @Override
-    public Vertex addVertex(Visibility visibility, Authorizations authorizations) {
-        return prepareVertex(visibility).save(authorizations);
-    }
-
-    @Override
-    public Vertex addVertex(String vertexId, Visibility visibility, Authorizations authorizations) {
-        return prepareVertex(vertexId, visibility).save(authorizations);
-    }
-
-    @Override
     public Iterable<Vertex> addVertices(Iterable<ElementBuilder<Vertex>> vertices, Authorizations authorizations) {
         List<Vertex> addedVertices = new ArrayList<>();
         for (ElementBuilder<Vertex> vertexBuilder : vertices) {
@@ -222,26 +212,6 @@ public abstract class GraphBase implements Graph {
 
     @Override
     public abstract Iterable<Vertex> getVertices(FetchHints fetchHints, Long endTime, Authorizations authorizations);
-
-    @Override
-    public Edge addEdge(Vertex outVertex, Vertex inVertex, String label, Visibility visibility, Authorizations authorizations) {
-        return prepareEdge(outVertex, inVertex, label, visibility).save(authorizations);
-    }
-
-    @Override
-    public Edge addEdge(String edgeId, Vertex outVertex, Vertex inVertex, String label, Visibility visibility, Authorizations authorizations) {
-        return prepareEdge(edgeId, outVertex, inVertex, label, visibility).save(authorizations);
-    }
-
-    @Override
-    public Edge addEdge(String outVertexId, String inVertexId, String label, Visibility visibility, Authorizations authorizations) {
-        return prepareEdge(outVertexId, inVertexId, label, visibility).save(authorizations);
-    }
-
-    @Override
-    public Edge addEdge(String edgeId, String outVertexId, String inVertexId, String label, Visibility visibility, Authorizations authorizations) {
-        return prepareEdge(edgeId, outVertexId, inVertexId, label, visibility).save(authorizations);
-    }
 
     @Override
     public EdgeBuilderByVertexId prepareEdge(String outVertexId, String inVertexId, String label, Visibility visibility) {
@@ -1066,7 +1036,7 @@ public abstract class GraphBase implements Graph {
     }
 
     protected Iterable<ExtendedDataRow> getAllExtendedData(FetchHints fetchHints, Authorizations authorizations) {
-        JoinIterable<Element> allElements = new JoinIterable<>(getVertices(fetchHints, authorizations), getEdges(fetchHints, authorizations));
+        JoinIterable<Element> allElements = new JoinIterable<Element>(getVertices(fetchHints, authorizations), getEdges(fetchHints, authorizations));
         return new SelectManyIterable<Element, ExtendedDataRow>(allElements) {
             @Override
             protected Iterable<? extends ExtendedDataRow> getIterable(Element element) {
@@ -1104,22 +1074,26 @@ public abstract class GraphBase implements Graph {
     }
 
     @Override
+    @Deprecated
     public void visitElements(GraphVisitor graphVisitor, Authorizations authorizations) {
         visitVertices(graphVisitor, authorizations);
         visitEdges(graphVisitor, authorizations);
     }
 
     @Override
+    @Deprecated
     public void visitVertices(GraphVisitor graphVisitor, Authorizations authorizations) {
         visit(getVertices(authorizations), graphVisitor);
     }
 
     @Override
+    @Deprecated
     public void visitEdges(GraphVisitor graphVisitor, Authorizations authorizations) {
         visit(getEdges(authorizations), graphVisitor);
     }
 
     @Override
+    @Deprecated
     public void visit(Iterable<? extends Element> elements, GraphVisitor visitor) {
         int i = 0;
         for (Element element : elements) {

--- a/core/src/main/java/org/vertexium/JavaVertexiumSerializer.java
+++ b/core/src/main/java/org/vertexium/JavaVertexiumSerializer.java
@@ -14,6 +14,7 @@ public class JavaVertexiumSerializer implements VertexiumSerializer {
     }
 
     @Override
+    @SuppressWarnings("unchecked")
     public <T> T bytesToObject(byte[] bytes) {
         if (bytes == null || bytes.length == 0) {
             return null;

--- a/core/src/main/java/org/vertexium/Vertex.java
+++ b/core/src/main/java/org/vertexium/Vertex.java
@@ -3,6 +3,7 @@ package org.vertexium;
 import org.vertexium.mutation.ExistingElementMutation;
 import org.vertexium.query.VertexQuery;
 
+@SuppressWarnings("unchecked")
 public interface Vertex extends Element {
     /**
      * Gets all edges attached to this vertex.
@@ -390,6 +391,7 @@ public interface Vertex extends Element {
      *
      * @return The mutation builder.
      */
+    @Override
     ExistingElementMutation<Vertex> prepareMutation();
 
     /**

--- a/core/src/main/java/org/vertexium/mutation/ElementMutation.java
+++ b/core/src/main/java/org/vertexium/mutation/ElementMutation.java
@@ -153,6 +153,249 @@ public interface ElementMutation<T extends Element> extends ElementLocation {
     ElementMutation<T> softDeleteProperty(String key, String name, Visibility visibility, Object eventData);
 
     /**
+     * Marks a property as hidden for a given visibility.
+     *
+     * @param key                The key of the property.
+     * @param name               The name of the property.
+     * @param propertyVisibility The visibility of the property.
+     * @param visibility         The visibility string under which this property is hidden.
+     *                           This visibility can be a superset of the property visibility to mark
+     *                           it as hidden for only a subset of authorizations.
+     */
+    default ElementMutation<T> markPropertyHidden(String key, String name, Visibility propertyVisibility, Visibility visibility) {
+        return markPropertyHidden(key, name, propertyVisibility, null, visibility, null);
+    }
+
+    /**
+     * Marks a property as hidden for a given visibility.
+     *
+     * @param key                The key of the property.
+     * @param name               The name of the property.
+     * @param propertyVisibility The visibility of the property.
+     * @param visibility         The visibility string under which this property is hidden.
+     *                           This visibility can be a superset of the property visibility to mark
+     *                           it as hidden for only a subset of authorizations.
+     * @param eventData          Data to store with the hidden
+     */
+    default ElementMutation<T> markPropertyHidden(String key, String name, Visibility propertyVisibility, Visibility visibility, Object eventData) {
+        return markPropertyHidden(key, name, propertyVisibility, null, visibility, eventData);
+    }
+
+    /**
+     * Marks a property as hidden for a given visibility.
+     *
+     * @param key                The key of the property.
+     * @param name               The name of the property.
+     * @param propertyVisibility The visibility of the property.
+     * @param timestamp          The timestamp.
+     * @param visibility         The visibility string under which this property is hidden.
+     *                           This visibility can be a superset of the property visibility to mark
+     *                           it as hidden for only a subset of authorizations.
+     */
+    default ElementMutation<T> markPropertyHidden(
+        String key,
+        String name,
+        Visibility propertyVisibility,
+        Long timestamp,
+        Visibility visibility
+    ) {
+        return markPropertyHidden(key, name, propertyVisibility, timestamp, visibility, null);
+    }
+
+    /**
+     * Marks a property as hidden for a given visibility.
+     *
+     * @param key                The key of the property.
+     * @param name               The name of the property.
+     * @param propertyVisibility The visibility of the property.
+     * @param timestamp          The timestamp.
+     * @param visibility         The visibility string under which this property is hidden.
+     *                           This visibility can be a superset of the property visibility to mark
+     *                           it as hidden for only a subset of authorizations.
+     * @param eventData          Data to store with the hidden
+     */
+    ElementMutation<T> markPropertyHidden(
+        String key,
+        String name,
+        Visibility propertyVisibility,
+        Long timestamp,
+        Visibility visibility,
+        Object eventData
+    );
+
+    /**
+     * Marks a property as hidden for a given visibility.
+     *
+     * @param property   The property.
+     * @param visibility The visibility string under which this property is hidden.
+     *                   This visibility can be a superset of the property visibility to mark
+     *                   it as hidden for only a subset of authorizations.
+     */
+    default ElementMutation<T> markPropertyHidden(Property property, Visibility visibility) {
+        return markPropertyHidden(property, visibility, null);
+    }
+
+    /**
+     * Marks a property as hidden for a given visibility.
+     *
+     * @param property   The property.
+     * @param visibility The visibility string under which this property is hidden.
+     *                   This visibility can be a superset of the property visibility to mark
+     *                   it as hidden for only a subset of authorizations.
+     * @param eventData  Data to store with the hidden
+     */
+    default ElementMutation<T> markPropertyHidden(Property property, Visibility visibility, Object eventData) {
+        return markPropertyHidden(property, null, visibility, eventData);
+    }
+
+    /**
+     * Marks a property as hidden for a given visibility.
+     *
+     * @param property   The property.
+     * @param timestamp  The timestamp.
+     * @param visibility The visibility string under which this property is hidden.
+     *                   This visibility can be a superset of the property visibility to mark
+     *                   it as hidden for only a subset of authorizations.
+     */
+    default ElementMutation<T> markPropertyHidden(Property property, Long timestamp, Visibility visibility) {
+        return markPropertyHidden(property, timestamp, visibility, null);
+    }
+
+    /**
+     * Marks a property as hidden for a given visibility.
+     *
+     * @param property   The property.
+     * @param timestamp  The timestamp.
+     * @param visibility The visibility string under which this property is hidden.
+     *                   This visibility can be a superset of the property visibility to mark
+     *                   it as hidden for only a subset of authorizations.
+     */
+    default ElementMutation<T> markPropertyHidden(Property property, Long timestamp, Visibility visibility, Object data) {
+        return markPropertyHidden(
+            property.getKey(),
+            property.getName(),
+            property.getVisibility(),
+            timestamp,
+            visibility,
+            data
+        );
+    }
+
+    /**
+     * Marks a property as visible for a given visibility, effectively undoing markPropertyHidden.
+     *
+     * @param key                The key of the property.
+     * @param name               The name of the property.
+     * @param propertyVisibility The visibility of the property.
+     * @param visibility         The visibility string under which this property is now visible.
+     */
+    default ElementMutation<T> markPropertyVisible(String key, String name, Visibility propertyVisibility, Visibility visibility) {
+        return markPropertyVisible(key, name, propertyVisibility, null, visibility, null);
+    }
+
+    /**
+     * Marks a property as visible for a given visibility, effectively undoing markPropertyHidden.
+     *
+     * @param key                The key of the property.
+     * @param name               The name of the property.
+     * @param propertyVisibility The visibility of the property.
+     * @param visibility         The visibility string under which this property is now visible.
+     * @param eventData          Data to store with the visible
+     */
+    default ElementMutation<T> markPropertyVisible(String key, String name, Visibility propertyVisibility, Visibility visibility, Object eventData) {
+        return markPropertyVisible(key, name, propertyVisibility, null, visibility, eventData);
+    }
+
+    /**
+     * Marks a property as visible for a given visibility, effectively undoing markPropertyHidden.
+     *
+     * @param key                The key of the property.
+     * @param name               The name of the property.
+     * @param propertyVisibility The visibility of the property.
+     * @param timestamp          The timestamp.
+     * @param visibility         The visibility string under which this property is now visible.
+     */
+    default ElementMutation<T> markPropertyVisible(
+        String key,
+        String name,
+        Visibility propertyVisibility,
+        Long timestamp,
+        Visibility visibility
+    ) {
+        return markPropertyVisible(key, name, propertyVisibility, timestamp, visibility, null);
+    }
+
+    /**
+     * Marks a property as visible for a given visibility, effectively undoing markPropertyHidden.
+     *
+     * @param key                The key of the property.
+     * @param name               The name of the property.
+     * @param propertyVisibility The visibility of the property.
+     * @param timestamp          The timestamp.
+     * @param visibility         The visibility string under which this property is now visible.
+     * @param eventData          Data to store with the visible
+     */
+    ElementMutation<T> markPropertyVisible(
+        String key,
+        String name,
+        Visibility propertyVisibility,
+        Long timestamp,
+        Visibility visibility,
+        Object eventData
+    );
+
+    /**
+     * Marks a property as visible for a given visibility, effectively undoing markPropertyHidden.
+     *
+     * @param property   The property.
+     * @param visibility The visibility string under which this property is now visible.
+     */
+    default ElementMutation<T> markPropertyVisible(Property property, Visibility visibility) {
+        return markPropertyVisible(property, null, visibility, null);
+    }
+
+    /**
+     * Marks a property as visible for a given visibility, effectively undoing markPropertyHidden.
+     *
+     * @param property   The property.
+     * @param visibility The visibility string under which this property is now visible.
+     * @param eventData  Data to store with the visible
+     */
+    default ElementMutation<T> markPropertyVisible(Property property, Visibility visibility, Object eventData) {
+        return markPropertyVisible(property, null, visibility, eventData);
+    }
+
+    /**
+     * Marks a property as visible for a given visibility, effectively undoing markPropertyHidden.
+     *
+     * @param property   The property.
+     * @param timestamp  The timestamp.
+     * @param visibility The visibility string under which this property is now visible.
+     */
+    default ElementMutation<T> markPropertyVisible(Property property, Long timestamp, Visibility visibility) {
+        return markPropertyVisible(property, timestamp, visibility, null);
+    }
+
+    /**
+     * Marks a property as visible for a given visibility, effectively undoing markPropertyHidden.
+     *
+     * @param property   The property.
+     * @param timestamp  The timestamp.
+     * @param visibility The visibility string under which this property is now visible.
+     * @param eventData  Data to store with the visible
+     */
+    default ElementMutation<T> markPropertyVisible(Property property, Long timestamp, Visibility visibility, Object eventData) {
+        return markPropertyVisible(
+            property.getKey(),
+            property.getName(),
+            property.getVisibility(),
+            timestamp,
+            visibility,
+            eventData
+        );
+    }
+
+    /**
      * Adds additional visibilities to the element. These visibilities will not effect the Visibility returned from
      * {@link Element#getVisibility()}. These visibilities can also be bypassed by {@link FetchHints}.
      *
@@ -294,6 +537,16 @@ public interface ElementMutation<T extends Element> extends ElementLocation {
      * Gets the additional extended data visibility delete mutations
      */
     Iterable<AdditionalExtendedDataVisibilityDeleteMutation> getAdditionalExtendedDataVisibilityDeletes();
+
+    /**
+     * Gets mark property hidden mutations
+     */
+    Iterable<MarkPropertyHiddenMutation> getMarkPropertyHiddenMutations();
+
+    /**
+     * Gets mark property visible mutations
+     */
+    Iterable<MarkPropertyVisibleMutation> getMarkPropertyVisibleMutations();
 
     /**
      * Sets the index hint of this element.

--- a/core/src/main/java/org/vertexium/mutation/ExistingElementMutationImpl.java
+++ b/core/src/main/java/org/vertexium/mutation/ExistingElementMutationImpl.java
@@ -20,6 +20,8 @@ public abstract class ExistingElementMutationImpl<T extends Element> implements 
     private final List<AdditionalVisibilityDeleteMutation> additionalVisibilityDeleteMutations = new ArrayList<>();
     private final List<AdditionalExtendedDataVisibilityAddMutation> additionalExtendedDataVisibilities = new ArrayList<>();
     private final List<AdditionalExtendedDataVisibilityDeleteMutation> additionalExtendedDataVisibilityDeletes = new ArrayList<>();
+    private final List<MarkPropertyHiddenMutation> markPropertyHiddenMutations = new ArrayList<>();
+    private final List<MarkPropertyVisibleMutation> markPropertyVisibleMutations = new ArrayList<>();
     private final T element;
     private Visibility newElementVisibility;
     private Object newElementVisibilityData;
@@ -310,6 +312,32 @@ public abstract class ExistingElementMutationImpl<T extends Element> implements 
     }
 
     @Override
+    public ElementMutation<T> markPropertyHidden(
+        String key,
+        String name,
+        Visibility propertyVisibility,
+        Long timestamp,
+        Visibility visibility,
+        Object eventData
+    ) {
+        markPropertyHiddenMutations.add(new MarkPropertyHiddenMutation(key, name, propertyVisibility, timestamp, visibility, eventData));
+        return this;
+    }
+
+    @Override
+    public ElementMutation<T> markPropertyVisible(
+        String key,
+        String name,
+        Visibility propertyVisibility,
+        Long timestamp,
+        Visibility visibility,
+        Object eventData
+    ) {
+        markPropertyVisibleMutations.add(new MarkPropertyVisibleMutation(key, name, propertyVisibility, timestamp, visibility, eventData));
+        return this;
+    }
+
+    @Override
     public T getElement() {
         return element;
     }
@@ -365,6 +393,16 @@ public abstract class ExistingElementMutationImpl<T extends Element> implements 
     }
 
     @Override
+    public List<MarkPropertyHiddenMutation> getMarkPropertyHiddenMutations() {
+        return markPropertyHiddenMutations;
+    }
+
+    @Override
+    public List<MarkPropertyVisibleMutation> getMarkPropertyVisibleMutations() {
+        return markPropertyVisibleMutations;
+    }
+
+    @Override
     public ElementMutation<T> setIndexHint(IndexHint indexHint) {
         this.indexHint = indexHint;
         return this;
@@ -401,6 +439,14 @@ public abstract class ExistingElementMutationImpl<T extends Element> implements 
         }
 
         if (extendedDataDeletes.size() > 0) {
+            return true;
+        }
+
+        if (markPropertyHiddenMutations.size() > 0) {
+            return true;
+        }
+
+        if (markPropertyVisibleMutations.size() > 0) {
             return true;
         }
 

--- a/core/src/main/java/org/vertexium/mutation/MarkPropertyHiddenMutation.java
+++ b/core/src/main/java/org/vertexium/mutation/MarkPropertyHiddenMutation.java
@@ -1,0 +1,52 @@
+package org.vertexium.mutation;
+
+import org.vertexium.Visibility;
+
+public class MarkPropertyHiddenMutation {
+    private final String propertyKey;
+    private final String propertyName;
+    private final Visibility propertyVisibility;
+    private final Long timestamp;
+    private final Visibility visibility;
+    private final Object eventData;
+
+    public MarkPropertyHiddenMutation(
+        String propertyKey,
+        String propertyName,
+        Visibility propertyVisibility,
+        Long timestamp,
+        Visibility visibility,
+        Object eventData
+    ) {
+        this.propertyKey = propertyKey;
+        this.propertyName = propertyName;
+        this.propertyVisibility = propertyVisibility;
+        this.timestamp = timestamp;
+        this.visibility = visibility;
+        this.eventData = eventData;
+    }
+
+    public String getPropertyKey() {
+        return propertyKey;
+    }
+
+    public String getPropertyName() {
+        return propertyName;
+    }
+
+    public Visibility getPropertyVisibility() {
+        return propertyVisibility;
+    }
+
+    public Long getTimestamp() {
+        return timestamp;
+    }
+
+    public Visibility getVisibility() {
+        return visibility;
+    }
+
+    public Object getEventData() {
+        return eventData;
+    }
+}

--- a/core/src/main/java/org/vertexium/mutation/MarkPropertyVisibleMutation.java
+++ b/core/src/main/java/org/vertexium/mutation/MarkPropertyVisibleMutation.java
@@ -1,0 +1,52 @@
+package org.vertexium.mutation;
+
+import org.vertexium.Visibility;
+
+public class MarkPropertyVisibleMutation {
+    private final String propertyKey;
+    private final String propertyName;
+    private final Visibility propertyVisibility;
+    private final Long timestamp;
+    private final Visibility visibility;
+    private final Object eventData;
+
+    public MarkPropertyVisibleMutation(
+        String propertyKey,
+        String propertyName,
+        Visibility propertyVisibility,
+        Long timestamp,
+        Visibility visibility,
+        Object eventData
+    ) {
+        this.propertyKey = propertyKey;
+        this.propertyName = propertyName;
+        this.propertyVisibility = propertyVisibility;
+        this.timestamp = timestamp;
+        this.visibility = visibility;
+        this.eventData = eventData;
+    }
+
+    public String getPropertyKey() {
+        return propertyKey;
+    }
+
+    public String getPropertyName() {
+        return propertyName;
+    }
+
+    public Visibility getPropertyVisibility() {
+        return propertyVisibility;
+    }
+
+    public Long getTimestamp() {
+        return timestamp;
+    }
+
+    public Visibility getVisibility() {
+        return visibility;
+    }
+
+    public Object getEventData() {
+        return eventData;
+    }
+}

--- a/core/src/main/java/org/vertexium/query/DefaultGraphQuery.java
+++ b/core/src/main/java/org/vertexium/query/DefaultGraphQuery.java
@@ -50,7 +50,7 @@ public class DefaultGraphQuery extends GraphQueryBase {
             .setIncludeExtendedDataTableNames(true)
             .setIgnoreAdditionalVisibilities(extendedDataFetchHints.isIgnoreAdditionalVisibilities())
             .build();
-        return extendedData(extendedDataFetchHints, new JoinIterable<>(
+        return extendedData(extendedDataFetchHints, new JoinIterable<Element>(
             getIterableFromElementType(ElementType.VERTEX, extendedDataTableNamesFetchHints),
             getIterableFromElementType(ElementType.EDGE, extendedDataTableNamesFetchHints)
         ));

--- a/core/src/main/java/org/vertexium/query/DefaultMultiVertexQuery.java
+++ b/core/src/main/java/org/vertexium/query/DefaultMultiVertexQuery.java
@@ -33,7 +33,7 @@ public class DefaultMultiVertexQuery extends QueryBase implements MultiVertexQue
         Iterable<Vertex> vertices = getGraph().getVertices(IterableUtils.toIterable(getVertexIds()), fetchHints, getParameters().getAuthorizations());
         Iterable<String> edgeIds = new VerticesToEdgeIdsIterable(vertices, getParameters().getAuthorizations());
         Iterable<Edge> edges = getGraph().getEdges(edgeIds, fetchHints, getParameters().getAuthorizations());
-        return extendedData(fetchHints, new JoinIterable<>(vertices, edges));
+        return extendedData(fetchHints, new JoinIterable<Element>(vertices, edges));
     }
 
     public String[] getVertexIds() {

--- a/core/src/main/java/org/vertexium/query/DefaultVertexQuery.java
+++ b/core/src/main/java/org/vertexium/query/DefaultVertexQuery.java
@@ -71,7 +71,7 @@ public class DefaultVertexQuery extends VertexQueryBase implements VertexQuery {
         FetchHints fetchHints = FetchHints.builder()
             .setIncludeExtendedDataTableNames(true)
             .build();
-        return extendedData(extendedDataFetchHints, new JoinIterable<>(
+        return extendedData(extendedDataFetchHints, new JoinIterable<Element>(
             allVertices(fetchHints),
             allEdges(fetchHints)
         ));

--- a/core/src/main/java/org/vertexium/query/QueryBase.java
+++ b/core/src/main/java/org/vertexium/query/QueryBase.java
@@ -37,8 +37,8 @@ public abstract class QueryBase implements Query, SimilarToGraphQuery {
     }
 
     @Override
+    @SuppressWarnings("unchecked")
     public QueryResultsIterable<Vertex> vertices(FetchHints fetchHints) {
-        //noinspection unchecked
         return (QueryResultsIterable<Vertex>) search(EnumSet.of(VertexiumObjectType.VERTEX), fetchHints);
     }
 
@@ -59,8 +59,8 @@ public abstract class QueryBase implements Query, SimilarToGraphQuery {
     }
 
     @Override
+    @SuppressWarnings("unchecked")
     public QueryResultsIterable<Edge> edges(FetchHints fetchHints) {
-        //noinspection unchecked
         return (QueryResultsIterable<Edge>) search(EnumSet.of(VertexiumObjectType.EDGE), fetchHints);
     }
 
@@ -81,8 +81,8 @@ public abstract class QueryBase implements Query, SimilarToGraphQuery {
     }
 
     @Override
+    @SuppressWarnings("unchecked")
     public QueryResultsIterable<ExtendedDataRow> extendedDataRows(FetchHints fetchHints) {
-        //noinspection unchecked
         return (QueryResultsIterable<ExtendedDataRow>) search(EnumSet.of(VertexiumObjectType.EXTENDED_DATA), fetchHints);
     }
 
@@ -244,8 +244,8 @@ public abstract class QueryBase implements Query, SimilarToGraphQuery {
     }
 
     @Override
+    @SuppressWarnings("unchecked")
     public QueryResultsIterable<Element> elements(FetchHints fetchHints) {
-        //noinspection unchecked
         return (QueryResultsIterable<Element>) search(VertexiumObjectType.ELEMENTS, fetchHints);
     }
 

--- a/core/src/main/java/org/vertexium/query/QueryResultsJoinIterable.java
+++ b/core/src/main/java/org/vertexium/query/QueryResultsJoinIterable.java
@@ -7,11 +7,13 @@ import org.vertexium.util.JoinIterable;
 import java.io.IOException;
 
 public class QueryResultsJoinIterable<T extends Element> extends JoinIterable<T> implements QueryResultsIterable<T> {
+    @SuppressWarnings("unchecked")
     public QueryResultsJoinIterable(Iterable<T>... iterables) {
         super(iterables);
     }
 
     @Override
+    @SuppressWarnings("unchecked")
     public <TResult extends AggregationResult> TResult getAggregationResult(String name, Class<? extends TResult> resultType) {
         for (Iterable<? extends T> iterable : getIterables()) {
             if (iterable instanceof QueryResultsIterable) {

--- a/core/src/main/java/org/vertexium/util/ArrayIterable.java
+++ b/core/src/main/java/org/vertexium/util/ArrayIterable.java
@@ -10,6 +10,7 @@ public class ArrayIterable<T> implements Iterable<T> {
     }
 
     @Override
+    @SuppressWarnings("unchecked")
     public Iterator<T> iterator() {
         return new ArrayIterator(this.items);
     }

--- a/core/src/main/java/org/vertexium/util/FilterIterable.java
+++ b/core/src/main/java/org/vertexium/util/FilterIterable.java
@@ -15,6 +15,7 @@ public abstract class FilterIterable<T> extends LookAheadIterable<T, T> implemen
     }
 
     @Override
+    @SuppressWarnings("unchecked")
     protected Iterator<T> createIterator() {
         return (Iterator<T>) this.iterable.iterator();
     }

--- a/core/src/main/java/org/vertexium/util/JavaSerializableUtils.java
+++ b/core/src/main/java/org/vertexium/util/JavaSerializableUtils.java
@@ -25,6 +25,7 @@ public class JavaSerializableUtils {
         }
     }
 
+    @SuppressWarnings("unchecked")
     public static <T> T copy(T value) {
         return (T) bytesToObject(objectToBytes(value));
     }

--- a/core/src/main/java/org/vertexium/util/JoinIterable.java
+++ b/core/src/main/java/org/vertexium/util/JoinIterable.java
@@ -10,8 +10,8 @@ import java.util.Queue;
 public class JoinIterable<T> implements Iterable<T> {
     private final Iterable<? extends T>[] iterables;
 
+    @SuppressWarnings("unchecked")
     public JoinIterable(Iterable<? extends Iterable<? extends T>> iterables) {
-        //noinspection unchecked
         this(Iterables.toArray(iterables, Iterable.class));
     }
 

--- a/core/src/main/java/org/vertexium/util/ObjectUtils.java
+++ b/core/src/main/java/org/vertexium/util/ObjectUtils.java
@@ -12,6 +12,7 @@ public class ObjectUtils {
         return compare(leftObj, rightObj) == 0;
     }
 
+    @SuppressWarnings("unchecked")
     public static int compare(Object first, Object second) {
         if (first == null && second == null) {
             return 0;

--- a/cypher/src/main/java/org/vertexium/cypher/CypherResultWriter.java
+++ b/cypher/src/main/java/org/vertexium/cypher/CypherResultWriter.java
@@ -15,13 +15,13 @@ import static org.vertexium.util.IterableUtils.count;
 import static org.vertexium.util.StreamUtils.stream;
 
 public class CypherResultWriter {
+    @SuppressWarnings("unchecked")
     public String columnValueToString(VertexiumCypherQueryContext ctx, Object o) {
         if (o == null) {
             return columnNullValueToString();
         } else if (o instanceof Optional) {
             return columnValueToString(ctx, ((Optional<?>) o).orElse(null));
         } else if (o instanceof Map) {
-            //noinspection unchecked
             return columnMapValueToString(ctx, (Map<String, Object>) o);
         } else if (o instanceof Double) {
             return columnDoubleValueToString((double) o);

--- a/cypher/src/main/java/org/vertexium/cypher/ast/CypherCstToAstVisitor.java
+++ b/cypher/src/main/java/org/vertexium/cypher/ast/CypherCstToAstVisitor.java
@@ -277,11 +277,11 @@ public class CypherCstToAstVisitor extends CypherBaseVisitor<CypherAstBase> {
     }
 
     @Override
+    @SuppressWarnings("unchecked")
     public CypherMapLiteral<String, CypherAstBase> visitOC_Properties(CypherParser.OC_PropertiesContext ctx) {
         if (ctx == null) {
             return null;
         }
-        //noinspection unchecked
         return (CypherMapLiteral<String, CypherAstBase>) super.visitOC_Properties(ctx);
     }
 
@@ -396,6 +396,7 @@ public class CypherCstToAstVisitor extends CypherBaseVisitor<CypherAstBase> {
         return toBinaryExpressions(ctx.children, this::visitOC_NotExpression);
     }
 
+    @SuppressWarnings("unchecked")
     private <T extends ParseTree> CypherBinaryExpression toBinaryExpressions(List<ParseTree> children, Function<T, CypherAstBase> itemTransform) {
         CypherAstBase left = null;
         CypherBinaryExpression.Op op = null;
@@ -411,7 +412,6 @@ public class CypherCstToAstVisitor extends CypherBaseVisitor<CypherAstBase> {
                     }
                 }
             } else {
-                //noinspection unchecked
                 CypherAstBase childObj = itemTransform.apply((T) child);
                 if (left == null) {
                     left = childObj;

--- a/cypher/src/main/java/org/vertexium/cypher/ast/model/CypherListLiteral.java
+++ b/cypher/src/main/java/org/vertexium/cypher/ast/model/CypherListLiteral.java
@@ -67,6 +67,7 @@ public class CypherListLiteral<TItem> extends CypherLiteral<List<TItem>> impleme
         return stream().map(o -> o == null ? "null" : o.toString()).collect(Collectors.joining(delimiter));
     }
 
+    @SuppressWarnings("unchecked")
     public static <T> CypherListLiteral<T> of(T... items) {
         return new CypherListLiteral<>(Lists.newArrayList(items));
     }

--- a/cypher/src/main/java/org/vertexium/cypher/ast/model/CypherLiteral.java
+++ b/cypher/src/main/java/org/vertexium/cypher/ast/model/CypherLiteral.java
@@ -19,6 +19,7 @@ public class CypherLiteral<T> extends CypherAstBase implements Comparable {
     }
 
     @Override
+    @SuppressWarnings("unchecked")
     public int compareTo(Object o) {
         if (!(getValue() instanceof Comparable)) {
             throw new VertexiumException("Literal value is not comparable (type: " + getValue().getClass().getName() + ")");
@@ -69,6 +70,7 @@ public class CypherLiteral<T> extends CypherAstBase implements Comparable {
         return Stream.of();
     }
 
+    @SuppressWarnings("unchecked")
     public static Object toJava(Object value) {
         if (value instanceof Iterable) {
             value = stream((Iterable<Object>) value)

--- a/cypher/src/main/java/org/vertexium/cypher/executionPlan/CreateNodePatternExecutionStep.java
+++ b/cypher/src/main/java/org/vertexium/cypher/executionPlan/CreateNodePatternExecutionStep.java
@@ -12,6 +12,7 @@ import java.util.List;
 public class CreateNodePatternExecutionStep extends CreateElementPatternExecutionStep {
     private final List<String> labelNames;
 
+    @SuppressWarnings("unchecked")
     public CreateNodePatternExecutionStep(
         String name,
         List<String> labelNames,

--- a/cypher/src/main/java/org/vertexium/cypher/executionPlan/CreateRelationshipPatternExecutionStep.java
+++ b/cypher/src/main/java/org/vertexium/cypher/executionPlan/CreateRelationshipPatternExecutionStep.java
@@ -16,6 +16,7 @@ public class CreateRelationshipPatternExecutionStep extends CreateElementPattern
     private final String leftNodeName;
     private final String rightNodeName;
 
+    @SuppressWarnings("unchecked")
     public CreateRelationshipPatternExecutionStep(
         String name,
         List<String> relTypeNames,

--- a/cypher/src/main/java/org/vertexium/cypher/executionPlan/ExecutionPlanBuilder.java
+++ b/cypher/src/main/java/org/vertexium/cypher/executionPlan/ExecutionPlanBuilder.java
@@ -188,6 +188,7 @@ public class ExecutionPlanBuilder {
         return visitExpression(ctx, UUID.randomUUID().toString(), expression);
     }
 
+    @SuppressWarnings("unchecked")
     public ExecutionStepWithResultName visitExpression(VertexiumCypherQueryContext ctx, String resultName, CypherAstBase expression) {
         if (expression instanceof CypherVariable) {
             return visitVariable(ctx, resultName, (CypherVariable) expression);
@@ -338,6 +339,7 @@ public class ExecutionPlanBuilder {
         return new ListLiteralExecutionStep(resultName, elements);
     }
 
+    @SuppressWarnings("unchecked")
     private ExecutionStepWithResultName visitLiteral(VertexiumCypherQueryContext ctx, String resultName, CypherLiteral expression) {
         Object value = expression.getValue();
         if (value instanceof Map) {
@@ -392,6 +394,7 @@ public class ExecutionPlanBuilder {
         );
     }
 
+    @SuppressWarnings("unchecked")
     private PatternPartExecutionStep visitPatternPart(VertexiumCypherQueryContext ctx, boolean optional, CypherPatternPart patternPart) {
         CypherListLiteral<CypherElementPattern> elementPatterns = patternPart.getElementPatterns();
         List<MatchPartExecutionStep> steps = elementPatterns.stream()

--- a/cypher/src/main/java/org/vertexium/cypher/executionPlan/ListComprehensionExecutionStep.java
+++ b/cypher/src/main/java/org/vertexium/cypher/executionPlan/ListComprehensionExecutionStep.java
@@ -40,6 +40,7 @@ public class ListComprehensionExecutionStep extends ExecutionStepWithChildren im
     }
 
     @Override
+    @SuppressWarnings("unchecked")
     public VertexiumCypherResult execute(VertexiumCypherQueryContext ctx, VertexiumCypherResult source) {
         source = super.execute(ctx, source);
         return source.peek(row -> {

--- a/cypher/src/main/java/org/vertexium/cypher/executionPlan/SetItemExecutionStep.java
+++ b/cypher/src/main/java/org/vertexium/cypher/executionPlan/SetItemExecutionStep.java
@@ -44,6 +44,7 @@ public class SetItemExecutionStep extends ExecutionStepWithChildren {
         });
     }
 
+    @SuppressWarnings("unchecked")
     private void executeEquals(VertexiumCypherQueryContext ctx, CypherResultRow row, Object left, Object right) {
         Element leftElement = (Element) row.get(leftResultName + LookupExecutionStep.SCOPE_ELEMENT_SUFFIX);
         Property leftProperty = (Property) row.get(leftResultName + LookupExecutionStep.SCOPE_PROPERTY_SUFFIX);
@@ -112,6 +113,7 @@ public class SetItemExecutionStep extends ExecutionStepWithChildren {
         throw new VertexiumCypherNotImplemented(String.format("set {left: %s, right: %s}", left, right));
     }
 
+    @SuppressWarnings("unchecked")
     private void executePlusEquals(VertexiumCypherQueryContext ctx, CypherResultRow row, Object left, Object right) {
         if (left instanceof Element) {
             Element leftElement = (Element) left;

--- a/cypher/src/main/java/org/vertexium/cypher/executionPlan/UnwindClauseExecutionStep.java
+++ b/cypher/src/main/java/org/vertexium/cypher/executionPlan/UnwindClauseExecutionStep.java
@@ -30,6 +30,7 @@ public class UnwindClauseExecutionStep extends ExecutionStepWithChildren {
         return source.flatMapCypherResult(this::executeOnRow);
     }
 
+    @SuppressWarnings("unchecked")
     private Stream<CypherResultRow> executeOnRow(CypherResultRow row) {
         Object expressionResult = row.get(expressionResultName);
         row.popScope();

--- a/cypher/src/main/java/org/vertexium/cypher/functions/scalar/PropertiesFunction.java
+++ b/cypher/src/main/java/org/vertexium/cypher/functions/scalar/PropertiesFunction.java
@@ -48,6 +48,7 @@ public class PropertiesFunction extends SimpleCypherFunction {
         throw new VertexiumException("not implemented");
     }
 
+    @SuppressWarnings("unchecked")
     private Map<String, Object> getPropertiesFromMap(VertexiumCypherQueryContext ctx, Map map) {
         return map;
     }

--- a/cypher/src/main/java/org/vertexium/cypher/utils/ObjectUtils.java
+++ b/cypher/src/main/java/org/vertexium/cypher/utils/ObjectUtils.java
@@ -20,6 +20,7 @@ public class ObjectUtils {
         return compare(leftObj, rightObj) == 0;
     }
 
+    @SuppressWarnings("unchecked")
     public static int compare(Object leftObj, Object rightObj) {
         if (leftObj == null && rightObj == null) {
             return 0;

--- a/elasticsearch5/plugin/src/main/java/org/vertexium/elasticsearch5/plugin/VertexiumElasticsearchPlugin.java
+++ b/elasticsearch5/plugin/src/main/java/org/vertexium/elasticsearch5/plugin/VertexiumElasticsearchPlugin.java
@@ -10,6 +10,7 @@ import static java.util.Collections.singletonList;
 
 public class VertexiumElasticsearchPlugin extends Plugin implements SearchPlugin {
     @Override
+    @SuppressWarnings("unchecked")
     public List<QuerySpec<?>> getQueries() {
         return singletonList(new QuerySpec<>(
             VertexiumQueryStringQueryBuilder.NAME,

--- a/elasticsearch5/plugin/src/main/java/org/vertexium/elasticsearch5/plugin/VertexiumQueryStringQueryBuilder.java
+++ b/elasticsearch5/plugin/src/main/java/org/vertexium/elasticsearch5/plugin/VertexiumQueryStringQueryBuilder.java
@@ -76,6 +76,7 @@ public class VertexiumQueryStringQueryBuilder extends QueryStringQueryBuilder {
         throw new RuntimeException("not implemented");
     }
 
+    @SuppressWarnings("unchecked")
     protected FieldNameToVisibilityMap getFieldNameToVisibilityMap(QueryShardContext context) {
         try {
             Map<String, String> results = new HashMap<>();
@@ -90,7 +91,6 @@ public class VertexiumQueryStringQueryBuilder extends QueryStringQueryBuilder {
                 if (elementMetadata == null) {
                     continue;
                 }
-                //noinspection unchecked
                 Map<String, Map<String, String>> meta = (Map<String, Map<String, String>>) elementMetadata.getSourceAsMap().get("_meta");
                 if (meta == null) {
                     continue;

--- a/elasticsearch5/search-index/src/main/java/org/vertexium/elasticsearch5/ElasticsearchEdge.java
+++ b/elasticsearch5/search-index/src/main/java/org/vertexium/elasticsearch5/ElasticsearchEdge.java
@@ -3,6 +3,7 @@ package org.vertexium.elasticsearch5;
 import org.vertexium.*;
 import org.vertexium.mutation.ExistingEdgeMutation;
 
+@SuppressWarnings("unchecked")
 public class ElasticsearchEdge extends ElasticsearchElement implements Edge {
     private String label;
     private String inVertexId;

--- a/elasticsearch5/search-index/src/main/java/org/vertexium/elasticsearch5/ElasticsearchElement.java
+++ b/elasticsearch5/search-index/src/main/java/org/vertexium/elasticsearch5/ElasticsearchElement.java
@@ -97,62 +97,14 @@ public abstract class ElasticsearchElement extends ElementBase {
     }
 
     @Override
-    @SuppressWarnings("deprecation")
-    public Iterable<HistoricalPropertyValue> getHistoricalPropertyValues(Authorizations authorizations) {
-        throw new VertexiumNotSupportedException("getHistoricalPropertyValues is not supported");
-    }
-
-    @Override
-    @SuppressWarnings("deprecation")
-    public Iterable<HistoricalPropertyValue> getHistoricalPropertyValues(Long startTime, Long endTime, Authorizations authorizations) {
-        throw new VertexiumNotSupportedException("getHistoricalPropertyValues is not supported");
-    }
-
-    @Override
-    @SuppressWarnings("deprecation")
-    public Iterable<HistoricalPropertyValue> getHistoricalPropertyValues(String key, String name, Visibility visibility, Authorizations authorizations) {
-        throw new VertexiumNotSupportedException("getHistoricalPropertyValues is not supported");
-    }
-
-    @Override
-    @SuppressWarnings("deprecation")
-    public Iterable<HistoricalPropertyValue> getHistoricalPropertyValues(String key, String name, Visibility visibility, Long startTime, Long endTime, Authorizations authorizations) {
-        throw new VertexiumNotSupportedException("getHistoricalPropertyValues is not supported");
-    }
-
-    @Override
     public <T extends Element> ExistingElementMutation<T> prepareMutation() {
         throw new VertexiumNotSupportedException("prepareMutation is not supported");
     }
 
     @Override
-    public void deleteProperty(String key, String name, Authorizations authorizations) {
-        throw new VertexiumNotSupportedException("deleteProperty is not supported");
-    }
-
-    @Override
-    public void deleteProperty(String key, String name, Visibility visibility, Authorizations authorizations) {
-        throw new VertexiumNotSupportedException("deleteProperty is not supported");
-    }
-
-    @Override
-    public void deleteProperties(String name, Authorizations authorizations) {
-        throw new VertexiumNotSupportedException("deleteProperties is not supported");
-    }
-
-    @Override
-    public void softDeleteProperty(String key, String name, Object eventData, Authorizations authorizations) {
-        throw new VertexiumNotSupportedException("softDeleteProperty is not supported");
-    }
-
-    @Override
+    @Deprecated
     public void softDeleteProperty(String key, String name, Visibility visibility, Object eventData, Authorizations authorizations) {
         throw new VertexiumNotSupportedException("softDeleteProperty is not supported");
-    }
-
-    @Override
-    public void softDeleteProperties(String name, Object eventData, Authorizations authorizations) {
-        throw new VertexiumNotSupportedException("softDeleteProperties is not supported");
     }
 
     @Override
@@ -161,66 +113,12 @@ public abstract class ElasticsearchElement extends ElementBase {
     }
 
     @Override
-    public void addPropertyValue(String key, String name, Object value, Visibility visibility, Authorizations authorizations) {
-        throw new VertexiumNotSupportedException("addPropertyValue is not supported");
-    }
-
-    @Override
-    public void addPropertyValue(String key, String name, Object value, Metadata metadata, Visibility visibility, Authorizations authorizations) {
-        throw new VertexiumNotSupportedException("addPropertyValue is not supported");
-    }
-
-    @Override
-    public void setProperty(String name, Object value, Visibility visibility, Authorizations authorizations) {
-        throw new VertexiumNotSupportedException("setProperty is not supported");
-    }
-
-    @Override
-    public void setProperty(String name, Object value, Metadata metadata, Visibility visibility, Authorizations authorizations) {
-        throw new VertexiumNotSupportedException("setProperty is not supported");
-    }
-
-    @Override
     public Authorizations getAuthorizations() {
         return authorizations;
     }
 
     @Override
-    public void markPropertyHidden(
-        String key,
-        String name,
-        Visibility propertyVisibility,
-        Visibility visibility,
-        Object eventData,
-        Authorizations authorizations
-    ) {
-        throw new VertexiumNotSupportedException("markPropertyHidden is not supported");
-    }
-
-    @Override
-    public void markPropertyHidden(
-        String key,
-        String name,
-        Visibility propertyVisibility,
-        Long timestamp,
-        Visibility visibility,
-        Object eventData,
-        Authorizations authorizations
-    ) {
-        throw new VertexiumNotSupportedException("markPropertyHidden is not supported");
-    }
-
-    @Override
-    public void markPropertyHidden(
-        Property property,
-        Visibility visibility,
-        Object eventData,
-        Authorizations authorizations
-    ) {
-        throw new VertexiumNotSupportedException("markPropertyHidden is not supported");
-    }
-
-    @Override
+    @Deprecated
     public void markPropertyHidden(
         Property property,
         Long timestamp,
@@ -229,52 +127,6 @@ public abstract class ElasticsearchElement extends ElementBase {
         Authorizations authorizations
     ) {
         throw new VertexiumNotSupportedException("markPropertyHidden is not supported");
-    }
-
-    @Override
-    public void markPropertyVisible(
-        String key,
-        String name,
-        Visibility propertyVisibility,
-        Visibility visibility,
-        Object eventData,
-        Authorizations authorizations
-    ) {
-        throw new VertexiumNotSupportedException("markPropertyVisible is not supported");
-    }
-
-    @Override
-    public void markPropertyVisible(
-        String key,
-        String name,
-        Visibility propertyVisibility,
-        Long timestamp,
-        Visibility visibility,
-        Object eventData,
-        Authorizations authorizations
-    ) {
-        throw new VertexiumNotSupportedException("markPropertyVisible is not supported");
-    }
-
-    @Override
-    public void markPropertyVisible(
-        Property property,
-        Visibility visibility,
-        Object eventData,
-        Authorizations authorizations
-    ) {
-        throw new VertexiumNotSupportedException("markPropertyVisible is not supported");
-    }
-
-    @Override
-    public void markPropertyVisible(
-        Property property,
-        Long timestamp,
-        Visibility visibility,
-        Object eventData,
-        Authorizations authorizations
-    ) {
-        throw new VertexiumNotSupportedException("markPropertyVisible is not supported");
     }
 
     @Override

--- a/elasticsearch5/search-index/src/main/java/org/vertexium/elasticsearch5/ElasticsearchVertex.java
+++ b/elasticsearch5/search-index/src/main/java/org/vertexium/elasticsearch5/ElasticsearchVertex.java
@@ -4,6 +4,7 @@ import org.vertexium.*;
 import org.vertexium.mutation.ExistingElementMutation;
 import org.vertexium.query.VertexQuery;
 
+@SuppressWarnings("unchecked")
 public class ElasticsearchVertex extends ElasticsearchElement implements Vertex {
     private String className = ElasticsearchElement.class.getSimpleName();
 

--- a/elasticsearch5/search-index/src/test/java/org/vertexium/elasticsearch5/Elasticsearch5SearchIndexTest.java
+++ b/elasticsearch5/search-index/src/test/java/org/vertexium/elasticsearch5/Elasticsearch5SearchIndexTest.java
@@ -55,6 +55,7 @@ public class Elasticsearch5SearchIndexTest extends GraphTestBase {
     }
 
     @Override
+    @SuppressWarnings("unchecked")
     protected Graph createGraph() {
         InMemoryGraphConfiguration configuration = new InMemoryGraphConfiguration(elasticsearchResource.createConfig());
         return InMemoryGraph.create(configuration);
@@ -99,7 +100,7 @@ public class Elasticsearch5SearchIndexTest extends GraphTestBase {
     @Test
     public void testQueryExecutionCountWhenPaging() {
         graph.prepareVertex("v1", VISIBILITY_A).save(AUTHORIZATIONS_A);
-        graph.addVertex("v2", VISIBILITY_A, AUTHORIZATIONS_A);
+        graph.prepareVertex("v2", VISIBILITY_A).save(AUTHORIZATIONS_A);
         graph.flush();
 
         long startingNumQueries = getNumQueries();
@@ -128,8 +129,8 @@ public class Elasticsearch5SearchIndexTest extends GraphTestBase {
         Elasticsearch5SearchIndex searchIndex = (Elasticsearch5SearchIndex) ((GraphWithSearchIndex) graph).getSearchIndex();
         searchIndex.getConfig().getGraphConfiguration().set(GraphConfiguration.SEARCH_INDEX_PROP_PREFIX + "." + ElasticsearchSearchIndexConfiguration.QUERY_PAGE_SIZE, 1);
 
-        graph.addVertex("v1", VISIBILITY_A, AUTHORIZATIONS_A);
-        graph.addVertex("v2", VISIBILITY_A, AUTHORIZATIONS_A);
+        graph.prepareVertex("v1", VISIBILITY_A).save(AUTHORIZATIONS_A);
+        graph.prepareVertex("v2", VISIBILITY_A).save(AUTHORIZATIONS_A);
         graph.flush();
 
         long startingNumQueries = getNumQueries();
@@ -141,7 +142,7 @@ public class Elasticsearch5SearchIndexTest extends GraphTestBase {
         searchIndex = (Elasticsearch5SearchIndex) ((GraphWithSearchIndex) graph).getSearchIndex();
         searchIndex.getConfig().getGraphConfiguration().set(GraphConfiguration.SEARCH_INDEX_PROP_PREFIX + "." + ElasticsearchSearchIndexConfiguration.QUERY_PAGE_SIZE, 2);
 
-        graph.addVertex("v3", VISIBILITY_A, AUTHORIZATIONS_A);
+        graph.prepareVertex("v3", VISIBILITY_A).save(AUTHORIZATIONS_A);
         graph.flush();
 
         vertices = graph.query(AUTHORIZATIONS_A).vertices();
@@ -188,9 +189,9 @@ public class Elasticsearch5SearchIndexTest extends GraphTestBase {
 
     @Test
     public void testQueryReturningElasticsearchEdge() {
-        graph.addVertex("v1", VISIBILITY_A, AUTHORIZATIONS_A);
-        graph.addVertex("v2", VISIBILITY_A, AUTHORIZATIONS_A);
-        graph.addEdge("e1", "v1", "v2", LABEL_LABEL1, VISIBILITY_A, AUTHORIZATIONS_A);
+        graph.prepareVertex("v1", VISIBILITY_A).save(AUTHORIZATIONS_A);
+        graph.prepareVertex("v2", VISIBILITY_A).save(AUTHORIZATIONS_A);
+        graph.prepareEdge("e1", "v1", "v2", LABEL_LABEL1, VISIBILITY_A).save(AUTHORIZATIONS_A);
         graph.flush();
 
         QueryResultsIterable<Edge> edges = graph.query(AUTHORIZATIONS_A)
@@ -206,9 +207,9 @@ public class Elasticsearch5SearchIndexTest extends GraphTestBase {
 
     @Test
     public void testQueryReturningElasticsearchVertex() {
-        graph.addVertex("v1", VISIBILITY_A, AUTHORIZATIONS_A);
-        graph.addVertex("v2", VISIBILITY_B, AUTHORIZATIONS_B);
-        graph.addEdge("e1", "v1", "v2", LABEL_LABEL1, VISIBILITY_A, AUTHORIZATIONS_A);
+        graph.prepareVertex("v1", VISIBILITY_A).save(AUTHORIZATIONS_A);
+        graph.prepareVertex("v2", VISIBILITY_B).save(AUTHORIZATIONS_B);
+        graph.prepareEdge("e1", "v1", "v2", LABEL_LABEL1, VISIBILITY_A).save(AUTHORIZATIONS_A);
         graph.flush();
 
         QueryResultsIterable<Vertex> vertices = graph.query(AUTHORIZATIONS_B)
@@ -221,9 +222,9 @@ public class Elasticsearch5SearchIndexTest extends GraphTestBase {
 
     @Test(expected = VertexiumNotSupportedException.class)
     public void testRetrievingVerticesFromElasticsearchEdge() {
-        graph.addVertex("v1", VISIBILITY_A, AUTHORIZATIONS_A);
-        graph.addVertex("v2", VISIBILITY_A, AUTHORIZATIONS_A);
-        graph.addEdge("e1", "v1", "v2", LABEL_LABEL1, VISIBILITY_A, AUTHORIZATIONS_A);
+        graph.prepareVertex("v1", VISIBILITY_A).save(AUTHORIZATIONS_A);
+        graph.prepareVertex("v2", VISIBILITY_A).save(AUTHORIZATIONS_A);
+        graph.prepareEdge("e1", "v1", "v2", LABEL_LABEL1, VISIBILITY_A).save(AUTHORIZATIONS_A);
         graph.flush();
 
         QueryResultsIterable<Edge> edges = graph.query(AUTHORIZATIONS_A)

--- a/inmemory/src/main/java/org/vertexium/inmemory/InMemoryEdge.java
+++ b/inmemory/src/main/java/org/vertexium/inmemory/InMemoryEdge.java
@@ -6,6 +6,7 @@ import org.vertexium.inmemory.mutations.EdgeSetupMutation;
 import org.vertexium.mutation.ExistingEdgeMutation;
 import org.vertexium.search.IndexHint;
 
+@SuppressWarnings("unchecked")
 public class InMemoryEdge extends InMemoryElement<InMemoryEdge> implements Edge {
     private final EdgeSetupMutation edgeSetupMutation;
 
@@ -82,7 +83,6 @@ public class InMemoryEdge extends InMemoryElement<InMemoryEdge> implements Edge 
     }
 
     @Override
-    @SuppressWarnings("unchecked")
     public ExistingEdgeMutation prepareMutation() {
         return new ExistingEdgeMutation(this) {
             @Override

--- a/inmemory/src/main/java/org/vertexium/inmemory/InMemoryGraph.java
+++ b/inmemory/src/main/java/org/vertexium/inmemory/InMemoryGraph.java
@@ -244,6 +244,7 @@ public class InMemoryGraph extends GraphBaseWithSearchIndex {
     }
 
     @Override
+    @SuppressWarnings("deprecation")
     public void softDeleteVertex(Vertex vertex, Long timestamp, Object eventData, Authorizations authorizations) {
         if (!((InMemoryVertex) vertex).canRead(authorizations)) {
             return;
@@ -408,6 +409,7 @@ public class InMemoryGraph extends GraphBaseWithSearchIndex {
         };
     }
 
+    @SuppressWarnings("unchecked")
     private Edge savePreparedEdge(final EdgeBuilderBase edgeBuilder, final String outVertexId, final String inVertexId, Long timestamp, Authorizations authorizations) {
         if (timestamp == null) {
             timestamp = IncreasingTime.currentTimeMillis();

--- a/inmemory/src/main/java/org/vertexium/inmemory/InMemoryTableElement.java
+++ b/inmemory/src/main/java/org/vertexium/inmemory/InMemoryTableElement.java
@@ -47,18 +47,20 @@ public abstract class InMemoryTableElement<TElement extends InMemoryElement> imp
         return findFirstMutation(ElementTimestampMutation.class).getTimestamp();
     }
 
+    @SuppressWarnings("unchecked")
     protected <T extends Mutation> T findLastMutation(Class<T> clazz) {
         List<Mutation> filteredMutations = getFilteredMutations(m -> clazz.isAssignableFrom(m.getClass()));
-        //noinspection unchecked
         return filteredMutations.isEmpty() ? null : (T) filteredMutations.get(filteredMutations.size() - 1);
     }
 
+    @SuppressWarnings("unchecked")
     protected <T extends Mutation> T findFirstMutation(Class<T> clazz) {
         List<Mutation> filteredMutations = getFilteredMutations(m -> clazz.isAssignableFrom(m.getClass()));
         //noinspection unchecked
         return filteredMutations.isEmpty() ? null : (T) filteredMutations.get(0);
     }
 
+    @SuppressWarnings("unchecked")
     protected <T extends Mutation> Iterable<T> findMutations(Class<T> clazz) {
         //noinspection unchecked
         return (Iterable<T>) getFilteredMutations(m -> clazz.isAssignableFrom(m.getClass()));
@@ -106,6 +108,7 @@ public abstract class InMemoryTableElement<TElement extends InMemoryElement> imp
         }
     }
 
+    @SuppressWarnings("unchecked")
     public Stream<HistoricalEvent> getHistoricalEvents(
         InMemoryGraph graph,
         HistoricalEventId after,
@@ -163,7 +166,6 @@ public abstract class InMemoryTableElement<TElement extends InMemoryElement> imp
                 if (historicalEventsFetchHints.isIncludePropertyValues()) {
                     value = addPropertyValueMutation.getValue();
                     if (value instanceof StreamingPropertyValueRef) {
-                        //noinspection unchecked
                         value = ((StreamingPropertyValueRef) value).toStreamingPropertyValue(graph, timestamp);
                     }
                 } else {

--- a/inmemory/src/main/java/org/vertexium/inmemory/InMemoryVertex.java
+++ b/inmemory/src/main/java/org/vertexium/inmemory/InMemoryVertex.java
@@ -12,6 +12,7 @@ import org.vertexium.util.FilterIterable;
 import java.util.HashMap;
 import java.util.Map;
 
+@SuppressWarnings("unchecked")
 public class InMemoryVertex extends InMemoryElement<InMemoryVertex> implements Vertex {
     public InMemoryVertex(
         InMemoryGraph graph,
@@ -335,7 +336,6 @@ public class InMemoryVertex extends InMemoryElement<InMemoryVertex> implements V
     }
 
     @Override
-    @SuppressWarnings("unchecked")
     public ExistingElementMutation<Vertex> prepareMutation() {
         return new ExistingElementMutationImpl<Vertex>(this) {
             @Override

--- a/inmemory/src/test/java/org/vertexium/inmemory/InMemoryGraphTest.java
+++ b/inmemory/src/test/java/org/vertexium/inmemory/InMemoryGraphTest.java
@@ -63,6 +63,7 @@ public class InMemoryGraphTest extends GraphTestBase {
     }
 
     @Test
+    @SuppressWarnings("unchecked")
     public void testStrictTyping() {
         Map<String, String> config = createConfig();
         config.put(GraphConfiguration.STRICT_TYPING, "true");
@@ -70,10 +71,13 @@ public class InMemoryGraphTest extends GraphTestBase {
 
         g.defineProperty("prop1").dataType(String.class).define();
 
-        Vertex v = g.addVertex("v1", VISIBILITY_A, AUTHORIZATIONS_A);
-        v.addPropertyValue("k1", "prop1", "value1", VISIBILITY_A, AUTHORIZATIONS_A);
+        Vertex v = g.prepareVertex("v1", VISIBILITY_A)
+            .addPropertyValue("k1", "prop1", "value1", VISIBILITY_A)
+            .save(AUTHORIZATIONS_A);
         try {
-            v.addPropertyValue("k1", "prop2", "value1", VISIBILITY_A, AUTHORIZATIONS_A);
+            v.prepareMutation()
+                .addPropertyValue("k1", "prop2", "value1", VISIBILITY_A)
+                .save(AUTHORIZATIONS_A);
             throw new RuntimeException("Expected a type exception");
         } catch (VertexiumTypeException ex) {
             assertEquals("prop2", ex.getName());

--- a/kryo-serializer/src/main/java/org/vertexium/serializer/kryo/KryoFactory.java
+++ b/kryo-serializer/src/main/java/org/vertexium/serializer/kryo/KryoFactory.java
@@ -85,6 +85,7 @@ public class KryoFactory {
         }
 
         @Override
+        @SuppressWarnings("unchecked")
         public Object read(Kryo kryo, Input input, Class<Object> type) {
             OldGeoPoint old = (OldGeoPoint) defaultSerializer.read(kryo, input, type);
             return new GeoPoint(old.latitude, old.longitude, old.altitude, old.description);

--- a/kryo-serializer/src/main/java/org/vertexium/serializer/kryo/KryoVertexiumSerializer.java
+++ b/kryo-serializer/src/main/java/org/vertexium/serializer/kryo/KryoVertexiumSerializer.java
@@ -24,6 +24,7 @@ public class KryoVertexiumSerializer implements VertexiumSerializer {
     }
 
     @Override
+    @SuppressWarnings("unchecked")
     public <T> T bytesToObject(byte[] bytes) {
         if (bytes == null || bytes.length == 0) {
             return null;

--- a/kryo-serializer/src/main/java/org/vertexium/serializer/kryo/quickSerializers/BigDecimalQuickTypeSerializer.java
+++ b/kryo-serializer/src/main/java/org/vertexium/serializer/kryo/quickSerializers/BigDecimalQuickTypeSerializer.java
@@ -14,6 +14,7 @@ public class BigDecimalQuickTypeSerializer implements QuickTypeSerializer {
     }
 
     @Override
+    @SuppressWarnings("unchecked")
     public <T> T valueToObject(byte[] data) {
         return (T) new BigDecimal(new String(data, 1, data.length - 1));
     }

--- a/kryo-serializer/src/main/java/org/vertexium/serializer/kryo/quickSerializers/DateQuickTypeSerializer.java
+++ b/kryo-serializer/src/main/java/org/vertexium/serializer/kryo/quickSerializers/DateQuickTypeSerializer.java
@@ -12,6 +12,7 @@ public class DateQuickTypeSerializer implements QuickTypeSerializer {
     }
 
     @Override
+    @SuppressWarnings("unchecked")
     public <T> T valueToObject(byte[] data) {
         return (T) new Date((long) longQuickTypeSerializer.valueToObject(data));
     }

--- a/kryo-serializer/src/main/java/org/vertexium/serializer/kryo/quickSerializers/DoubleQuickTypeSerializer.java
+++ b/kryo-serializer/src/main/java/org/vertexium/serializer/kryo/quickSerializers/DoubleQuickTypeSerializer.java
@@ -13,6 +13,7 @@ public class DoubleQuickTypeSerializer implements QuickTypeSerializer {
     }
 
     @Override
+    @SuppressWarnings("unchecked")
     public <T> T valueToObject(byte[] data) {
         ByteBuffer buffer = ByteBuffer.wrap(data);
         buffer.get();

--- a/kryo-serializer/src/main/java/org/vertexium/serializer/kryo/quickSerializers/KryoQuickTypeSerializer.java
+++ b/kryo-serializer/src/main/java/org/vertexium/serializer/kryo/quickSerializers/KryoQuickTypeSerializer.java
@@ -24,6 +24,7 @@ public class KryoQuickTypeSerializer implements QuickTypeSerializer {
     }
 
     @Override
+    @SuppressWarnings("unchecked")
     public <T> T valueToObject(byte[] data) {
         Input input = new UnsafeInput(data);
         input.read();

--- a/kryo-serializer/src/main/java/org/vertexium/serializer/kryo/quickSerializers/LongQuickTypeSerializer.java
+++ b/kryo-serializer/src/main/java/org/vertexium/serializer/kryo/quickSerializers/LongQuickTypeSerializer.java
@@ -22,6 +22,7 @@ public class LongQuickTypeSerializer implements QuickTypeSerializer {
     }
 
     @Override
+    @SuppressWarnings("unchecked")
     public <T> T valueToObject(byte[] data) {
         long l = ((((long) data[1]) << 56)
             | (((long) data[2] & 0xff) << 48)

--- a/kryo-serializer/src/main/java/org/vertexium/serializer/kryo/quickSerializers/StringQuickTypeSerializer.java
+++ b/kryo-serializer/src/main/java/org/vertexium/serializer/kryo/quickSerializers/StringQuickTypeSerializer.java
@@ -1,9 +1,10 @@
 package org.vertexium.serializer.kryo.quickSerializers;
 
 import java.nio.charset.Charset;
+import java.nio.charset.StandardCharsets;
 
 public class StringQuickTypeSerializer implements QuickTypeSerializer {
-    private Charset charset = Charset.forName("utf8");
+    private Charset charset = StandardCharsets.UTF_8;
 
     @Override
     public byte[] objectToBytes(Object value) {
@@ -15,6 +16,7 @@ public class StringQuickTypeSerializer implements QuickTypeSerializer {
     }
 
     @Override
+    @SuppressWarnings("unchecked")
     public <T> T valueToObject(byte[] data) {
         return (T) new String(data, 1, data.length - 1, charset);
     }

--- a/multimodule-test/accumulo-elasticsearch5/src/test/java/org/vertexium/multimodule/AccumuloElasticsearch5Test.java
+++ b/multimodule-test/accumulo-elasticsearch5/src/test/java/org/vertexium/multimodule/AccumuloElasticsearch5Test.java
@@ -138,8 +138,10 @@ public class AccumuloElasticsearch5Test extends AccumuloGraphTestBase {
     public void testDocumentMissingHandler() throws Exception {
         TestElasticsearch5ExceptionHandler.authorizations = AUTHORIZATIONS_ALL;
 
-        graph.addVertex("v1", VISIBILITY_A, AUTHORIZATIONS_A);
-        graph.addVertex("v2", VISIBILITY_A, AUTHORIZATIONS_A);
+        graph.prepareVertex("v1", VISIBILITY_A)
+            .save(AUTHORIZATIONS_A);
+        graph.prepareVertex("v2", VISIBILITY_A)
+            .save(AUTHORIZATIONS_A);
         graph.flush();
 
         elasticsearchResource.clearIndices(getSearchIndex());

--- a/pom.xml
+++ b/pom.xml
@@ -53,7 +53,6 @@
     </developers>
 
     <properties>
-        <java.compiler.showWarnings>true</java.compiler.showWarnings>
         <java.source.version>1.8</java.source.version>
         <java.target.version>1.8</java.target.version>
         <java.release.version>1.8</java.release.version>
@@ -236,7 +235,14 @@
                 <configuration>
                     <source>${java.source.version}</source>
                     <target>${java.target.version}</target>
-                    <showWarnings>${java.compiler.showWarnings}</showWarnings>
+                    <showWarnings>true</showWarnings>
+                    <failOnWarning>true</failOnWarning>
+                    <!-- Maven doesn't detect deprecation warnings without this set to true -->
+                    <showDeprecation>true</showDeprecation>
+                    <compilerArgs>
+                        <!-- Maven doesn't detect unchecked warnings without this lint argument -->
+                        <arg>-Xlint:unchecked</arg>
+                    </compilerArgs>
                 </configuration>
             </plugin>
             <plugin>

--- a/test/src/main/java/org/vertexium/test/VertexiumSerializerTestBase.java
+++ b/test/src/main/java/org/vertexium/test/VertexiumSerializerTestBase.java
@@ -278,7 +278,7 @@ public abstract class VertexiumSerializerTestBase {
     protected abstract byte[] getGeoPolygonBytes();
 
     protected <T> void testValue(T value, byte[] bytes, TestValueCallback<T> fn) {
-        SerializableObject serializableObject = new SerializableObject<T>();
+        SerializableObject<T> serializableObject = new SerializableObject<>();
         serializableObject.a_start = "START";
         serializableObject.b_value = value;
         serializableObject.z_end = "END";

--- a/test/src/main/java/org/vertexium/test/util/VertexiumAssert.java
+++ b/test/src/main/java/org/vertexium/test/util/VertexiumAssert.java
@@ -122,6 +122,7 @@ public class VertexiumAssert {
         graphEvents.clear();
     }
 
+    @SuppressWarnings("unchecked")
     public static <T> void assertSet(Set<T> set, T... values) {
         assertEquals("size mismatch", values.length, set.size());
         for (T value : values) {


### PR DESCRIPTION
  - Graph.addVertex
  - Graph.addEdge
  - Element.deleteProperty
  - Element.setProperty
  - Element.markPropertyHidden
  - Element.markPropertyVisible