### PR TITLE
Improve LazyMutableProperty Threadsafety

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,6 @@
+# v4.9.6
+* Fixed: Threading issue when multiple threads attempt to deserialize a LazyMutableProperty value at the same time.
+
 # v4.9.5
 * Fixed: ConcurrentModificationException possible when mutliple threads are iterating over the metadata of the same property instance.
 

--- a/accumulo/graph/src/main/java/org/vertexium/accumulo/LazyMutableProperty.java
+++ b/accumulo/graph/src/main/java/org/vertexium/accumulo/LazyMutableProperty.java
@@ -48,7 +48,7 @@ public class LazyMutableProperty extends MutableProperty {
     }
 
     @Override
-    public void setValue(Object value) {
+    public synchronized void setValue(Object value) {
         this.cachedPropertyValue = value;
         this.propertyValue = null;
     }
@@ -109,13 +109,17 @@ public class LazyMutableProperty extends MutableProperty {
     @SuppressWarnings("unchecked")
     public Object getValue() {
         if (cachedPropertyValue == null) {
-            if (propertyValue == null || propertyValue.length == 0) {
-                return null;
-            }
-            cachedPropertyValue = this.vertexiumSerializer.bytesToObject(propertyValue);
-            propertyValue = null;
-            if (cachedPropertyValue instanceof StreamingPropertyValueRef) {
-                cachedPropertyValue = ((StreamingPropertyValueRef) cachedPropertyValue).toStreamingPropertyValue(this.graph, getTimestamp());
+            synchronized(this) {
+                if (cachedPropertyValue == null) {
+                    if (propertyValue == null || propertyValue.length == 0) {
+                        return null;
+                    }
+                    cachedPropertyValue = this.vertexiumSerializer.bytesToObject(propertyValue);
+                    propertyValue = null;
+                    if (cachedPropertyValue instanceof StreamingPropertyValueRef) {
+                        cachedPropertyValue = ((StreamingPropertyValueRef) cachedPropertyValue).toStreamingPropertyValue(this.graph, getTimestamp());
+                    }
+                }
             }
         }
         return cachedPropertyValue;


### PR DESCRIPTION
Fix a threading issue when creating a cached version of a lazy property value. If two threads attempt to deserialize the value at the same time, there can be timing issues with the way the code sets the non-serialized value to null.