### PR TITLE
Improve Detection of Elasticsearch Scroll Leaks

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,6 @@
+# v4.9.4
+* Fixed: Improved detection and logging of Elasticsearch scrolls that are not closed properly.
+
 # v4.9.3
 * Fixed: Term aggregations that included the HasNot count and had no documents with the actual field were throwing an exception. This version now returns the proper count of documents (all of them) in the hasNot count.
 * Changed: Updated the validation logic in the GeoShape classes to more strictly adhere to the GeoJSON specification.

--- a/elasticsearch5/search-index/src/main/java/org/vertexium/elasticsearch5/ElasticsearchSearchQueryBase.java
+++ b/elasticsearch5/search-index/src/main/java/org/vertexium/elasticsearch5/ElasticsearchSearchQueryBase.java
@@ -8,6 +8,7 @@ import com.vividsolutions.jts.geom.Coordinate;
 import org.apache.lucene.analysis.TokenStream;
 import org.apache.lucene.analysis.standard.StandardAnalyzer;
 import org.apache.lucene.analysis.tokenattributes.CharTermAttribute;
+import org.elasticsearch.action.search.ClearScrollResponse;
 import org.elasticsearch.action.search.SearchRequestBuilder;
 import org.elasticsearch.action.search.SearchResponse;
 import org.elasticsearch.client.Client;
