### PR TITLE
Changed: InMemory: Support property graph queries with FetchHints.NONE

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,7 @@
 * Changed: Elasticsearch: Throw better exceptions when elements are missing in missing document helper
 * Changed: Elasticsearch: bulk to squash multiple updates to same element into a single update
 * Changed: Accumulo: use a string lookup to store label strings to reduce memory usage when reading vertices with large number of edges
+* Changed: InMemory: Support property graph queries with FetchHints.NONE
 * Fixed: Accumulo: don't queue events when no event listeners are attached
 
 # v4.9.7

--- a/core/src/main/java/org/vertexium/HasPropertiesIgnoringFetchHints.java
+++ b/core/src/main/java/org/vertexium/HasPropertiesIgnoringFetchHints.java
@@ -1,0 +1,11 @@
+package org.vertexium;
+
+public interface HasPropertiesIgnoringFetchHints {
+    default Iterable<Property> getPropertiesIgnoringFetchHints(String name) {
+        return getPropertiesIgnoringFetchHints(null, name);
+    }
+
+    Iterable<Property> getPropertiesIgnoringFetchHints(String key, String name);
+
+    Iterable<Property> getPropertiesIgnoringFetchHints();
+}

--- a/core/src/main/java/org/vertexium/query/QueryBase.java
+++ b/core/src/main/java/org/vertexium/query/QueryBase.java
@@ -552,7 +552,10 @@ public abstract class QueryBase implements Query, SimilarToGraphQuery {
         @Override
         public boolean isMatch(VertexiumObject vertexiumObject) {
             for (String key : this.keys) {
-                if (this.predicate.evaluate(vertexiumObject.getProperties(key), this.value, this.propertyDefinitions)) {
+                Iterable<Property> properties = vertexiumObject instanceof HasPropertiesIgnoringFetchHints
+                    ? ((HasPropertiesIgnoringFetchHints) vertexiumObject).getPropertiesIgnoringFetchHints(key)
+                    : vertexiumObject.getProperties(key);
+                if (this.predicate.evaluate(properties, this.value, this.propertyDefinitions)) {
                     return true;
                 }
             }

--- a/inmemory/src/test/java/org/vertexium/inmemory/InMemoryGraphTest.java
+++ b/inmemory/src/test/java/org/vertexium/inmemory/InMemoryGraphTest.java
@@ -86,9 +86,4 @@ public class InMemoryGraphTest extends GraphTestBase {
             assertEquals(String.class, ex.getValueClass());
         }
     }
-
-    @Override
-    protected boolean isFetchHintNoneVertexQuerySupported() {
-        return false;
-    }
 }

--- a/multimodule-test/accumulo-elasticsearch5/src/test/java/org/vertexium/multimodule/AccumuloElasticsearch5Test.java
+++ b/multimodule-test/accumulo-elasticsearch5/src/test/java/org/vertexium/multimodule/AccumuloElasticsearch5Test.java
@@ -82,11 +82,6 @@ public class AccumuloElasticsearch5Test extends AccumuloGraphTestBase {
     }
 
     @Override
-    protected boolean isFetchHintNoneVertexQuerySupported() {
-        return true;
-    }
-
-    @Override
     protected boolean isLuceneQueriesSupported() {
         return true;
     }

--- a/multimodule-test/accumulo-elasticsearch7/src/test/java/org/vertexium/multimodule/AccumuloElasticsearch7Test.java
+++ b/multimodule-test/accumulo-elasticsearch7/src/test/java/org/vertexium/multimodule/AccumuloElasticsearch7Test.java
@@ -82,11 +82,6 @@ public class AccumuloElasticsearch7Test extends AccumuloGraphTestBase {
     }
 
     @Override
-    protected boolean isFetchHintNoneVertexQuerySupported() {
-        return true;
-    }
-
-    @Override
     protected boolean isLuceneQueriesSupported() {
         return true;
     }

--- a/test/src/main/java/org/vertexium/test/GraphTestBase.java
+++ b/test/src/main/java/org/vertexium/test/GraphTestBase.java
@@ -2591,8 +2591,6 @@ public abstract class GraphTestBase {
         assertIdsAnyOrder(idsIterable, "v1", "v2", "v3", "e1", "e2");
         assertResultsCount(5, 5, idsIterable);
 
-        assumeTrue("FetchHints.NONE vertex queries are not supported", isFetchHintNoneVertexQuerySupported());
-
         idsIterable = graph.query(AUTHORIZATIONS_A).has(namePropertyName).vertexIds();
         assertIdsAnyOrder(idsIterable, "v1");
         assertResultsCount(1, 1, idsIterable);


### PR DESCRIPTION
To have better feature parity with Accumulo/ES graph add support to InMemoryGraph
to run property graph queries with FetchHints.NONE.

```
graph.query()
   .has("firstName", "Joe")
   .vertices(FetchHints.NONE)
```