### PR TITLE
Add a Count of Elements Missing a Field for TermsAggregation

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,6 @@
 # v4.8.1
 * Added: Term aggregation result includes `sum_other_doc_count` and `doc_count_error_upper_bound`
+* Added: Term aggregation parameter named `includeHasNotCount` to include a count of the number of element missing the aggregated property. This is false by default.
 
 # v4.8.0
 * Added: Option to refresh on flush as opposed to flushing at query time

--- a/core/src/main/java/org/vertexium/query/TermsAggregation.java
+++ b/core/src/main/java/org/vertexium/query/TermsAggregation.java
@@ -45,6 +45,11 @@ public class TermsAggregation extends Aggregation implements SupportsNestedAggre
         return includeHasNotCount;
     }
 
+    /**
+     * Setting this parameter to true will cause the aggregation to compute
+     * the number of elements that do not have a value for the property
+     * being aggregated on.
+     */
     public void setIncludeHasNotCount(boolean includeHasNotCount) {
         this.includeHasNotCount = includeHasNotCount;
     }

--- a/core/src/main/java/org/vertexium/query/TermsAggregation.java
+++ b/core/src/main/java/org/vertexium/query/TermsAggregation.java
@@ -8,6 +8,7 @@ public class TermsAggregation extends Aggregation implements SupportsNestedAggre
     private final String propertyName;
     private final List<Aggregation> nestedAggregations = new ArrayList<>();
     private Integer size;
+    private boolean includeHasNotCount;
 
     public TermsAggregation(String aggregationName, String propertyName) {
         this.aggregationName = aggregationName;
@@ -38,5 +39,13 @@ public class TermsAggregation extends Aggregation implements SupportsNestedAggre
 
     public void setSize(Integer size) {
         this.size = size;
+    }
+
+    public boolean isIncludeHasNotCount() {
+        return includeHasNotCount;
+    }
+
+    public void setIncludeHasNotCount(boolean includeHasNotCount) {
+        this.includeHasNotCount = includeHasNotCount;
     }
 }

--- a/core/src/main/java/org/vertexium/query/TermsResult.java
+++ b/core/src/main/java/org/vertexium/query/TermsResult.java
@@ -33,6 +33,11 @@ public class TermsResult extends AggregationResult {
         return docCountErrorUpperBound;
     }
 
+    /**
+     * @return If the parameter includeHasNotCount was set to true on the TermsAggregation, this will
+     *         return the number of elements that do not have a value for the property being aggregated.
+     *         If that parameter was false, this will return NOT_COMPUTED (-1).
+     */
     public long getHasNotCount() {
         return hasNotCount;
     }

--- a/core/src/main/java/org/vertexium/query/TermsResult.java
+++ b/core/src/main/java/org/vertexium/query/TermsResult.java
@@ -1,20 +1,24 @@
 package org.vertexium.query;
 
 public class TermsResult extends AggregationResult {
+    public static long NOT_COMPUTED = -1;
     private final Iterable<TermsBucket> buckets;
     private final long sumOfOtherDocCounts;
     private final long docCountErrorUpperBound;
+    private final long hasNotCount;
 
     public TermsResult(Iterable<TermsBucket> buckets) {
         this.buckets = buckets;
         this.sumOfOtherDocCounts = 0;
         this.docCountErrorUpperBound = 0;
+        this.hasNotCount = -1;
     }
 
-    public TermsResult(Iterable<TermsBucket> buckets, long sumOfOtherDocCounts, long docCountErrorUpperBound) {
+    public TermsResult(Iterable<TermsBucket> buckets, long sumOfOtherDocCounts, long docCountErrorUpperBound, long hasNotCount) {
         this.buckets = buckets;
         this.sumOfOtherDocCounts = sumOfOtherDocCounts;
         this.docCountErrorUpperBound = docCountErrorUpperBound;
+        this.hasNotCount = hasNotCount;
     }
 
     public Iterable<TermsBucket> getBuckets() {
@@ -27,5 +31,9 @@ public class TermsResult extends AggregationResult {
 
     public long getDocCountErrorUpperBound() {
         return docCountErrorUpperBound;
+    }
+
+    public long getHasNotCount() {
+        return hasNotCount;
     }
 }

--- a/elasticsearch5/search-index/src/main/java/org/vertexium/elasticsearch5/Elasticsearch5SearchIndex.java
+++ b/elasticsearch5/search-index/src/main/java/org/vertexium/elasticsearch5/Elasticsearch5SearchIndex.java
@@ -115,7 +115,8 @@ public class Elasticsearch5SearchIndex implements SearchIndex, SearchIndexWithVe
     private String[] indexNamesAsArray;
     private IndexSelectionStrategy indexSelectionStrategy;
     private boolean allFieldEnabled;
-    public static final Pattern AGGREGATION_NAME_PATTERN = Pattern.compile("(.*?)_([0-9a-f]+)");
+    public static final String AGGREGATION_HAS_NOT_SUFFIX = "HAS_NOT_FILTER";
+    public static final Pattern AGGREGATION_NAME_PATTERN = Pattern.compile("(.*?)_([0-9a-f]+|" + AGGREGATION_HAS_NOT_SUFFIX + ")");
     private final PropertyNameVisibilitiesStore propertyNameVisibilitiesStore;
     private final BulkUpdateService bulkUpdateService;
     private final String geoShapePrecision;

--- a/elasticsearch5/search-index/src/main/java/org/vertexium/elasticsearch5/ElasticsearchSearchQueryBase.java
+++ b/elasticsearch5/search-index/src/main/java/org/vertexium/elasticsearch5/ElasticsearchSearchQueryBase.java
@@ -24,6 +24,7 @@ import org.elasticsearch.search.SearchHits;
 import org.elasticsearch.search.aggregations.AbstractAggregationBuilder;
 import org.elasticsearch.search.aggregations.AggregationBuilder;
 import org.elasticsearch.search.aggregations.AggregationBuilders;
+import org.elasticsearch.search.aggregations.bucket.filter.FilterAggregationBuilder;
 import org.elasticsearch.search.aggregations.bucket.geogrid.GeoGridAggregationBuilder;
 import org.elasticsearch.search.aggregations.bucket.histogram.DateHistogramAggregationBuilder;
 import org.elasticsearch.search.aggregations.bucket.histogram.DateHistogramInterval;
@@ -1559,7 +1560,15 @@ public class ElasticsearchSearchQueryBase extends QueryBase {
 
                 termsAggs.add(termsAgg);
             }
+
+            if (agg.isIncludeHasNotCount()) {
+                QueryBuilder hasNotQuery = getFilterForHasNotPropertyContainer(new HasNotPropertyContainer(fieldName));
+                String aggregationName = createAggregationName(agg.getAggregationName(), AGGREGATION_HAS_NOT_SUFFIX);
+                FilterAggregationBuilder filterAgg = AggregationBuilders.filter(aggregationName, hasNotQuery);
+                termsAggs.add(filterAgg);
+            }
         }
+
         return termsAggs;
     }
 


### PR DESCRIPTION
When performing a `TermsAggregation`, in addition to knowing the terms it's sometimes useful to know how many documents do not have the field at all. This PR adds a new parameter `includeHasNotCount` to the `TermsAggregation` in order to compute this value. It's false by default so that existing code will not incur additional overhead to compute a value they won't be reading.