### PR TITLE
Improve Travis CI build Performance

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,5 +1,5 @@
 language: java
-script: travis_wait 60 mvn test -Pnolog,$TEST_EXECUTION_PROFILE
+script: mvn test -Pnolog,$TEST_EXECUTION_PROFILE
 jdk:
   - openjdk8
 env:
@@ -13,3 +13,7 @@ branches:
   only:
     - master
     - 2.5.x
+
+cache:
+  directories:
+  - $HOME/.m2


### PR DESCRIPTION

According to [Build times out because no output was received](https://docs.travis-ci.com/user/common-build-problems/#build-times-out-because-no-output-was-received), we should carefully use travis_wait, as it may make the build unstable and extend the build time.

[Caching Dependencies and Directories](https://docs.travis-ci.com/user/caching/) Travis CI can cache content that does not often change, to speed up the build process.

=====================
If there are any inappropriate modifications in this PR, please give me a reply and I will change them.
