### PR TITLE
 Fix Re-Indexing Elements with Hidden Properties

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,6 @@
 # v4.9.2
 * Fixed: Elasticsearch 7 query string transformation was improperly stripping escape characters from fields that could not be found in the search index.
+* Fixed: When re-indexing an element with hidden properties in Elasticsearch, the hidden property field was not being included in the list of fields to add.
 
 # v4.9.1
 * Added: MetadataPlugin which allows filtering common values from being written to the data store

--- a/core/src/main/java/org/vertexium/search/DefaultSearchIndex.java
+++ b/core/src/main/java/org/vertexium/search/DefaultSearchIndex.java
@@ -174,6 +174,11 @@ public class DefaultSearchIndex implements SearchIndex {
     }
 
     @Override
+    public boolean isDeleteElementSupported() {
+        return false;
+    }
+
+    @Override
     public void addElementExtendedData(
         Graph graph,
         ElementLocation elementLocation,

--- a/core/src/main/java/org/vertexium/search/SearchIndex.java
+++ b/core/src/main/java/org/vertexium/search/SearchIndex.java
@@ -104,6 +104,8 @@ public interface SearchIndex {
 
     boolean isFieldLevelSecuritySupported();
 
+    boolean isDeleteElementSupported();
+
     <T extends Element> void alterElementVisibility(
         Graph graph,
         ExistingElementMutation<T> elementMutation,

--- a/elasticsearch5/search-index/src/main/java/org/vertexium/elasticsearch5/Elasticsearch5SearchIndex.java
+++ b/elasticsearch5/search-index/src/main/java/org/vertexium/elasticsearch5/Elasticsearch5SearchIndex.java
@@ -659,6 +659,15 @@ public class Elasticsearch5SearchIndex implements SearchIndex, SearchIndexWithVe
                 fieldsToSet.put(EDGE_LABEL_FIELD_NAME, edge.getLabel());
             }
 
+            for (Property property : element.getProperties()) {
+                for (Visibility hiddenVisibility : property.getHiddenVisibilities()) {
+                    String hiddenVisibilityPropertyName = addVisibilityToPropertyName(graph, HIDDEN_PROPERTY_FIELD_NAME, hiddenVisibility);
+                    if (!isPropertyInIndex(graph, HIDDEN_PROPERTY_FIELD_NAME, hiddenVisibility)) {
+                        addPropertyToIndex(graph, indexInfo, hiddenVisibilityPropertyName, hiddenVisibility, Boolean.class, false, false, false);
+                    }
+                    fieldsToSet.put(hiddenVisibilityPropertyName, true);
+                }
+            }
             for (Visibility hiddenVisibility : element.getHiddenVisibilities()) {
                 String hiddenVisibilityPropertyName = addVisibilityToPropertyName(graph, HIDDEN_VERTEX_FIELD_NAME, hiddenVisibility);
                 if (!isPropertyInIndex(graph, HIDDEN_VERTEX_FIELD_NAME, hiddenVisibility)) {
@@ -1621,6 +1630,11 @@ public class Elasticsearch5SearchIndex implements SearchIndex, SearchIndexWithVe
 
     @Override
     public boolean isFieldLevelSecuritySupported() {
+        return true;
+    }
+
+    @Override
+    public boolean isDeleteElementSupported() {
         return true;
     }
 

--- a/elasticsearch7/search-index/src/main/java/org/vertexium/elasticsearch7/Elasticsearch7SearchIndex.java
+++ b/elasticsearch7/search-index/src/main/java/org/vertexium/elasticsearch7/Elasticsearch7SearchIndex.java
@@ -626,6 +626,15 @@ public class Elasticsearch7SearchIndex implements SearchIndex, SearchIndexWithVe
 
             Map<String, Object> fieldsToSet = getPropertiesAsFields(graph, element.getProperties());
 
+            for (Property property : element.getProperties()) {
+                for (Visibility hiddenVisibility : property.getHiddenVisibilities()) {
+                    String hiddenVisibilityPropertyName = addVisibilityToPropertyName(graph, HIDDEN_PROPERTY_FIELD_NAME, hiddenVisibility);
+                    if (!isPropertyInIndex(graph, HIDDEN_PROPERTY_FIELD_NAME, hiddenVisibility)) {
+                        addPropertyToIndex(graph, indexInfo, hiddenVisibilityPropertyName, hiddenVisibility, Boolean.class, false, false, false);
+                    }
+                    fieldsToSet.put(hiddenVisibilityPropertyName, true);
+                }
+            }
             for (Visibility hiddenVisibility : element.getHiddenVisibilities()) {
                 String hiddenVisibilityPropertyName = addVisibilityToPropertyName(graph, HIDDEN_VERTEX_FIELD_NAME, hiddenVisibility);
                 if (!isPropertyInIndex(graph, HIDDEN_VERTEX_FIELD_NAME, hiddenVisibility)) {
@@ -1591,6 +1600,11 @@ public class Elasticsearch7SearchIndex implements SearchIndex, SearchIndexWithVe
 
     @Override
     public boolean isFieldLevelSecuritySupported() {
+        return true;
+    }
+
+    @Override
+    public boolean isDeleteElementSupported() {
         return true;
     }
 


### PR DESCRIPTION
When re-indexing an element with hidden properties in Elasticsearch, the hidden property field was not being included in the list of fields to add.