### PR TITLE
Fixed: Term Aggregation with no Matching Fields

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,7 @@
 * Changed: Elasticsearch: search.indexRefreshInterval configuration to be a string to be in line with what Elasticsearch expects
 * Fixed: Elasticsearch 7 query string transformation was improperly stripping escape characters from fields that could not be found in the search index.
 * Fixed: When re-indexing an element with hidden properties in Elasticsearch, the hidden property field was not being included in the list of fields to add.
+* Fixed: Term aggregations that included the HasNot count and had no documents with the actual field were throwing an exception. This version now returns the proper count of documents (all of them) in the hasNot count.
 
 # v4.9.1
 * Added: MetadataPlugin which allows filtering common values from being written to the data store

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,8 +1,10 @@
+# v4.9.3
+* Fixed: Term aggregations that included the HasNot count and had no documents with the actual field were throwing an exception. This version now returns the proper count of documents (all of them) in the hasNot count.
+
 # v4.9.2
 * Changed: Elasticsearch: search.indexRefreshInterval configuration to be a string to be in line with what Elasticsearch expects
 * Fixed: Elasticsearch 7 query string transformation was improperly stripping escape characters from fields that could not be found in the search index.
 * Fixed: When re-indexing an element with hidden properties in Elasticsearch, the hidden property field was not being included in the list of fields to add.
-* Fixed: Term aggregations that included the HasNot count and had no documents with the actual field were throwing an exception. This version now returns the proper count of documents (all of them) in the hasNot count.
 
 # v4.9.1
 * Added: MetadataPlugin which allows filtering common values from being written to the data store

--- a/elasticsearch7/search-index/src/main/java/org/vertexium/elasticsearch7/ElasticsearchGraphQueryIterable.java
+++ b/elasticsearch7/search-index/src/main/java/org/vertexium/elasticsearch7/ElasticsearchGraphQueryIterable.java
@@ -118,46 +118,52 @@ public class ElasticsearchGraphQueryIterable<T> extends DefaultGraphQueryIterabl
     private static Map<String, AggregationResult> reduceAggregationResults(ElasticsearchSearchQueryBase query, Map<String, List<Aggregation>> aggsByName) {
         Map<String, AggregationResult> results = new HashMap<>();
         for (Map.Entry<String, List<Aggregation>> entry : aggsByName.entrySet()) {
-            results.put(entry.getKey(), reduceAggregationResults(query, entry.getValue()));
+            results.put(entry.getKey(), reduceAggregationResults(query, query.getAggregationByName(entry.getKey()), entry.getValue()));
         }
         return results;
     }
 
