### PR TITLE
Fix implicit casting by ElasticSearch during sorting script

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,6 @@
+# v4.9.7
++ Fixed: Sorting issue when ElasticSearch attempts to implicitly cast Date Times to Doubles in search query string
+
 # v4.9.6
 * Fixed: Threading issue when multiple threads attempt to deserialize a LazyMutableProperty value at the same time.
 * Fixed: When updating a visibility on a field multiple times, it was possible to set the value of the field to null. This issue has been fixed.

--- a/elasticsearch5/search-index/src/main/java/org/vertexium/elasticsearch5/ElasticsearchSearchQueryBase.java
+++ b/elasticsearch5/search-index/src/main/java/org/vertexium/elasticsearch5/ElasticsearchSearchQueryBase.java
@@ -403,7 +403,7 @@ public class ElasticsearchSearchQueryBase extends QueryBase {
                 if (propertyDefinition.getDataType() == String.class) {
                     scriptSrc += "return fieldValues.length > 0 ? fieldValues : (params.esOrder == 'asc' ? [Character.toString(Character.MAX_VALUE)] : '');";
                 } else {
-                    scriptSrc += "return fieldValues.length > 0 ? fieldValues[0] : (params.esOrder == 'asc' ? Integer.MAX_VALUE : Integer.MIN_VALUE);";
+                    scriptSrc += "return fieldValues.length > 0 ? fieldValues[0] : (params.esOrder == 'asc' ? Long.MAX_VALUE : Long.MIN_VALUE);";
                 }
 
                 List<String> fieldNames = Arrays.stream(propertyNames).map(propertyName ->

--- a/elasticsearch7/search-index/src/main/java/org/vertexium/elasticsearch7/ElasticsearchSearchQueryBase.java
+++ b/elasticsearch7/search-index/src/main/java/org/vertexium/elasticsearch7/ElasticsearchSearchQueryBase.java
@@ -407,7 +407,7 @@ public class ElasticsearchSearchQueryBase extends QueryBase {
                 if (propertyDefinition.getDataType() == String.class) {
                     scriptSrc += "return fieldValues.length > 0 ? fieldValues[0] : (params.esOrder == 'asc' ? Character.toString(Character.MAX_VALUE) : '');";
                 } else {
-                    scriptSrc += "return fieldValues.length > 0 ? (fieldValues[0] instanceof JodaCompatibleZonedDateTime ? fieldValues[0].getMillis() : fieldValues[0]) : (params.esOrder == 'asc' ? Integer.MAX_VALUE : Integer.MIN_VALUE);";
+                    scriptSrc += "return fieldValues.length > 0 ? (fieldValues[0] instanceof JodaCompatibleZonedDateTime ? fieldValues[0].getMillis() : fieldValues[0]) : (params.esOrder == 'asc' ? Long.MAX_VALUE : Long.MIN_VALUE);";
                 }
 
                 List<String> fieldNames = Arrays.stream(propertyNames).map(propertyName ->

--- a/elasticsearch7/search-index/src/main/java/org/vertexium/elasticsearch7/ElasticsearchSearchQueryBase.java
+++ b/elasticsearch7/search-index/src/main/java/org/vertexium/elasticsearch7/ElasticsearchSearchQueryBase.java
@@ -405,7 +405,7 @@ public class ElasticsearchSearchQueryBase extends QueryBase {
                         "if (params.esOrder == 'asc') { Collections.sort(fieldValues); } else { Collections.sort(fieldValues, Collections.reverseOrder()); }";
 
                 if (propertyDefinition.getDataType() == String.class) {
-                    scriptSrc += "return fieldValues.length > 0 ? (fieldValues[0] instanceof JodaCompatibleZonedDateTime ? fieldValues[0].getMillis() : fieldValues[0]) : (params.esOrder == 'asc' ? Character.toString(Character.MAX_VALUE) : '');";
+                    scriptSrc += "return fieldValues.length > 0 ? fieldValues[0] : (params.esOrder == 'asc' ? Character.toString(Character.MAX_VALUE) : '');";
                 } else {
                     scriptSrc += "return fieldValues.length > 0 ? (fieldValues[0] instanceof JodaCompatibleZonedDateTime ? fieldValues[0].getMillis() : fieldValues[0]) : (params.esOrder == 'asc' ? Integer.MAX_VALUE : Integer.MIN_VALUE);";
                 }

--- a/elasticsearch7/search-index/src/main/java/org/vertexium/elasticsearch7/ElasticsearchSearchQueryBase.java
+++ b/elasticsearch7/search-index/src/main/java/org/vertexium/elasticsearch7/ElasticsearchSearchQueryBase.java
@@ -401,13 +401,13 @@ public class ElasticsearchSearchQueryBase extends QueryBase {
 
             String[] propertyNames = getPropertyNames(propertyDefinition.getPropertyName());
             if (propertyNames.length > 1) {
-                String scriptSrc = "def fieldValues = []; for (def fieldName : params.fieldNames) { fieldValues.addAll(doc[fieldName]); } " +
-                    "if (params.esOrder == 'asc') { Collections.sort(fieldValues); } else { Collections.sort(fieldValues, Collections.reverseOrder()); }";
+                String scriptSrc = "def fieldValues = []; for (def fieldName : params.fieldNames) { if(doc[fieldName].size() !=0) { fieldValues.addAll(doc[fieldName]); }} " +
+                        "if (params.esOrder == 'asc') { Collections.sort(fieldValues); } else { Collections.sort(fieldValues, Collections.reverseOrder()); }";
 
                 if (propertyDefinition.getDataType() == String.class) {
-                    scriptSrc += "return fieldValues.length > 0 ? fieldValues[0] : (params.esOrder == 'asc' ? Character.toString(Character.MAX_VALUE) : '');";
+                    scriptSrc += "return fieldValues.length > 0 ? (fieldValues[0] instanceof JodaCompatibleZonedDateTime ? fieldValues[0].getMillis() : fieldValues[0]) : (params.esOrder == 'asc' ? Character.toString(Character.MAX_VALUE) : '');";
                 } else {
-                    scriptSrc += "return fieldValues.length > 0 ? fieldValues[0] : (params.esOrder == 'asc' ? Integer.MAX_VALUE : Integer.MIN_VALUE);";
+                    scriptSrc += "return fieldValues.length > 0 ? (fieldValues[0] instanceof JodaCompatibleZonedDateTime ? fieldValues[0].getMillis() : fieldValues[0]) : (params.esOrder == 'asc' ? Integer.MAX_VALUE : Integer.MIN_VALUE);";
                 }
 
                 List<String> fieldNames = Arrays.stream(propertyNames).map(propertyName ->

--- a/elasticsearch7/search-index/src/test/java/org/vertexium/elasticsearch7/Elasticsearch7SearchIndexTest.java
+++ b/elasticsearch7/search-index/src/test/java/org/vertexium/elasticsearch7/Elasticsearch7SearchIndexTest.java
@@ -28,11 +28,6 @@ import org.vertexium.test.GraphTestBase;
 import org.vertexium.util.CloseableUtils;
 
 import java.io.IOException;
-import java.time.LocalDate;
-import java.time.ZoneId;
-import java.time.ZoneOffset;
-import java.time.ZonedDateTime;
-import java.util.Date;
 import java.util.Iterator;
 import java.util.List;
 import java.util.concurrent.CountDownLatch;
@@ -40,7 +35,6 @@ import java.util.concurrent.atomic.AtomicBoolean;
 
 import static org.junit.Assert.*;
 import static org.vertexium.test.util.VertexiumAssert.assertResultsCount;
-import static org.vertexium.test.util.VertexiumAssert.assertVertexIds;
 import static org.vertexium.util.CloseableUtils.closeQuietly;
 import static org.vertexium.util.IterableUtils.count;
 import static org.vertexium.util.IterableUtils.toList;

--- a/elasticsearch7/search-index/src/test/java/org/vertexium/elasticsearch7/Elasticsearch7SearchIndexTest.java
+++ b/elasticsearch7/search-index/src/test/java/org/vertexium/elasticsearch7/Elasticsearch7SearchIndexTest.java
@@ -268,39 +268,6 @@ public class Elasticsearch7SearchIndexTest extends GraphTestBase {
     }
 
     @Test
-    public void testESSort() {
-        graph.defineProperty("DayOfDeath").dataType(Date.class).sortable(true).define();
-
-        ZoneId zoneId = ZoneId.of("UTC+1");
-        ZonedDateTime dateVertex1 = ZonedDateTime.of(2015, 11, 30, 23, 45, 59, 1234, zoneId);
-        ZonedDateTime dateVertex2 = ZonedDateTime.of(2018, 11, 30, 23, 45, 59, 1234, zoneId);
-
-        graph.prepareVertex("v1", VISIBILITY_EMPTY)
-                .addPropertyValue("k1", "DayOfDeath", dateVertex1, VISIBILITY_A)
-                .save(AUTHORIZATIONS_A_AND_B);
-        graph.flush();
-
-        graph.prepareVertex("v2", VISIBILITY_EMPTY)
-                .addPropertyValue("k2", "DayOfDeath", dateVertex1, VISIBILITY_A)
-                .addPropertyValue("k3", "DayOfDeath", dateVertex2, VISIBILITY_B)
-                .save(AUTHORIZATIONS_A_AND_B);
-        graph.flush();
-
-        graph.prepareVertex("v3", VISIBILITY_EMPTY)
-                .addPropertyValue("k3", "v3", "value1", VISIBILITY_A)
-                .addPropertyValue("k2", "DayOfDeath", 1234, VISIBILITY_A)
-                .save(AUTHORIZATIONS_A_AND_B);
-        graph.flush();
-
-
-        Iterable<Vertex> query1vertices = graph.query("*", AUTHORIZATIONS_A_AND_B).sort("DayOfDeath", SortDirection.ASCENDING).vertices();
-        assertVertexIds(query1vertices, "v3", "v1", "v2");
-        Iterable<Vertex> query2vertices =graph.query("*", AUTHORIZATIONS_A_AND_B).sort("DayOfDeath", SortDirection.DESCENDING).vertices();
-        assertVertexIds(query2vertices, "v2", "v1", "v3");
-
-    }
-
-    @Test
     public void testDisallowLeadingWildcardsInQueryString() {
         graph.prepareVertex("v1", VISIBILITY_A).setProperty("prop1", "value1", VISIBILITY_A).save(AUTHORIZATIONS_A);
         graph.flush();

--- a/test/src/main/java/org/vertexium/test/GraphTestBase.java
+++ b/test/src/main/java/org/vertexium/test/GraphTestBase.java
@@ -3807,7 +3807,7 @@ public abstract class GraphTestBase {
     }
 
     @Test
-    public void testESSort() {
+    public void testESSortWithDateProperties() {
         graph.defineProperty("DayOfDeath").dataType(Date.class).sortable(true).define();
 
         ZoneId zoneId = ZoneId.of("UTC+1");

--- a/test/src/main/java/org/vertexium/test/GraphTestBase.java
+++ b/test/src/main/java/org/vertexium/test/GraphTestBase.java
@@ -3807,7 +3807,7 @@ public abstract class GraphTestBase {
     }
 
     @Test
-    public void testESSortWithDateProperties() {
+    public void testESSortWithDateProperties() throws Exception {
         graph.defineProperty("DayOfDeath").dataType(Date.class).sortable(true).define();
 
         ZoneId zoneId = ZoneId.of("UTC+1");
@@ -3833,7 +3833,7 @@ public abstract class GraphTestBase {
 
 
         Iterable<Vertex> query1vertices = graph.query("*", AUTHORIZATIONS_A_AND_B).sort("DayOfDeath", SortDirection.ASCENDING).vertices();
-        assertVertexIds(query1vertices, "v3", "v1", "v2");
+        assertVertexIds(query1vertices, "v1", "v2", "v3");
         Iterable<Vertex> query2vertices =graph.query("*", AUTHORIZATIONS_A_AND_B).sort("DayOfDeath", SortDirection.DESCENDING).vertices();
         assertVertexIds(query2vertices, "v2", "v1", "v3");
 

--- a/test/src/main/java/org/vertexium/test/GraphTestBase.java
+++ b/test/src/main/java/org/vertexium/test/GraphTestBase.java
@@ -3809,25 +3809,23 @@ public abstract class GraphTestBase {
     @Test
     public void testESSortWithDateProperties() throws Exception {
         graph.defineProperty("DayOfDeath").dataType(Date.class).sortable(true).define();
-
-        ZoneId zoneId = ZoneId.of("UTC+1");
-        ZonedDateTime dateVertex1 = ZonedDateTime.of(2015, 11, 30, 23, 45, 59, 1234, zoneId);
-        ZonedDateTime dateVertex2 = ZonedDateTime.of(2018, 11, 30, 23, 45, 59, 1234, zoneId);
-
+        graph.defineProperty("v3").dataType(String.class).sortable(true).define();
+        Date dateVertex1 = createDate(2020, 3, 9);
+        Date dateVertex2 = createDate(2020, 3, 11);
+        Date dateVertex3 = createDate(2020, 3, 31);
         graph.prepareVertex("v1", VISIBILITY_EMPTY)
                 .addPropertyValue("k1", "DayOfDeath", dateVertex1, VISIBILITY_A)
                 .save(AUTHORIZATIONS_A_AND_B);
         graph.flush();
 
         graph.prepareVertex("v2", VISIBILITY_EMPTY)
-                .addPropertyValue("k2", "DayOfDeath", dateVertex1, VISIBILITY_A)
-                .addPropertyValue("k3", "DayOfDeath", dateVertex2, VISIBILITY_B)
+                .addPropertyValue("k2", "DayOfDeath", dateVertex2, VISIBILITY_A)
+                .addPropertyValue("k4", "DayOfDeath", dateVertex3, VISIBILITY_B)
                 .save(AUTHORIZATIONS_A_AND_B);
         graph.flush();
 
         graph.prepareVertex("v3", VISIBILITY_EMPTY)
                 .addPropertyValue("k3", "v3", "value1", VISIBILITY_A)
-                .addPropertyValue("k2", "DayOfDeath", 1234, VISIBILITY_A)
                 .save(AUTHORIZATIONS_A_AND_B);
         graph.flush();
 

--- a/test/src/main/java/org/vertexium/test/GraphTestBase.java
+++ b/test/src/main/java/org/vertexium/test/GraphTestBase.java
@@ -39,10 +39,7 @@ import java.math.BigDecimal;
 import java.math.BigInteger;
 import java.text.ParseException;
 import java.text.SimpleDateFormat;
-import java.time.LocalDate;
-import java.time.Month;
-import java.time.ZoneOffset;
-import java.time.ZonedDateTime;
+import java.time.*;
 import java.util.*;
 import java.util.concurrent.CyclicBarrier;
 import java.util.concurrent.atomic.AtomicInteger;
@@ -3807,6 +3804,39 @@ public abstract class GraphTestBase {
             .sort(genderPropertyName, SortDirection.DESCENDING)
             .vertices());
         assertVertexIds(vertices, "v4", "v3", "v1", "v2", "v6", "v5");
+    }
+
+    @Test
+    public void testESSort() {
+        graph.defineProperty("DayOfDeath").dataType(Date.class).sortable(true).define();
+
+        ZoneId zoneId = ZoneId.of("UTC+1");
+        ZonedDateTime dateVertex1 = ZonedDateTime.of(2015, 11, 30, 23, 45, 59, 1234, zoneId);
+        ZonedDateTime dateVertex2 = ZonedDateTime.of(2018, 11, 30, 23, 45, 59, 1234, zoneId);
+
+        graph.prepareVertex("v1", VISIBILITY_EMPTY)
+                .addPropertyValue("k1", "DayOfDeath", dateVertex1, VISIBILITY_A)
+                .save(AUTHORIZATIONS_A_AND_B);
+        graph.flush();
+
+        graph.prepareVertex("v2", VISIBILITY_EMPTY)
+                .addPropertyValue("k2", "DayOfDeath", dateVertex1, VISIBILITY_A)
+                .addPropertyValue("k3", "DayOfDeath", dateVertex2, VISIBILITY_B)
+                .save(AUTHORIZATIONS_A_AND_B);
+        graph.flush();
+
+        graph.prepareVertex("v3", VISIBILITY_EMPTY)
+                .addPropertyValue("k3", "v3", "value1", VISIBILITY_A)
+                .addPropertyValue("k2", "DayOfDeath", 1234, VISIBILITY_A)
+                .save(AUTHORIZATIONS_A_AND_B);
+        graph.flush();
+
+
+        Iterable<Vertex> query1vertices = graph.query("*", AUTHORIZATIONS_A_AND_B).sort("DayOfDeath", SortDirection.ASCENDING).vertices();
+        assertVertexIds(query1vertices, "v3", "v1", "v2");
+        Iterable<Vertex> query2vertices =graph.query("*", AUTHORIZATIONS_A_AND_B).sort("DayOfDeath", SortDirection.DESCENDING).vertices();
+        assertVertexIds(query2vertices, "v2", "v1", "v3");
+
     }
 
     @Test


### PR DESCRIPTION
Fixed: Sorting issue when ElasticSearch attempts to implicitly cast Date Times to Doubles in search query string