### PR TITLE
Fixed: Accumulo: don't queue events when no event listeners are attached

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,7 @@
 # v4.10.0
 * Added: System property "metricRegistryStartConsoleReporter" to start the metric registry console reporter automatically
 * Changed: Elasticsearch: Throw better exceptions when elements are missing in missing document helper
+* Fixed: Accumulo: don't queue events when no event listeners are attached
 
 # v4.9.7
 * Fixed: Sorting issue when ElasticSearch attempts to implicitly cast Date Times to Doubles in search query string

--- a/accumulo/graph/src/main/java/org/vertexium/accumulo/AccumuloGraph.java
+++ b/accumulo/graph/src/main/java/org/vertexium/accumulo/AccumuloGraph.java
@@ -534,6 +534,9 @@ public class AccumuloGraph extends GraphBaseWithSearchIndex implements Traceable
     }
 
     private void queueEvent(GraphEvent graphEvent) {
+        if (!hasEventListeners()) {
+            return;
+        }
         synchronized (this.graphEventQueue) {
             this.graphEventQueue.add(graphEvent);
         }
@@ -797,7 +800,9 @@ public class AccumuloGraph extends GraphBaseWithSearchIndex implements Traceable
             for (Vertex vertex : verticesToDelete) {
                 addMutations(VertexiumObjectType.VERTEX, elementMutationBuilder.getDeleteRowMutation(vertex.getId()));
 
-                queueEvent(new DeleteVertexEvent(AccumuloGraph.this, vertex));
+                if (hasEventListeners()) {
+                    queueEvent(new DeleteVertexEvent(AccumuloGraph.this, vertex));
+                }
             }
         }
 
@@ -820,7 +825,9 @@ public class AccumuloGraph extends GraphBaseWithSearchIndex implements Traceable
                 // Deletes everything else related to edge.
                 addMutations(VertexiumObjectType.EDGE, elementMutationBuilder.getDeleteRowMutation(edgeLocation.getId()));
 
-                queueEvent(new DeleteEdgeEvent(AccumuloGraph.this, edgeLocation));
+                if (hasEventListeners()) {
+                    queueEvent(new DeleteEdgeEvent(AccumuloGraph.this, edgeLocation));
+                }
             }
         }
 


### PR DESCRIPTION
Prevents memory leak because the event queue was never getting cleared