### PR TITLE
Add StringStreamingPropertyValue for Faster Indexing

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,6 @@
+# v4.9.4
+* Added: Add a specialized version of StreamingPropertyValue to be more performant in the case where the value is a String already in memory
+
 # v4.9.3
 * Fixed: Term aggregations that included the HasNot count and had no documents with the actual field were throwing an exception. This version now returns the proper count of documents (all of them) in the hasNot count.
 * Changed: Updated the validation logic in the GeoShape classes to more strictly adhere to the GeoJSON specification.

--- a/accumulo/graph/src/main/java/org/vertexium/accumulo/StringStreamingPropertyValueRef.java
+++ b/accumulo/graph/src/main/java/org/vertexium/accumulo/StringStreamingPropertyValueRef.java
@@ -1,0 +1,19 @@
+package org.vertexium.accumulo;
+
+import org.vertexium.property.StreamingPropertyValue;
+import org.vertexium.property.StreamingPropertyValueRef;
+import org.vertexium.property.StringStreamingPropertyValue;
+
+public class StringStreamingPropertyValueRef extends StreamingPropertyValueRef<AccumuloGraph> {
+    StringStreamingPropertyValue propertyValue;
+
+    public StringStreamingPropertyValueRef(StringStreamingPropertyValue propertyValue) {
+        super(propertyValue);
+        this.propertyValue = propertyValue;
+    }
+
+    @Override
+    public StreamingPropertyValue toStreamingPropertyValue(AccumuloGraph graph, long timestamp) {
+        return propertyValue;
+    }
+}

--- a/accumulo/graph/src/main/java/org/vertexium/accumulo/util/DataInDataTableStreamingPropertyValueStorageStrategy.java
+++ b/accumulo/graph/src/main/java/org/vertexium/accumulo/util/DataInDataTableStreamingPropertyValueStorageStrategy.java
@@ -11,9 +11,11 @@ import org.vertexium.VertexiumException;
 import org.vertexium.accumulo.AccumuloGraphConfiguration;
 import org.vertexium.accumulo.ElementMutationBuilder;
 import org.vertexium.accumulo.StreamingPropertyValueTableDataRef;
+import org.vertexium.accumulo.StringStreamingPropertyValueRef;
 import org.vertexium.accumulo.keys.DataTableRowKey;
 import org.vertexium.property.StreamingPropertyValue;
 import org.vertexium.property.StreamingPropertyValueRef;
+import org.vertexium.property.StringStreamingPropertyValue;
 
 import java.io.InputStream;
 import java.util.List;
@@ -61,6 +63,9 @@ public class DataInDataTableStreamingPropertyValueStorageStrategy implements Str
             dataMutation.put(METADATA_COLUMN_FAMILY, METADATA_LENGTH_COLUMN_QUALIFIER, property.getTimestamp(), new Value(Longs.toByteArray(offset)));
             elementMutationBuilder.saveDataMutation(dataMutation);
 
+            if (streamingPropertyValue instanceof StringStreamingPropertyValue) {
+                return new StringStreamingPropertyValueRef((StringStreamingPropertyValue) streamingPropertyValue);
+            }
             return new StreamingPropertyValueTableDataRef(dataTableRowKey, streamingPropertyValue, offset);
         } catch (Exception ex) {
             throw new VertexiumException("Could not store streaming property value", ex);

--- a/core/src/main/java/org/vertexium/property/StreamingPropertyValue.java
+++ b/core/src/main/java/org/vertexium/property/StreamingPropertyValue.java
@@ -3,7 +3,6 @@ package org.vertexium.property;
 import org.vertexium.VertexiumException;
 import org.vertexium.util.IOUtils;
 
-import java.io.ByteArrayInputStream;
 import java.io.IOException;
 import java.io.InputStream;
 import java.io.Serializable;
@@ -41,8 +40,7 @@ public abstract class StreamingPropertyValue extends PropertyValue implements Se
     }
 
     public static StreamingPropertyValue create(String value) {
-        InputStream data = new ByteArrayInputStream(value.getBytes());
-        return new DefaultStreamingPropertyValue(data, String.class);
+        return new StringStreamingPropertyValue(value);
     }
 
     public static StreamingPropertyValue create(InputStream inputStream, Class type, Long length) {

--- a/core/src/main/java/org/vertexium/property/StringStreamingPropertyValue.java
+++ b/core/src/main/java/org/vertexium/property/StringStreamingPropertyValue.java
@@ -1,0 +1,34 @@
+package org.vertexium.property;
+
+import java.io.ByteArrayInputStream;
+import java.io.InputStream;
+
+import static java.nio.charset.StandardCharsets.UTF_8;
+
+public class StringStreamingPropertyValue extends StreamingPropertyValue {
+    private static final long serialVersionUID = 8609536455398889081L;
+    private final String value;
+
+    public StringStreamingPropertyValue() {
+        this(null);
+    }
+
+    public StringStreamingPropertyValue(String value) {
+        super(String.class);
+        this.value = value;
+    }
+
+    @Override
+    public String readToString() {
+        return value;
+    }
+
+    public InputStream getInputStream() {
+        byte[] bytes = value == null ? new byte[0] : value.getBytes(UTF_8);
+        return new ByteArrayInputStream(bytes);
+    }
+
+    public Long getLength() {
+        return value == null ? 0 : Long.valueOf(value.getBytes(UTF_8).length);
+    }
+}


### PR DESCRIPTION
Add a specialized version on StreamingPropertyValue to be more performant in the case where the value is a String already in memory