### PR TITLE
Add term aggregation result attributes

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,6 @@
+# v4.8.1
+* Added: Term aggregation result includes `sum_other_doc_count` and `doc_count_error_upper_bound`
+
 # v4.8.0
 * Added: Option to refresh on flush as opposed to flushing at query time
 * Added: Graph.getElements - get multiple elements (vertices and edges) with one call

--- a/core/src/main/java/org/vertexium/query/DefaultGraphQueryIterableWithAggregations.java
+++ b/core/src/main/java/org/vertexium/query/DefaultGraphQueryIterableWithAggregations.java
@@ -87,14 +87,19 @@ public class DefaultGraphQueryIterableWithAggregations<T extends VertexiumObject
         Map<Object, List<T>> elementsByProperty = getElementsByProperty(it, propertyName, o -> o);
         elementsByProperty = collapseBucketsByCase(elementsByProperty);
 
+        long other = 0;
         List<TermsBucket> buckets = new ArrayList<>();
         for (Map.Entry<Object, List<T>> entry : elementsByProperty.entrySet()) {
             Object key = entry.getKey();
             int count = entry.getValue().size();
-            Map<String, AggregationResult> nestedResults = getNestedResults(agg.getNestedAggregations(), entry.getValue());
-            buckets.add(new TermsBucket(key, count, nestedResults));
+            if (agg.getSize() == null || buckets.size() < agg.getSize()) {
+                Map<String, AggregationResult> nestedResults = getNestedResults(agg.getNestedAggregations(), entry.getValue());
+                buckets.add(new TermsBucket(key, count, nestedResults));
+            } else {
+                other += count;
+            }
         }
-        return new TermsResult(buckets);
+        return new TermsResult(buckets, other, 0);
     }
 
     private Map<Object, List<T>> collapseBucketsByCase(Map<Object, List<T>> elementsByProperty) {

--- a/core/src/main/java/org/vertexium/query/TermsResult.java
+++ b/core/src/main/java/org/vertexium/query/TermsResult.java
@@ -2,12 +2,30 @@ package org.vertexium.query;
 
 public class TermsResult extends AggregationResult {
     private final Iterable<TermsBucket> buckets;
+    private final long sumOfOtherDocCounts;
+    private final long docCountErrorUpperBound;
 
     public TermsResult(Iterable<TermsBucket> buckets) {
         this.buckets = buckets;
+        this.sumOfOtherDocCounts = 0;
+        this.docCountErrorUpperBound = 0;
+    }
+
+    public TermsResult(Iterable<TermsBucket> buckets, long sumOfOtherDocCounts, long docCountErrorUpperBound) {
+        this.buckets = buckets;
+        this.sumOfOtherDocCounts = sumOfOtherDocCounts;
+        this.docCountErrorUpperBound = docCountErrorUpperBound;
     }
 
     public Iterable<TermsBucket> getBuckets() {
         return buckets;
+    }
+
+    public long getSumOfOtherDocCounts() {
+        return sumOfOtherDocCounts;
+    }
+
+    public long getDocCountErrorUpperBound() {
+        return docCountErrorUpperBound;
     }
 }


### PR DESCRIPTION
Adds 2 attributes to the TermResult object

1. `docCountErrorUpperBound`
1. `sumOfOtherDocCounts`