### PR TITLE
Fix renaming of elementing during search update

### DIFF
--- a/elasticsearch7/search-index/src/main/resources/org/vertexium/elasticsearch7/update-fields-on-document.painless
+++ b/elasticsearch7/search-index/src/main/resources/org/vertexium/elasticsearch7/update-fields-on-document.painless
@@ -7,8 +7,13 @@ void updateFieldsToRemove(def ctx, def fieldsToRemove) {
 
 void updateFieldsToRename(def ctx, def fieldsToRename) {
     for (def fieldToRename : fieldsToRename.entrySet()) {
-        ctx._source[fieldToRename.getValue()] = ctx._source[fieldToRename.getKey()];
-        ctx._source.remove(fieldToRename.getKey());
+        if (fieldToRename.getKey() != fieldToRename.getValue()) {
+            def existingValue = ctx._source[fieldToRename.getKey()];
+            if (existingValue != null) {
+                ctx._source[fieldToRename.getValue()] = existingValue;
+                ctx._source.remove(fieldToRename.getKey());
+            }
+        }
     }
 }
 

--- a/elasticsearch7/search-index/src/test/java/org/vertexium/elasticsearch7/Elasticsearch7SearchIndexTest.java
+++ b/elasticsearch7/search-index/src/test/java/org/vertexium/elasticsearch7/Elasticsearch7SearchIndexTest.java
@@ -17,6 +17,7 @@ import org.vertexium.elasticsearch7.sorting.ElasticsearchLengthOfStringSortingSt
 import org.vertexium.inmemory.InMemoryAuthorizations;
 import org.vertexium.inmemory.InMemoryGraph;
 import org.vertexium.inmemory.InMemoryGraphConfiguration;
+import org.vertexium.mutation.ExistingElementMutation;
 import org.vertexium.query.QueryResultsIterable;
 import org.vertexium.query.SortDirection;
 import org.vertexium.query.TermsAggregation;
@@ -213,6 +214,25 @@ public class Elasticsearch7SearchIndexTest extends GraphTestBase {
 
         assertResultsCount(2, 2, vertices);
         assertEquals(startingNumQueries + 6, getNumQueries());
+    }
+
+    @Test
+    public void testQueryCreateAndUpdate() {
+        graph.prepareVertex("v1", VISIBILITY_A).save(AUTHORIZATIONS_A);
+        graph.flush();
+
+        QueryResultsIterable<Vertex> vertices = graph.query(AUTHORIZATIONS_A).vertices();
+        assertResultsCount(1, 1, vertices);
+
+        Vertex v1 = graph.getVertex("v1", AUTHORIZATIONS_A);
+        ExistingElementMutation<Vertex> m1 = v1.prepareMutation().alterElementVisibility(VISIBILITY_EMPTY);
+        ExistingElementMutation<Vertex> m2 = v1.prepareMutation().alterElementVisibility(VISIBILITY_EMPTY);
+        m1.save(AUTHORIZATIONS_A);
+        m2.save(AUTHORIZATIONS_A);
+        graph.flush();
+
+        vertices = graph.query(AUTHORIZATIONS_A).vertices();
+        assertResultsCount(1, 1, vertices);
     }
 
     @Test


### PR DESCRIPTION
This PR fixes an issue with updating a fvisibility on a field and then updating it again. The result was that the updated field would get its visiblity set correctly, but the value would be set to `null` even though the value is not null. This fix ensures that does not happen.