### PR TITLE
Clean Up Metrics on Graph Shutdown

### DIFF
--- a/core/src/main/java/org/vertexium/GraphBaseWithSearchIndex.java
+++ b/core/src/main/java/org/vertexium/GraphBaseWithSearchIndex.java
@@ -143,6 +143,7 @@ public abstract class GraphBaseWithSearchIndex extends GraphBase implements Grap
             this.searchIndex.shutdown();
             this.searchIndex = null;
         }
+        getMetricsRegistry().shutdown();
     }
 
     @Override

--- a/core/src/main/java/org/vertexium/metric/DropWizardMetricRegistry.java
+++ b/core/src/main/java/org/vertexium/metric/DropWizardMetricRegistry.java
@@ -2,17 +2,17 @@ package org.vertexium.metric;
 
 import com.codahale.metrics.MetricRegistry;
 
-import java.util.HashMap;
 import java.util.Map;
+import java.util.concurrent.ConcurrentHashMap;
 import java.util.function.Supplier;
 
 public class DropWizardMetricRegistry implements VertexiumMetricRegistry {
     private final MetricRegistry metricRegistry;
-    private final Map<String, Counter> countersByName = new HashMap<>();
-    private final Map<String, Timer> timersByName = new HashMap<>();
-    private final Map<String, Histogram> histogramsByName = new HashMap<>();
-    private final Map<String, Gauge> gaugesByName = new HashMap<>();
-    private final Map<String, StackTraceTracker> stackTraceTrackersByName = new HashMap<>();
+    private final Map<String, Counter> countersByName = new ConcurrentHashMap<>();
+    private final Map<String, Timer> timersByName = new ConcurrentHashMap<>();
+    private final Map<String, Histogram> histogramsByName = new ConcurrentHashMap<>();
+    private final Map<String, Gauge> gaugesByName = new ConcurrentHashMap<>();
+    private final Map<String, StackTraceTracker> stackTraceTrackersByName = new ConcurrentHashMap<>();
 
     public DropWizardMetricRegistry() {
         this(new MetricRegistry());
@@ -79,6 +79,15 @@ public class DropWizardMetricRegistry implements VertexiumMetricRegistry {
     @Override
     public Iterable<? extends StackTraceTracker> getStackTraceTrackers() {
         return stackTraceTrackersByName.values();
+    }
+
+    @Override
+    public void shutdown() {
+        countersByName.keySet().forEach(metricRegistry::remove);
+        timersByName.keySet().forEach(metricRegistry::remove);
+        histogramsByName.keySet().forEach(metricRegistry::remove);
+        gaugesByName.keySet().forEach(metricRegistry::remove);
+        stackTraceTrackersByName.keySet().forEach(metricRegistry::remove);
     }
 
     public static class Gauge<T> implements org.vertexium.metric.Gauge<T> {

--- a/core/src/main/java/org/vertexium/metric/NullMetricRegistry.java
+++ b/core/src/main/java/org/vertexium/metric/NullMetricRegistry.java
@@ -99,4 +99,13 @@ public class NullMetricRegistry implements VertexiumMetricRegistry {
     public Iterable<? extends StackTraceTracker> getStackTraceTrackers() {
         return stackTraceTrackersByName.values();
     }
+
+    @Override
+    public void shutdown() {
+        countersByName.clear();
+        timersByName.clear();
+        histogramsByName.clear();
+        gaugesByName.clear();
+        stackTraceTrackersByName.clear();
+    }
 }

--- a/core/src/main/java/org/vertexium/metric/VertexiumMetricRegistry.java
+++ b/core/src/main/java/org/vertexium/metric/VertexiumMetricRegistry.java
@@ -48,4 +48,6 @@ public interface VertexiumMetricRegistry {
     StackTraceTracker getStackTraceTracker(String name);
 
     Iterable<? extends StackTraceTracker> getStackTraceTrackers();
+
+    void shutdown();
 }

--- a/elasticsearch5/search-index/src/main/java/org/vertexium/elasticsearch5/MetadataTablePropertyNameVisibilitiesStore.java
+++ b/elasticsearch5/search-index/src/main/java/org/vertexium/elasticsearch5/MetadataTablePropertyNameVisibilitiesStore.java
@@ -9,14 +9,18 @@ import org.vertexium.util.VertexiumLogger;
 import org.vertexium.util.VertexiumLoggerFactory;
 
 import java.nio.charset.Charset;
-import java.util.*;
+import java.util.ArrayList;
+import java.util.Collection;
+import java.util.List;
+import java.util.Map;
+import java.util.concurrent.ConcurrentHashMap;
 
 public class MetadataTablePropertyNameVisibilitiesStore extends PropertyNameVisibilitiesStore {
     private static final VertexiumLogger LOGGER = VertexiumLoggerFactory.getLogger(MetadataTablePropertyNameVisibilitiesStore.class);
     public static final String PROPERTY_NAME_VISIBILITY_TO_HASH_PREFIX = "propertyNameVisibility.";
     public static final String HASH_TO_VISIBILITY = "visibilityHash.";
     private static final Charset UTF8 = Charset.forName("utf8");
-    private Map<String, Visibility> visibilityCache = new HashMap<>();
+    private Map<String, Visibility> visibilityCache = new ConcurrentHashMap<>();
 
     public Collection<String> getHashesWithAuthorization(Graph graph, String authorization, Authorizations authorizations) {
         List<String> hashes = new ArrayList<>();


### PR DESCRIPTION
We had a case where the graph was shut down and a new graph was created with the same drop wizard metrics registry. As a result, errors were thrown when Vertexium tried to re-register the bulk index gauges. This PR will clean up all metrics registered through the Vertexium registry when the graph is shutdown.

In addition, we noticed a concurrency issue in the `MetadataTablePropertyNameVisibilitiesStore` that is fixed as part of this PR.