### PR TITLE
Fix a Deadlock when Loading Indices

### DIFF
--- a/elasticsearch7/search-index/src/main/java/org/vertexium/elasticsearch7/DefaultIndexSelectionStrategy.java
+++ b/elasticsearch7/search-index/src/main/java/org/vertexium/elasticsearch7/DefaultIndexSelectionStrategy.java
@@ -74,27 +74,27 @@ public class DefaultIndexSelectionStrategy implements IndexSelectionStrategy {
     }
 
     private void loadIndicesToQuery(Elasticsearch7SearchIndex es) {
+        Set<String> newIndicesToQuery = new HashSet<>();
+        if (splitEdgesAndVertices) {
+            newIndicesToQuery.add(defaultIndexName + VERTICES_INDEX_SUFFIX_NAME);
+            newIndicesToQuery.add(defaultIndexName + EDGES_INDEX_SUFFIX_NAME);
+        } else {
+            newIndicesToQuery.add(defaultIndexName);
+        }
+        Set<String> indexNames = es.getIndexNamesFromElasticsearch();
+        for (String indexName : indexNames) {
+            if (indexName.startsWith(extendedDataIndexNamePrefix)) {
+                newIndicesToQuery.add(indexName);
+            }
+        }
+
+        for (String indexName : newIndicesToQuery) {
+            es.ensureIndexCreatedAndInitialized(indexName);
+        }
+
         Lock writeLock = indicesToQueryLock.writeLock();
         writeLock.lock();
         try {
-            Set<String> newIndicesToQuery = new HashSet<>();
-            if (splitEdgesAndVertices) {
-                newIndicesToQuery.add(defaultIndexName + VERTICES_INDEX_SUFFIX_NAME);
-                newIndicesToQuery.add(defaultIndexName + EDGES_INDEX_SUFFIX_NAME);
-            } else {
-                newIndicesToQuery.add(defaultIndexName);
-            }
-            Set<String> indexNames = es.getIndexNamesFromElasticsearch();
-            for (String indexName : indexNames) {
-                if (indexName.startsWith(extendedDataIndexNamePrefix)) {
-                    newIndicesToQuery.add(indexName);
-                }
-            }
-
-            for (String indexName : newIndicesToQuery) {
-                es.ensureIndexCreatedAndInitialized(indexName);
-            }
-
             indicesToQueryArray = newIndicesToQuery.toArray(new String[0]);
             nextUpdateTime = new Date().getTime() + INDEX_UPDATE_MS;
         } finally {


### PR DESCRIPTION
When loading index information from ElasticSearch, we encountered a deadlock between two threads. One thread held the lock [here in the index selection strategy](https://github.com/visallo/vertexium/blob/master/elasticsearch7/search-index/src/main/java/org/vertexium/elasticsearch7/DefaultIndexSelectionStrategy.java#L78
). The other thread held the lock [here in the search index](https://github.com/visallo/vertexium/blob/master/elasticsearch7/search-index/src/main/java/org/vertexium/elasticsearch7/Elasticsearch7SearchIndex.java#L275). The result is that these two threads deadlocked and held up all threads in the search index.

This change will cause the `DefaultIndexSelectionStrategy.loadIndicesToQuery` method to potentially get called by multiple threads when the cache expires, but this is a compromise to prevent a more serious re-write of these classes.

