### PR TITLE
Fixed: Elasticsearch: Streaming Property Values being indexed as "" after an update of the property

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,6 @@
+# v4.9.7
+* Fixed: Elasticsearch: Streaming Property Values being indexed as "" after an update of the property 
+
 # v4.9.6
 * Fixed: Threading issue when multiple threads attempt to deserialize a LazyMutableProperty value at the same time.
 * Fixed: When updating a visibility on a field multiple times, it was possible to set the value of the field to null. This issue has been fixed.

--- a/accumulo/graph/src/main/java/org/vertexium/accumulo/AccumuloGraph.java
+++ b/accumulo/graph/src/main/java/org/vertexium/accumulo/AccumuloGraph.java
@@ -559,6 +559,13 @@ public class AccumuloGraph extends GraphBaseWithSearchIndex implements Traceable
         }
         for (Property property : properties) {
             elementMutationBuilder.addPropertyToMutation(this, m, element, elementRowKey, property);
+            if (property.getValue() instanceof StreamingPropertyValue) {
+                // We need to specifically update the property on the element after transformValue is called because
+                // on add or set property we are creating a DefaultStreamingPropertyValue which has been consumed at
+                // this point. The transformValue method in `addPropertyToMutation` creates a new InputSteam based
+                // on the strategy.
+                element.addPropertyInternal(property);
+            }
         }
         for (AdditionalVisibilityAddMutation additionalVisibility : additionalVisibilities) {
             elementMutationBuilder.addAdditionalVisibilityToMutation(m, additionalVisibility);

--- a/test/src/main/java/org/vertexium/test/GraphTestBase.java
+++ b/test/src/main/java/org/vertexium/test/GraphTestBase.java
@@ -5829,6 +5829,30 @@ public abstract class GraphTestBase {
     }
 
     @Test
+    public void testQueryingUpdatedStreamingPropertyValues() throws Exception {
+        graph.defineProperty("fullText").dataType(String.class).textIndexHint(TextIndexHint.FULL_TEXT).define();
+
+        graph.prepareVertex("v1", VISIBILITY_A)
+                .setProperty("fullText", StreamingPropertyValue.create("Test Value"), VISIBILITY_A)
+                .save(AUTHORIZATIONS_A_AND_B);
+        graph.flush();
+
+        Assert.assertEquals(1, count(graph.query(AUTHORIZATIONS_A).has("fullText", TextPredicate.CONTAINS, "Test").vertices()));
+
+        graph.prepareVertex("v1", VISIBILITY_A)
+                .setProperty("fullText", StreamingPropertyValue.create("Updated Test Value"), VISIBILITY_A)
+                .save(AUTHORIZATIONS_A_AND_B);
+        graph.flush();
+        Assert.assertEquals(1, count(graph.query(AUTHORIZATIONS_A).has("fullText", TextPredicate.CONTAINS, "Updated").vertices()));
+
+        Vertex v = graph.getVertex("v1", AUTHORIZATIONS_A);
+        v.prepareMutation().setProperty("fullText", StreamingPropertyValue.create("Updated Test Value - existing mutation"), VISIBILITY_A)
+                .save(AUTHORIZATIONS_A_AND_B);
+        graph.flush();
+        Assert.assertEquals(1, count(graph.query(AUTHORIZATIONS_A).has("fullText", TextPredicate.CONTAINS, "mutation").vertices()));
+    }
+
+    @Test
     public void testGetStreamingPropertyValueInputStreams() throws Exception {
         graph.defineProperty("a").dataType(String.class).textIndexHint(TextIndexHint.FULL_TEXT).define();
         graph.defineProperty("b").dataType(String.class).textIndexHint(TextIndexHint.FULL_TEXT).define();


### PR DESCRIPTION
Note: I didn't test SPV extended data values since it doesn't look like we support them on initial add