### PR TITLE
Fix ElasticSearch 7 Query String Transformation Escaping.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,6 @@
+# v4.9.2
+* Fixed: Elasticsearch 7 query string transformation was improperly stripping escape characters from fields that could not be found in the search index.
+
 # v4.9.1
 * Added: MetadataPlugin which allows filtering common values from being written to the data store
 * Added: Elasticsearch detect and close open scrolls

--- a/elasticsearch7/search-index/src/main/java/org/vertexium/elasticsearch7/lucene/DefaultQueryStringTransformer.java
+++ b/elasticsearch7/search-index/src/main/java/org/vertexium/elasticsearch7/lucene/DefaultQueryStringTransformer.java
@@ -86,7 +86,7 @@ public class DefaultQueryStringTransformer implements QueryStringTransformer {
 
             String[] fieldNames = expandFieldName(fieldName, authorizations);
             if (fieldNames == null || fieldNames.length == 0) {
-                ret.append(fieldName).append(":");
+                ret.append(clauseQueryStringNode.getField().image).append(":");
             } else if (fieldNames.length == 1) {
                 ret.append(EscapeQuerySyntax.escapeTerm(fieldNames[0], Locale.getDefault())).append(":");
             } else {

--- a/test/src/main/java/org/vertexium/test/GraphTestBase.java
+++ b/test/src/main/java/org/vertexium/test/GraphTestBase.java
@@ -4334,6 +4334,10 @@ public abstract class GraphTestBase {
         vertices = graph.query("http\\:\\/\\/vertexium.org#name:{Fern TO Gern}", AUTHORIZATIONS_A)
             .vertices();
         Assert.assertEquals(1, count(vertices));
+
+        vertices = graph.query("(http\\:\\/\\/vertexium.org\\/custom#notFoundProperty:Joe OR http\\:\\/\\/vertexium.org#name:Joe)", AUTHORIZATIONS_A)
+            .vertices();
+        Assert.assertEquals(2, count(vertices));
     }
 
     protected boolean isFieldNamesInQuerySupported() {


### PR DESCRIPTION
Elasticsearch 7 query string transformation was improperly stripping escape characters from fields that could not be found in the search index. Now, if the fieldname is not found it will be put back into the query string exactly as it appeared before processing.