@@ -480,9 +481,12 @@ public class ElasticsearchSearchQueryBase extends QueryBase {
 
     private void closeScroll(String scrollId) {
         try {
-            client.prepareClearScroll()
+            ClearScrollResponse clearScrollResponse = client.prepareClearScroll()
                 .addScrollId(scrollId)
                 .execute().actionGet();
+            if (!clearScrollResponse.isSucceeded()) {
+                LOGGER.warn("Unable to clear scroll " + scrollId);
+            }
         } catch (Exception ex) {
             throw new VertexiumException("Could not close iterator " + scrollId, ex);
         }

--- a/elasticsearch5/search-index/src/test/java/org/vertexium/elasticsearch5/Elasticsearch5SearchIndexTest.java
+++ b/elasticsearch5/search-index/src/test/java/org/vertexium/elasticsearch5/Elasticsearch5SearchIndexTest.java
@@ -545,7 +545,7 @@ public class Elasticsearch5SearchIndexTest extends GraphTestBase {
         assertEquals(6, getCurrentScrolls());
 
         // iterating completely should close the scroll for just that iterator
-        iterator1.forEachRemaining(vertex -> System.out.println());
+        iterator1.forEachRemaining(vertex -> {});
         assertEquals(4, getCurrentScrolls());
 
         // closing the iterator should close for just that iterator

--- a/elasticsearch5/search-index/src/test/java/org/vertexium/elasticsearch5/ElasticsearchResource.java
+++ b/elasticsearch5/search-index/src/test/java/org/vertexium/elasticsearch5/ElasticsearchResource.java
@@ -123,7 +123,7 @@ public class ElasticsearchResource extends ExternalResource {
         }
     }
 
-    public Client getRemoteClient() {
+    private Client getRemoteClient() {
         if (remoteClient == null) {
             Settings settings = Settings.builder()
                 .put("cluster.name", System.getProperty("REMOTE_ES_CLUSTER_NAME", "elasticsearch"))
@@ -146,10 +146,12 @@ public class ElasticsearchResource extends ExternalResource {
         return remoteClient;
     }
 
+    public Client getClient() {
+        return shouldUseRemoteElasticsearch() ? getRemoteClient() : runner.client();
+    }
+
     public void dropIndices() throws Exception {
-        AdminClient client = shouldUseRemoteElasticsearch()
-            ? getRemoteClient().admin()
-            : runner.admin();
+        AdminClient client = getClient().admin();
         String[] indices = client.indices().prepareGetIndex().execute().get().indices();
         for (String index : indices) {
             if (index.startsWith(ES_INDEX_NAME) || index.startsWith(ES_EXTENDED_DATA_INDEX_NAME_PREFIX)) {

--- a/elasticsearch7/search-index/src/main/java/org/vertexium/elasticsearch7/ElasticsearchSearchQueryBase.java
+++ b/elasticsearch7/search-index/src/main/java/org/vertexium/elasticsearch7/ElasticsearchSearchQueryBase.java
@@ -7,6 +7,7 @@ import com.google.common.collect.Maps;
 import org.apache.lucene.analysis.TokenStream;
 import org.apache.lucene.analysis.standard.StandardAnalyzer;
 import org.apache.lucene.analysis.tokenattributes.CharTermAttribute;
+import org.elasticsearch.action.search.ClearScrollResponse;
 import org.elasticsearch.action.search.SearchRequestBuilder;
 import org.elasticsearch.action.search.SearchResponse;
 import org.elasticsearch.client.Client;
@@ -484,9 +485,12 @@ public class ElasticsearchSearchQueryBase extends QueryBase {
 
     private void closeScroll(String scrollId) {
         try {
-            client.prepareClearScroll()
+            ClearScrollResponse clearScrollResponse = client.prepareClearScroll()
                 .addScrollId(scrollId)
                 .execute().actionGet();
+            if (!clearScrollResponse.isSucceeded()) {
+                LOGGER.warn("Unable to clear scroll " + scrollId);
+            }
         } catch (Exception ex) {
             throw new VertexiumException("Could not close iterator " + scrollId, ex);
         }

--- a/elasticsearch7/search-index/src/test/java/org/vertexium/elasticsearch7/Elasticsearch7SearchIndexTest.java
+++ b/elasticsearch7/search-index/src/test/java/org/vertexium/elasticsearch7/Elasticsearch7SearchIndexTest.java
@@ -599,7 +599,7 @@ public class Elasticsearch7SearchIndexTest extends GraphTestBase {
         assertEquals(6, getCurrentScrolls());
 
         // iterating completely should close the scroll for just that iterator
-        iterator1.forEachRemaining(vertex -> System.out.println());
+        iterator1.forEachRemaining(vertex -> {});
         assertEquals(4, getCurrentScrolls());
 
         // closing the iterator should close for just that iterator

--- a/elasticsearch7/search-index/src/test/java/org/vertexium/elasticsearch7/Elasticsearch7SearchIndexTest.java
+++ b/elasticsearch7/search-index/src/test/java/org/vertexium/elasticsearch7/Elasticsearch7SearchIndexTest.java
@@ -6,10 +6,9 @@ import org.elasticsearch.action.admin.cluster.node.stats.NodesStatsRequestBuilde
 import org.elasticsearch.action.admin.cluster.node.stats.NodesStatsResponse;
 import org.elasticsearch.common.io.stream.NotSerializableExceptionWrapper;
 import org.elasticsearch.index.search.stats.SearchStats;
-import org.junit.Assert;
-import org.junit.Before;
-import org.junit.ClassRule;
-import org.junit.Test;
+import org.junit.*;
+import org.junit.rules.TestRule;
+import org.junit.runners.model.Statement;
 import org.vertexium.*;
 import org.vertexium.elasticsearch7.lucene.DefaultQueryStringTransformer;
 import org.vertexium.elasticsearch7.scoring.ElasticsearchFieldValueScoringStrategy;
@@ -25,7 +24,9 @@ import org.vertexium.query.TermsResult;
 import org.vertexium.scoring.ScoringStrategy;
 import org.vertexium.sorting.SortingStrategy;
 import org.vertexium.test.GraphTestBase;
+import org.vertexium.util.CloseableUtils;
 
+import java.io.IOException;
 import java.util.Iterator;
 import java.util.List;
 import java.util.concurrent.CountDownLatch;
@@ -58,6 +59,20 @@ public class Elasticsearch7SearchIndexTest extends GraphTestBase {
         elasticsearchResource.dropIndices();
         super.before();
     }
+
+    @Rule
+    public TestRule esOrphanScrollCheck = (base, description) -> new Statement() {
+        @Override
+        public void evaluate() throws Throwable {
+            long beforeScrollCount = getCurrentScrolls();
+            base.evaluate();
+            if ((getCurrentScrolls() - beforeScrollCount) > 0) {
+                System.gc();
+                System.gc();
+                fail("Leaked Elasticsearch scrolls detected.");
+            }
+        }
+    };
 
     @Override
     @SuppressWarnings("unchecked")
@@ -252,7 +267,7 @@ public class Elasticsearch7SearchIndexTest extends GraphTestBase {
         }
 
         // should succeed
-        graph.query(q.toString(), AUTHORIZATIONS_A).search().getTotalHits();
+        graph.query(q.toString(), AUTHORIZATIONS_A).limit(0).search().getTotalHits();
 
         try {
             q.append("done");
@@ -509,18 +524,98 @@ public class Elasticsearch7SearchIndexTest extends GraphTestBase {
         }
         getGraph().flush();
 
+        assertEquals(0, getCurrentScrolls());
+
         QueryResultsIterable<Vertex> vertices = getGraph().query(AUTHORIZATIONS_EMPTY)
             .has("name", "value1")
             .limit((Long) null)
             .vertices();
+        assertEquals(0, getCurrentScrolls());
         assertEquals(verticesToCreate, vertices.getTotalHits());
+        assertEquals(2, getCurrentScrolls()); // (number of scroll requests) * (number of shards)
         Iterator<Vertex> it = vertices.iterator();
+        assertEquals(2, getCurrentScrolls());
         assertTrue(it.hasNext());
         it.next();
         it = null;
+        vertices = null;
 
+        assertEquals(2, getCurrentScrolls());
         System.gc();
         System.gc();
+    }
+
+    @Test
+    public void testCloseIterableClearsScrollWithNoIterators() throws IOException {
+        int verticesToCreate = ElasticsearchResource.TEST_QUERY_PAGE_SIZE * 2;
+        for (int i = 0; i < verticesToCreate; i++) {
+            getGraph().prepareVertex("v" + i, VISIBILITY_EMPTY)
+                .addPropertyValue("k1", "name", "value1", VISIBILITY_EMPTY)
+                .save(AUTHORIZATIONS_EMPTY);
+        }
+        getGraph().flush();
+
+        assertEquals(0, getCurrentScrolls());
+
+        QueryResultsIterable<Vertex> vertices = getGraph().query(AUTHORIZATIONS_EMPTY)
+            .has("name", "value1")
+            .limit((Long) null)
+            .vertices();
+        assertEquals(0, getCurrentScrolls());
+        assertEquals(verticesToCreate, vertices.getTotalHits());
+        assertEquals(2, getCurrentScrolls()); // (number of scroll requests) * (number of shards)
+        vertices.close();
+        assertEquals(0, getCurrentScrolls());
+    }
+
+    @Test
+    public void testCompleteIteratorsClearsScroll() throws IOException {
+        int verticesToCreate = ElasticsearchResource.TEST_QUERY_PAGE_SIZE * 2;
+        for (int i = 0; i < verticesToCreate; i++) {
+            getGraph().prepareVertex("v" + i, VISIBILITY_EMPTY)
+                .addPropertyValue("k1", "name", "value1", VISIBILITY_EMPTY)
+                .save(AUTHORIZATIONS_EMPTY);
+        }
+        getGraph().flush();
+
+        assertEquals(0, getCurrentScrolls());
+
+        QueryResultsIterable<Vertex> vertices = getGraph().query(AUTHORIZATIONS_EMPTY)
+            .has("name", "value1")
+            .limit((Long) null)
+            .vertices();
+        assertEquals(0, getCurrentScrolls());
+        assertEquals(verticesToCreate, vertices.getTotalHits());
+        assertEquals(2, getCurrentScrolls()); // (number of scroll requests) * (number of shards)
+
+        // Open three iterators for a total of 6 scrolls. The first iterator will
+        // use the existing scroll id from the iterable. The second and third will
+        // begin new scrolls with their own scroll ids.
+        Iterator<Vertex> iterator1 = vertices.iterator();
+        assertEquals(2, getCurrentScrolls());
+        Iterator<Vertex> iterator2 = vertices.iterator();
+        assertEquals(4, getCurrentScrolls());
+        Iterator<Vertex> iterator3 = vertices.iterator();
+        assertEquals(6, getCurrentScrolls());
+
+        // iterating completely should close the scroll for just that iterator
+        iterator1.forEachRemaining(vertex -> System.out.println());
+        assertEquals(4, getCurrentScrolls());
+
+        // closing the iterator should close for just that iterator
+        CloseableUtils.closeQuietly(iterator2);
+        assertEquals(2, getCurrentScrolls());
+
+        // closing the iterable that produced the iterators should close all remaining iterators
+        vertices.close();
+        assertEquals(0, getCurrentScrolls());
+    }
+
+    private long getCurrentScrolls() {
+        NodesStatsResponse nodeStats = new NodesStatsRequestBuilder(elasticsearchResource.getClient(), NodesStatsAction.INSTANCE).get();
+        return nodeStats.getNodes().stream()
+            .mapToLong(node -> node.getIndices().getSearch().getTotal().getScrollCurrent())
+            .sum();
     }
 
     @Test
@@ -554,7 +649,7 @@ public class Elasticsearch7SearchIndexTest extends GraphTestBase {
     }
 
     private long getNumQueries() {
-        NodesStatsResponse nodeStats = new NodesStatsRequestBuilder(getSearchIndex().getClient(), NodesStatsAction.INSTANCE).get();
+        NodesStatsResponse nodeStats = new NodesStatsRequestBuilder(elasticsearchResource.getClient(), NodesStatsAction.INSTANCE).get();
 
         List<NodeStats> nodes = nodeStats.getNodes();
         assertEquals(1, nodes.size());

--- a/pom.xml
+++ b/pom.xml
@@ -495,6 +495,7 @@
                                 <!-- This prevents log4j from initializing. Use for Travis CI, which fails the build
                                      when the log output is too long. -->
                                 <log4j.configuration />
+                                <log4j2.configurationFile />
                             </systemProperties>
                         </configuration>
                     </plugin>

--- a/test/src/main/java/org/vertexium/test/GraphTestBase.java
+++ b/test/src/main/java/org/vertexium/test/GraphTestBase.java
@@ -53,8 +53,8 @@ import static org.junit.Assert.*;
 import static org.junit.Assume.assumeTrue;
 import static org.vertexium.query.TermsResult.NOT_COMPUTED;
 import static org.vertexium.test.util.VertexiumAssert.*;
-import static org.vertexium.util.IterableUtils.count;
-import static org.vertexium.util.IterableUtils.toList;
+import static org.vertexium.util.CloseableUtils.closeQuietly;
+import static org.vertexium.util.IterableUtils.*;
 import static org.vertexium.util.StreamUtils.stream;
 
 @RunWith(JUnit4.class)
@@ -1390,10 +1390,10 @@ public abstract class GraphTestBase {
         Assert.assertEquals(0, count(cVertices));
 
         Iterable<Vertex> aVertices = graph.getVertices(AUTHORIZATIONS_A);
-        assertEquals("v1", IterableUtils.single(aVertices).getId());
+        assertEquals("v1", single(aVertices).getId());
 
         Iterable<Vertex> bVertices = graph.getVertices(AUTHORIZATIONS_B);
-        assertEquals("v2", IterableUtils.single(bVertices).getId());
+        assertEquals("v2", single(bVertices).getId());
 
         Iterable<Vertex> allVertices = graph.getVertices(AUTHORIZATIONS_A_AND_B);
         Assert.assertEquals(2, count(allVertices));
@@ -1444,7 +1444,7 @@ public abstract class GraphTestBase {
             .extendedDataRows();
         assertResultsCount(1, 1, rows);
 
-        ExtendedDataRow row = IterableUtils.single(rows);
+        ExtendedDataRow row = single(rows);
         assertEquals("v1", row.getId().getElementId());
         assertEquals("table1", row.getId().getTableName());
         assertEquals("row1", row.getId().getRowId());
@@ -2380,9 +2380,9 @@ public abstract class GraphTestBase {
         Assert.assertEquals(1, count(e.getProperties()));
         assertEquals("valueA", e.getPropertyValues("propA").iterator().next());
         Assert.assertEquals(1, count(v1.getEdges(Direction.OUT, AUTHORIZATIONS_A)));
-        Assert.assertEquals(LABEL_LABEL1, IterableUtils.single(v1.getEdgesSummary(AUTHORIZATIONS_A).getOutEdgeLabels()));
+        Assert.assertEquals(LABEL_LABEL1, single(v1.getEdgesSummary(AUTHORIZATIONS_A).getOutEdgeLabels()));
         Assert.assertEquals(1, count(v2.getEdges(Direction.IN, AUTHORIZATIONS_A)));
-        Assert.assertEquals(LABEL_LABEL1, IterableUtils.single(v2.getEdgesSummary(AUTHORIZATIONS_A).getInEdgeLabels()));
+        Assert.assertEquals(LABEL_LABEL1, single(v2.getEdgesSummary(AUTHORIZATIONS_A).getInEdgeLabels()));
 
         e.prepareMutation()
             .alterEdgeLabel(LABEL_LABEL2)
@@ -2394,10 +2394,10 @@ public abstract class GraphTestBase {
         assertEquals("valueA", e.getPropertyValues("propA").iterator().next());
         v1 = graph.getVertex("v1", AUTHORIZATIONS_A);
         Assert.assertEquals(1, count(v1.getEdges(Direction.OUT, AUTHORIZATIONS_A)));
-        Assert.assertEquals(LABEL_LABEL2, IterableUtils.single(v1.getEdgesSummary(AUTHORIZATIONS_A).getOutEdgeLabels()));
+        Assert.assertEquals(LABEL_LABEL2, single(v1.getEdgesSummary(AUTHORIZATIONS_A).getOutEdgeLabels()));
         v2 = graph.getVertex("v2", AUTHORIZATIONS_A);
         Assert.assertEquals(1, count(v2.getEdges(Direction.IN, AUTHORIZATIONS_A)));
-        Assert.assertEquals(LABEL_LABEL2, IterableUtils.single(v2.getEdgesSummary(AUTHORIZATIONS_A).getInEdgeLabels()));
+        Assert.assertEquals(LABEL_LABEL2, single(v2.getEdgesSummary(AUTHORIZATIONS_A).getInEdgeLabels()));
 
         graph.prepareEdge(e.getId(), e.getVertexId(Direction.OUT), e.getVertexId(Direction.IN), e.getLabel(), e.getVisibility())
             .alterEdgeLabel("label3")
@@ -2409,10 +2409,10 @@ public abstract class GraphTestBase {
         assertEquals("valueA", e.getPropertyValues("propA").iterator().next());
         v1 = graph.getVertex("v1", AUTHORIZATIONS_A);
         Assert.assertEquals(1, count(v1.getEdges(Direction.OUT, AUTHORIZATIONS_A)));
-        Assert.assertEquals("label3", IterableUtils.single(v1.getEdgesSummary(AUTHORIZATIONS_A).getOutEdgeLabels()));
+        Assert.assertEquals("label3", single(v1.getEdgesSummary(AUTHORIZATIONS_A).getOutEdgeLabels()));
         v2 = graph.getVertex("v2", AUTHORIZATIONS_A);
         Assert.assertEquals(1, count(v2.getEdges(Direction.IN, AUTHORIZATIONS_A)));
-        Assert.assertEquals("label3", IterableUtils.single(v2.getEdgesSummary(AUTHORIZATIONS_A).getInEdgeLabels()));
+        Assert.assertEquals("label3", single(v2.getEdgesSummary(AUTHORIZATIONS_A).getInEdgeLabels()));
     }
 
     @Test
@@ -2478,11 +2478,11 @@ public abstract class GraphTestBase {
 
         Iterable<Edge> aEdges = graph.getVertex("v1", AUTHORIZATIONS_A_AND_B).getEdges(Direction.BOTH, AUTHORIZATIONS_A);
         Assert.assertEquals(1, count(aEdges));
-        assertEquals(LABEL_LABEL1, IterableUtils.single(aEdges).getLabel());
+        assertEquals(LABEL_LABEL1, single(aEdges).getLabel());
 
         Iterable<Edge> bEdges = graph.getVertex("v1", AUTHORIZATIONS_A_AND_B).getEdges(Direction.BOTH, AUTHORIZATIONS_B);
         Assert.assertEquals(1, count(bEdges));
-        assertEquals(LABEL_LABEL2, IterableUtils.single(bEdges).getLabel());
+        assertEquals(LABEL_LABEL2, single(bEdges).getLabel());
 
         Iterable<Edge> allEdges = graph.getVertex("v1", AUTHORIZATIONS_A_AND_B).getEdges(Direction.BOTH, AUTHORIZATIONS_A_AND_B);
         Assert.assertEquals(2, count(allEdges));
@@ -3560,20 +3560,20 @@ public abstract class GraphTestBase {
             .save(AUTHORIZATIONS_A_AND_B);
         graph.flush();
 
-        Iterable<Element> results = graph.query("*", AUTHORIZATIONS_A_AND_B).has("prop1").elements();
+        QueryResultsIterable<Element> results = graph.query("*", AUTHORIZATIONS_A_AND_B).has("prop1").elements();
         assertEquals(1, count(results));
-        assertEquals(1, ((IterableWithTotalHits) results).getTotalHits());
-        assertEquals("v1", results.iterator().next().getId());
+        assertEquals(1, results.getTotalHits());
+        assertEquals("v1", single(results).getId());
 
         results = graph.query("*", AUTHORIZATIONS_A_AND_B).has("exact").elements();
         assertEquals(1, count(results));
-        assertEquals(1, ((IterableWithTotalHits) results).getTotalHits());
-        assertEquals("v1", results.iterator().next().getId());
+        assertEquals(1, results.getTotalHits());
+        assertEquals("v1", single(results).getId());
 
         results = graph.query("*", AUTHORIZATIONS_A_AND_B).has("location").elements();
         assertEquals(1, count(results));
-        assertEquals(1, ((IterableWithTotalHits) results).getTotalHits());
-        assertEquals("v1", results.iterator().next().getId());
+        assertEquals(1, results.getTotalHits());
+        assertEquals("v1", single(results).getId());
     }
 
     @Test
@@ -3591,26 +3591,26 @@ public abstract class GraphTestBase {
             .save(AUTHORIZATIONS_A_AND_B);
         graph.flush();
 
-        Iterable<Element> results = graph.query("*", AUTHORIZATIONS_A_AND_B).hasNot("prop1").elements();
+        QueryResultsIterable<Element> results = graph.query("*", AUTHORIZATIONS_A_AND_B).hasNot("prop1").elements();
         assertEquals(1, count(results));
-        assertEquals(1, ((IterableWithTotalHits) results).getTotalHits());
-        assertEquals("v2", results.iterator().next().getId());
+        assertEquals(1, results.getTotalHits());
+        assertEquals("v2", single(results).getId());
 
         results = graph.query("*", AUTHORIZATIONS_A_AND_B).hasNot("prop3").sort(Element.ID_PROPERTY_NAME, SortDirection.ASCENDING).elements();
         assertEquals(2, count(results));
-        Iterator<Element> iterator = results.iterator();
-        assertEquals("v1", iterator.next().getId());
-        assertEquals("v2", iterator.next().getId());
+        List<Element> elements = toList(results.iterator());
+        assertEquals("v1", elements.get(0).getId());
+        assertEquals("v2", elements.get(1).getId());
 
         results = graph.query("*", AUTHORIZATIONS_A_AND_B).hasNot("exact").elements();
         assertEquals(1, count(results));
-        assertEquals(1, ((IterableWithTotalHits) results).getTotalHits());
-        assertEquals("v2", results.iterator().next().getId());
+        assertEquals(1, results.getTotalHits());
+        assertEquals("v2", single(results).getId());
 
         results = graph.query("*", AUTHORIZATIONS_A_AND_B).hasNot("location").elements();
         assertEquals(1, count(results));
-        assertEquals(1, ((IterableWithTotalHits) results).getTotalHits());
-        assertEquals("v2", results.iterator().next().getId());
+        assertEquals(1, results.getTotalHits());
+        assertEquals("v2", single(results).getId());
     }
 
     @Test
@@ -4714,7 +4714,7 @@ public abstract class GraphTestBase {
         assertEquals(invalidGeoPolygon, v1.getPropertyValue(locationProp));
 
         // make sure we can query for the vertex as expected
-        QueryResultsIterable<Vertex> queryResults = graph.query(AUTHORIZATIONS_A).has(nameProp, "Invalid GeoPolygon").vertices();
+        QueryResultsIterable<Vertex> queryResults = graph.query(AUTHORIZATIONS_A).has(nameProp, "Invalid GeoPolygon").limit(0).vertices();
         assertEquals(1, queryResults.getTotalHits());
 
         // try re-indexing the vertex. we expect that the search index will auto-repair the element
@@ -4722,9 +4722,9 @@ public abstract class GraphTestBase {
             ((GraphWithSearchIndex) graph).getSearchIndex().addElements(graph, Collections.singletonList(v1), AUTHORIZATIONS_A);
             graph.flush();
 
-            queryResults = graph.query(AUTHORIZATIONS_A).has(nameProp, "Invalid GeoPolygon").vertices();
+            queryResults = graph.query(AUTHORIZATIONS_A).has(nameProp, "Invalid GeoPolygon").limit(0).vertices();
             assertEquals(1, queryResults.getTotalHits());
-            queryResults = graph.query(AUTHORIZATIONS_A).has(locationProp).vertices();
+            queryResults = graph.query(AUTHORIZATIONS_A).has(locationProp).limit(0).vertices();
             assertEquals(1, queryResults.getTotalHits());
         }
     }
@@ -4764,6 +4764,7 @@ public abstract class GraphTestBase {
                 vertices = graph.query(AUTHORIZATIONS_A_AND_B).has("location", GeoCompare.CONTAINS, searchArea).vertices();
                 if (intersects instanceof GeoLine) {
                     assertEquals("Incorrect total hits match CONTAINS for shape " + searchArea.getDescription(), 0, vertices.getTotalHits());
+                    closeQuietly(vertices);
                 } else {
                     assertEquals("Incorrect total hits match CONTAINS for shape " + searchArea.getDescription(), 1, vertices.getTotalHits());
                     assertVertexIdsAnyOrder(vertices, "v4");
@@ -4781,12 +4782,13 @@ public abstract class GraphTestBase {
         assertEquals("Incorrect total hits match DISJOINT for polygon with hole", 2, vertices.getTotalHits());
         assertVertexIdsAnyOrder(vertices, "v2", "v3");
 
-        vertices = graph.query(AUTHORIZATIONS_A_AND_B).has("location", GeoCompare.WITHIN, triangle).vertices();
+        vertices = graph.query(AUTHORIZATIONS_A_AND_B).has("location", GeoCompare.WITHIN, triangle).limit(0).vertices();
         assertEquals("Incorrect total hits match WITHIN for polygon with hole", 0, vertices.getTotalHits());
 
         vertices = graph.query(AUTHORIZATIONS_A_AND_B).has("location", GeoCompare.CONTAINS, triangle).vertices();
         if (intersects instanceof GeoLine) {
             assertEquals("Incorrect total hits match CONTAINS for polygon with hole", 0, vertices.getTotalHits());
+            closeQuietly(vertices);
         } else {
             assertEquals("Incorrect total hits match CONTAINS for polygon with hole", 1, vertices.getTotalHits());
             assertVertexIdsAnyOrder(vertices, "v4");
@@ -6837,8 +6839,8 @@ public abstract class GraphTestBase {
             .minDocFrequency(1)
             .maxDocFrequency(10)
             .boost(2.0f);
-        QueryResultsIterable<? extends VertexiumObject> searchResults = query.search();
-        List<Vertex> vertices = toList(query.vertices());
+        QueryResultsIterable<Vertex> searchResults = query.vertices();
+        List<Vertex> vertices = toList(searchResults);
 
         assertTrue(vertices.size() > 0);
         assertEquals(vertices.size(), searchResults.getTotalHits());
@@ -6849,8 +6851,8 @@ public abstract class GraphTestBase {
             .minDocFrequency(1)
             .maxDocFrequency(10)
             .boost(2.0f);
-        searchResults = query.search();
-        vertices = toList(query.vertices());
+        searchResults = query.vertices();
+        vertices = toList(searchResults);
 
         assertTrue(vertices.size() > 0);
         assertTrue(vertices.stream().noneMatch(vertex -> vertex.getId().equals("v3")));
@@ -7210,7 +7212,7 @@ public abstract class GraphTestBase {
         agg = new TermsAggregation("terms-count", "gender");
         assumeTrue("terms aggregation not supported", q.isAggregationSupported(agg));
         q.addAggregation(agg);
-        aggregationResult = q.vertices().getAggregationResult("terms-count", TermsResult.class);
+        aggregationResult = q.limit(0).vertices().getAggregationResult("terms-count", TermsResult.class);
 
         vertexPropertyCountByValue = termsBucketToMap(aggregationResult.getBuckets());
         assertEquals(1, vertexPropertyCountByValue.size());
@@ -8873,6 +8875,7 @@ public abstract class GraphTestBase {
         List<ExtendedDataRow> rows = Lists.newArrayList(graph.getVertex("v1", AUTHORIZATIONS_A).getExtendedData("table1"));
         assertEquals(1, rows.size());
         QueryResultsIterable<? extends VertexiumObject> searchResults = graph.query("value", AUTHORIZATIONS_A)
+            .limit(0)
             .search();
         assertEquals(1, searchResults.getTotalHits());
 
@@ -8987,6 +8990,7 @@ public abstract class GraphTestBase {
         QueryResultsIterable<Vertex> queryResults = graph.query(AUTHORIZATIONS_A)
             .has(dateColumnName, date1)
             .sort(dateColumnName, SortDirection.ASCENDING)
+            .limit(0)
             .vertices();
         assertEquals(0, queryResults.getTotalHits());
 
@@ -9399,6 +9403,7 @@ public abstract class GraphTestBase {
         // Should not come back when finding edges
         QueryResultsIterable<Edge> queryResults = graph.query(AUTHORIZATIONS_A)
             .has("date", date1)
+            .limit(0)
             .edges();
         assertEquals(0, queryResults.getTotalHits());
 


### PR DESCRIPTION
Improve detection and logging of Elasticsearch scrolls that are not closed by Vertexium clients. Fixed a few leaks present in the test code and also added a check after every test to fail if a leak is introduced.