-    private static AggregationResult reduceAggregationResults(ElasticsearchSearchQueryBase query, List<Aggregation> aggs) {
-        if (aggs.size() == 0) {
+    private static AggregationResult reduceAggregationResults(ElasticsearchSearchQueryBase query, org.vertexium.query.Aggregation queryAgg, List<Aggregation> resultAggs) {
+        if (resultAggs.size() == 0) {
             throw new VertexiumException("Cannot reduce zero sized aggregation list");
         }
-        Aggregation first = aggs.get(0);
-        if (first.getName().endsWith(AGGREGATION_HAS_NOT_SUFFIX)) {
-            if (aggs.size() > 1) {
-                first = aggs.get(1);
-            } else {
-                throw new VertexiumException("Unhandled aggregation. Found HasNot filter with no associated aggregations.");
+
+        Object aggType = queryAgg;
+        if (queryAgg == null) {
+            Aggregation first = resultAggs.get(0);
+            if (first.getName().endsWith(AGGREGATION_HAS_NOT_SUFFIX)) {
+                if (resultAggs.size() > 1) {
+                    first = resultAggs.get(1);
+                } else {
+                    throw new VertexiumException("Unhandled aggregation. Found HasNot filter with no associated aggregations and no query aggregation.");
+                }
             }
+            aggType = first;
         }
 
-        if (first instanceof HistogramAggregation || first instanceof InternalHistogram || first instanceof InternalDateHistogram) {
-            return reduceHistogramResults(query, aggs);
+        if (aggType instanceof HistogramAggregation || aggType instanceof CalendarFieldAggregation ||
+            aggType instanceof InternalHistogram || aggType instanceof InternalDateHistogram) {
+            return reduceHistogramResults(query, resultAggs);
         }
-        if (first instanceof RangeAggregation || first instanceof InternalRange) {
-            return reduceRangeResults(query, aggs);
+        if (aggType instanceof RangeAggregation || aggType instanceof InternalRange) {
+            return reduceRangeResults(query, resultAggs);
         }
-        if (first instanceof PercentilesAggregation || first instanceof Percentiles) {
-            return reducePercentilesResults(query, aggs);
+        if (aggType instanceof PercentilesAggregation || aggType instanceof Percentiles) {
+            return reducePercentilesResults(query, resultAggs);
         }
-        if (first instanceof TermsAggregation || first instanceof InternalTerms) {
-            return reduceTermsResults(query, aggs);
+        if (aggType instanceof TermsAggregation || aggType instanceof InternalTerms) {
+            return reduceTermsResults(query, resultAggs);
         }
-        if (first instanceof GeohashAggregation || first instanceof InternalGeoHashGrid) {
-            return reduceGeohashResults(query, aggs);
+        if (aggType instanceof GeohashAggregation || aggType instanceof InternalGeoHashGrid) {
+            return reduceGeohashResults(query, resultAggs);
         }
-        if (first instanceof StatisticsAggregation || first instanceof InternalExtendedStats) {
-            return reduceStatisticsResults(aggs);
+        if (aggType instanceof StatisticsAggregation || aggType instanceof InternalExtendedStats) {
+            return reduceStatisticsResults(resultAggs);
         }
-        if (first instanceof CardinalityAggregation || first instanceof InternalCardinality) {
-            return reduceCardinalityResults(query, aggs);
+        if (aggType instanceof CardinalityAggregation || aggType instanceof InternalCardinality) {
+            return reduceCardinalityResults(query, resultAggs);
         }
-        throw new VertexiumException("Unhandled aggregation type: " + first.getClass().getName());
+        throw new VertexiumException("Unhandled aggregation type: " + aggType.getClass().getName());
     }
 
     private static HistogramResult reduceHistogramResults(ElasticsearchSearchQueryBase query, List<Aggregation> aggs) {

--- a/elasticsearch7/search-index/src/test/java/org/vertexium/elasticsearch7/Elasticsearch7SearchIndexTest.java
+++ b/elasticsearch7/search-index/src/test/java/org/vertexium/elasticsearch7/Elasticsearch7SearchIndexTest.java
@@ -20,6 +20,8 @@ import org.vertexium.inmemory.InMemoryGraph;
 import org.vertexium.inmemory.InMemoryGraphConfiguration;
 import org.vertexium.query.QueryResultsIterable;
 import org.vertexium.query.SortDirection;
+import org.vertexium.query.TermsAggregation;
+import org.vertexium.query.TermsResult;
 import org.vertexium.scoring.ScoringStrategy;
 import org.vertexium.sorting.SortingStrategy;
 import org.vertexium.test.GraphTestBase;
@@ -93,6 +95,26 @@ public class Elasticsearch7SearchIndexTest extends GraphTestBase {
 
         QueryResultsIterable<Vertex> vertices = graph.query(AUTHORIZATIONS_A).sort("age", SortDirection.ASCENDING).vertices();
         Assert.assertEquals(2, count(vertices));
+    }
+
+    @Test
+    public void testGraphQueryAggregateOnPropertyThatHasNoValuesInTheIndex() {
+        super.testGraphQueryAggregateOnPropertyThatHasNoValuesInTheIndex();
+
+        getSearchIndex().clearCache();
+
+        TermsAggregation aliasAggregation = new TermsAggregation("alias-agg", "alias");
+        aliasAggregation.setIncludeHasNotCount(true);
+        QueryResultsIterable<Vertex> vertices = graph.query(AUTHORIZATIONS_A)
+            .addAggregation(aliasAggregation)
+            .limit(0)
+            .vertices();
+
+        Assert.assertEquals(0, count(vertices));
+
+        TermsResult aliasAggResult = vertices.getAggregationResult(aliasAggregation.getAggregationName(), TermsResult.class);
+        assertEquals(2, aliasAggResult.getHasNotCount());
+        assertEquals(0, count(aliasAggResult.getBuckets()));
     }
 
     @Override


### PR DESCRIPTION
In the case of a TermAggregation with no matching fields, it would raise an exception if the caller requested `setIncludeHasNotCount(true)` but work otherwise. This PR fixes that to return the proper number of hits (all of them) in the hasNotCount.