### PR TITLE
Fix LazyPropertyMetadata ConcurrentModificationException

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,6 @@
+# v4.9.5
+* Fixed: ConcurrentModificationException possible when mutliple threads are iterating over the metadata of the same property instance.
+
 # v4.9.4
 * Fixed: Improved detection and logging of Elasticsearch scrolls that are not closed properly.
 

--- a/accumulo/graph/src/main/java/org/vertexium/accumulo/LazyPropertyMetadata.java
+++ b/accumulo/graph/src/main/java/org/vertexium/accumulo/LazyPropertyMetadata.java
@@ -3,13 +3,14 @@ package org.vertexium.accumulo;
 import org.vertexium.*;
 
 import java.util.*;
+import java.util.concurrent.ConcurrentHashMap;
 import java.util.concurrent.locks.ReadWriteLock;
 import java.util.concurrent.locks.ReentrantReadWriteLock;
 
 public class LazyPropertyMetadata implements Metadata {
     private static final String KEY_SEPARATOR = "\u001f";
     private transient ReadWriteLock entriesLock = new ReentrantReadWriteLock();
-    private final Map<String, Metadata.Entry> entries = new HashMap<>();
+    private final Map<String, Metadata.Entry> entries = new ConcurrentHashMap<>();
     private final List<MetadataEntry> metadataEntries;
     private int[] metadataIndexes;
     private final Set<String> removedEntries = new HashSet<>();


### PR DESCRIPTION
Encountered when multiple threads were getting metadata values from the lazy properties of the same vertex.
```
java.util.ConcurrentModificationException
	at java.base/java.util.HashMap$HashIterator.nextNode(HashMap.java:1493)
	at java.base/java.util.HashMap$EntryIterator.next(HashMap.java:1526)
	at java.base/java.util.HashMap$EntryIterator.next(HashMap.java:1524)
	at org.vertexium.accumulo.LazyPropertyMetadata.getEntry(LazyPropertyMetadata.java:180)
```