### PR TITLE
Changes to ES bulk update queue

### DIFF
--- a/core/src/main/java/org/vertexium/util/VertexiumReadWriteLock.java
+++ b/core/src/main/java/org/vertexium/util/VertexiumReadWriteLock.java
@@ -1,0 +1,13 @@
+package org.vertexium.util;
+
+import java.util.function.Supplier;
+
+public interface VertexiumReadWriteLock {
+    <T> T executeInReadLock(Supplier<T> fn);
+
+    void executeInReadLock(Runnable fn);
+
+    <T> T executeInWriteLock(Supplier<T> fn);
+
+    void executeInWriteLock(Runnable fn);
+}

--- a/core/src/main/java/org/vertexium/util/VertexiumStampedLock.java
+++ b/core/src/main/java/org/vertexium/util/VertexiumStampedLock.java
@@ -1,53 +1,52 @@
 package org.vertexium.util;
 
-import java.util.concurrent.locks.ReadWriteLock;
-import java.util.concurrent.locks.ReentrantReadWriteLock;
+import java.util.concurrent.locks.StampedLock;
 import java.util.function.Supplier;
 
-public class VertexiumReentrantReadWriteLock implements VertexiumReadWriteLock {
-    private final ReadWriteLock lock = new ReentrantReadWriteLock();
+public class VertexiumStampedLock implements VertexiumReadWriteLock {
+    private final StampedLock lock = new StampedLock();
 
-    public ReadWriteLock getLock() {
+    public StampedLock getLock() {
         return lock;
     }
 
     @Override
     public <T> T executeInReadLock(Supplier<T> fn) {
-        lock.readLock().lock();
+        long stamp = lock.readLock();
         try {
             return fn.get();
         } finally {
-            lock.readLock().unlock();
+            lock.unlockRead(stamp);
         }
     }
 
     @Override
     public void executeInReadLock(Runnable fn) {
-        lock.readLock().lock();
+        long stamp = lock.readLock();
         try {
             fn.run();
         } finally {
-            lock.readLock().unlock();
+            lock.unlockRead(stamp);
         }
     }
 
     @Override
     public <T> T executeInWriteLock(Supplier<T> fn) {
-        lock.writeLock().lock();
+        long stamp = lock.writeLock();
         try {
             return fn.get();
         } finally {
-            lock.writeLock().unlock();
+            lock.unlockWrite(stamp);
         }
     }
 
     @Override
     public void executeInWriteLock(Runnable fn) {
-        lock.writeLock().lock();
+        long stamp = lock.writeLock();
         try {
             fn.run();
         } finally {
-            lock.writeLock().unlock();
+            lock.unlockWrite(stamp);
         }
     }
 }

--- a/elasticsearch5/search-index/src/main/java/org/vertexium/elasticsearch5/bulk/BulkItemList.java
+++ b/elasticsearch5/search-index/src/main/java/org/vertexium/elasticsearch5/bulk/BulkItemList.java
@@ -1,12 +1,13 @@
 package org.vertexium.elasticsearch5.bulk;
 
-import org.vertexium.util.VertexiumReentrantReadWriteLock;
+import org.vertexium.util.VertexiumReadWriteLock;
+import org.vertexium.util.VertexiumStampedLock;
 
 import java.util.LinkedList;
 import java.util.List;
 
 public class BulkItemList {
-    private final VertexiumReentrantReadWriteLock lock = new VertexiumReentrantReadWriteLock();
+    private final VertexiumReadWriteLock lock = new VertexiumStampedLock();
     private final LinkedList<BulkItem> items = new LinkedList<>();
 
     public void add(BulkItem bulkItem) {


### PR DESCRIPTION
- Switch to using StampedLock for performance (https://blog.overops.com/java-8-stampedlocks-vs-readwritelocks-and-synchronized/ has some benchmarks)
- Expose queue submittedItems as a metric
- When waiting for an item to complete be sure to process the failed items because it could be one of those items

These are some tweaks I made on my project that gave better performance and fixed a couple conditions